### PR TITLE
feat(#67): 랜딩 페이지 MVP 구현

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,17 @@
-import { redirect } from 'next/navigation';
+import LandingNavbar from '@/components/landing/LandingNavbar';
+import Hero from '@/components/landing/Hero';
+import HowItWorks from '@/components/landing/HowItWorks';
+import Footer from '@/components/layout/Footer';
 
 export default function RootPage() {
-  redirect('/mentee/dashboard');
+  return (
+    <div className="flex flex-col min-h-screen">
+      <LandingNavbar />
+      <main className="flex-1">
+        <Hero />
+        <HowItWorks />
+      </main>
+      <Footer />
+    </div>
+  );
 }

--- a/apps/web/src/components/landing/Hero.tsx
+++ b/apps/web/src/components/landing/Hero.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+
+export default function Hero() {
+  return (
+    <section className="py-32">
+      <div className="max-w-5xl mx-auto px-6 flex flex-col items-center text-center">
+        {/* TODO: 히어로 카피 (headline) */}
+        <h1 className="text-5xl font-bold text-text-primary tracking-tight leading-tight min-h-[4rem]">
+          {/* 한 줄 카피가 들어갈 자리 */}
+        </h1>
+
+        {/* TODO: 히어로 카피 (subheadline) */}
+        <p className="mt-6 text-lg text-text-secondary max-w-xl min-h-[1.75rem]">
+          {/* 서브 카피 한두 줄이 들어갈 자리 */}
+        </p>
+
+        <div className="mt-10">
+          <Link
+            href="/mentee/dashboard/basic-info"
+            className="inline-flex items-center px-6 py-3 text-base font-semibold text-white bg-brand rounded-md hover:bg-brand-dark transition-colors"
+          >
+            시작하기
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/landing/HowItWorks.tsx
+++ b/apps/web/src/components/landing/HowItWorks.tsx
@@ -1,0 +1,51 @@
+type Step = {
+  number: string;
+  title: string;
+  description: string;
+};
+
+const STEPS: Step[] = [
+  {
+    number: '01',
+    title: '내 정보 입력',
+    description: '기본 프로필부터 LEET, GPA, 활동 경험까지 한 번에 기록하세요.',
+  },
+  {
+    number: '02',
+    title: 'AI 멘토 매칭',
+    description: 'AI가 내 데이터와 가장 잘 맞는 합격 선배를 찾아줍니다.',
+  },
+  {
+    number: '03',
+    title: '1:1 멘토링',
+    description: '매칭된 멘토와 직접 연결되어 입시 전략을 구체화하세요.',
+  },
+];
+
+export default function HowItWorks() {
+  return (
+    <section className="py-24 bg-brand-light">
+      <div className="max-w-5xl mx-auto px-6">
+        <div className="text-center mb-14">
+          <p className="text-sm font-semibold text-brand">How it works</p>
+          <h2 className="mt-2 text-3xl font-bold text-text-primary tracking-tight">
+            이렇게 이용해요
+          </h2>
+        </div>
+
+        <div className="grid grid-cols-3 gap-6">
+          {STEPS.map((step) => (
+            <div
+              key={step.number}
+              className="bg-white rounded-xl border border-border p-6 flex flex-col gap-3"
+            >
+              <span className="text-sm font-semibold text-brand">{step.number}</span>
+              <h3 className="text-lg font-semibold text-text-primary">{step.title}</h3>
+              <p className="text-sm text-text-secondary leading-relaxed">{step.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/landing/LandingNavbar.tsx
+++ b/apps/web/src/components/landing/LandingNavbar.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link';
+
+export default function LandingNavbar() {
+  return (
+    <header className="sticky top-0 z-50 h-16 bg-white border-b border-border flex items-center px-6 justify-between shrink-0">
+      <Link href="/" className="text-brand font-bold text-lg tracking-tight">
+        pLAWcess
+      </Link>
+      <Link
+        href="/mentee/dashboard/basic-info"
+        className="px-4 py-2 text-sm font-medium text-white bg-brand rounded-md hover:bg-brand-dark transition-colors"
+      >
+        시작하기
+      </Link>
+    </header>
+  );
+}

--- a/apps/web/src/components/layout/DashboardShell.tsx
+++ b/apps/web/src/components/layout/DashboardShell.tsx
@@ -2,7 +2,6 @@
 
 import Navbar from '@/components/layout/Navbar';
 import Sidebar from '@/components/layout/Sidebar';
-import Footer from '@/components/layout/Footer';
 
 export default function DashboardShell({ children }: { children: React.ReactNode }) {
   return (
@@ -10,9 +9,8 @@ export default function DashboardShell({ children }: { children: React.ReactNode
       <Navbar />
       <div className="flex flex-1 overflow-hidden">
         <Sidebar />
-        <main className="flex-1 overflow-auto bg-page-bg flex flex-col">
-          <div className="flex-1 px-10 py-8">{children}</div>
-          <Footer />
+        <main className="flex-1 overflow-auto bg-page-bg">
+          <div className="px-10 py-8">{children}</div>
         </main>
       </div>
     </div>

--- a/apps/web/src/components/layout/Footer.tsx
+++ b/apps/web/src/components/layout/Footer.tsx
@@ -1,11 +1,13 @@
 export default function Footer() {
   return (
-    <footer className="py-5 px-8 text-xs text-text-secondary border-t border-border bg-white shrink-0 space-y-1">
-      <p><span className="font-semibold text-text-primary">pLAWcess</span> | Copyright © pLAWcess ALL rights Reserved</p>
-      <p>Creators: 임태경 오지훈 송인보 한승주 김하연</p>
-      <p>Managed by: 고려대학교 자유전공학부 학생회 교육국</p>
-      <p>Contact: kusisedu@gmail.com</p>
-      <p>서울특별시 성북구 안암로 145 고려대학교 자유전공학부</p>
+    <footer className="text-xs text-text-secondary border-t border-border bg-white shrink-0">
+      <div className="max-w-5xl mx-auto px-6 py-5 space-y-1">
+        <p><span className="font-semibold text-text-primary">pLAWcess</span> | Copyright © pLAWcess ALL rights Reserved</p>
+        <p>Creators: 임태경 오지훈 송인보 한승주 김하연</p>
+        <p>Managed by: 고려대학교 자유전공학부 학생회 교육국</p>
+        <p>Contact: kusisedu@gmail.com</p>
+        <p>서울특별시 성북구 안암로 145 고려대학교 자유전공학부</p>
+      </div>
     </footer>
   );
 }

--- a/apps/web/src/components/layout/Navbar.tsx
+++ b/apps/web/src/components/layout/Navbar.tsx
@@ -1,9 +1,11 @@
-'use client';
+import Link from 'next/link';
 
 export default function Navbar() {
   return (
     <header className="h-16 bg-white border-b border-border flex items-center px-6 justify-between shrink-0">
-      <span className="text-brand font-bold text-lg tracking-tight">pLAWcess</span>
+      <Link href="/" className="text-brand font-bold text-lg tracking-tight">
+        pLAWcess
+      </Link>
       <div className="flex items-center gap-3 text-sm text-text-secondary">
         <button className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-100" aria-label="알림">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">


### PR DESCRIPTION
## Summary
- `/` 경로에 랜딩 페이지 신설 (기존 `/mentee/dashboard` 리다이렉트 제거)
- LandingNavbar / Hero / HowItWorks 섹션 컴포넌트 추가
- Hero 카피는 빈 자리만 확보 (추후 결정)
- Footer는 랜딩 전용으로 이동 (DashboardShell에서 제거)
- 멘티 Navbar 로고 클릭 시 `/` 이동
- 랜딩 Navbar sticky 처리, `max-w-5xl` 축으로 통일

## Test plan
- [ ] `pnpm dev:web` → `http://localhost:3000/` 접속 시 랜딩 렌더
- [ ] "시작하기" 클릭 → `/mentee/dashboard/basic-info` 이동
- [ ] 멘티 페이지 로고 클릭 → `/` 이동
- [ ] 랜딩 스크롤 시 Navbar 상단 고정
- [ ] How it works 3단계 카드 가로 정렬 확인
- [ ] Footer 내용(Creators/Contact/관리주체/주소) 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

solve #67 