### PR TITLE
feat: About·FAQ·공지사항 페이지 제작 및 Navbar·Footer 개편

### DIFF
--- a/apps/web/src/app/about/page.tsx
+++ b/apps/web/src/app/about/page.tsx
@@ -1,0 +1,21 @@
+import LandingNavbar from '@/components/landing/LandingNavbar';
+import Footer from '@/components/layout/Footer';
+import AboutHero from '@/components/landing/about/AboutHero';
+import ServiceIntro from '@/components/landing/about/ServiceIntro';
+import TargetAudience from '@/components/landing/about/TargetAudience';
+import FAQ from '@/components/landing/about/FAQ';
+
+export default function AboutPage() {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <LandingNavbar />
+      <main className="flex-1">
+        <AboutHero />
+        <ServiceIntro />
+        <TargetAudience />
+        <FAQ />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/apps/web/src/app/about/page.tsx
+++ b/apps/web/src/app/about/page.tsx
@@ -4,6 +4,12 @@ import AboutHero from '@/components/landing/about/AboutHero';
 import ServiceIntro from '@/components/landing/about/ServiceIntro';
 import TargetAudience from '@/components/landing/about/TargetAudience';
 import FAQ from '@/components/landing/about/FAQ';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'pLAWcess | 서비스 소개',
+  description: '고려대학교 자유전공학부 로스쿨 입시 멘토링 플랫폼 pLAWcess를 소개합니다.',
+};
 
 export default function AboutPage() {
   return (

--- a/apps/web/src/app/about/page.tsx
+++ b/apps/web/src/app/about/page.tsx
@@ -3,7 +3,6 @@ import Footer from '@/components/layout/Footer';
 import AboutHero from '@/components/landing/about/AboutHero';
 import ServiceIntro from '@/components/landing/about/ServiceIntro';
 import TargetAudience from '@/components/landing/about/TargetAudience';
-import FAQ from '@/components/landing/about/FAQ';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -19,7 +18,6 @@ export default function AboutPage() {
         <AboutHero />
         <ServiceIntro />
         <TargetAudience />
-        <FAQ />
       </main>
       <Footer />
     </div>

--- a/apps/web/src/app/announcements/page.tsx
+++ b/apps/web/src/app/announcements/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from 'next';
+import LandingNavbar from '@/components/landing/LandingNavbar';
+import Footer from '@/components/layout/Footer';
+
+export const metadata: Metadata = {
+  title: 'pLAWcess | 공지사항',
+  description: 'pLAWcess 공지사항',
+};
+
+export default function AnnouncementsPage() {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <LandingNavbar />
+      <main className="flex-1 bg-page-bg flex items-center justify-center">
+        <div className="text-center py-32">
+          <p className="text-base font-bold uppercase tracking-wider text-brand">Coming Soon</p>
+          <h1 className="mt-2 text-3xl font-extrabold text-text-primary tracking-tight sm:text-4xl">
+            공지사항
+          </h1>
+          <p className="mt-4 text-lg text-text-secondary">
+            곧 서비스될 예정입니다.
+          </p>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/apps/web/src/app/faq/page.tsx
+++ b/apps/web/src/app/faq/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+import LandingNavbar from '@/components/landing/LandingNavbar';
+import Footer from '@/components/layout/Footer';
+import FAQ from '@/components/landing/about/FAQ';
+
+export const metadata: Metadata = {
+  title: 'pLAWcess | FAQ',
+  description: 'pLAWcess 자주 묻는 질문',
+};
+
+export default function FAQPage() {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <LandingNavbar />
+      <main className="flex-1">
+        <FAQ />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -12,10 +12,10 @@ export default function NotFound() {
           <h1 className="mt-4 text-xl font-bold text-text-primary">페이지를 찾을 수 없어요</h1>
           <p className="mt-2 text-sm text-text-secondary">존재하지 않는 페이지를 찾으셨어요!</p>
           <Link
-            href="/mentee/dashboard"
+            href="/"
             className="inline-block mt-6 px-5 py-2.5 text-sm text-white bg-brand rounded-md hover:bg-brand-dark transition-colors"
           >
-            대시보드로 돌아가기
+            메인페이지로 돌아가기
           </Link>
         </div>
       </main>

--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -26,7 +26,7 @@ export default function PrivacyPage() {
                 1. 수집하는 개인정보 항목
               </h2>
               <p className="mt-4 text-base leading-relaxed text-text-body">
-                pLAWcess(이하 "서비스")는 멘토링 매칭 서비스 제공을 위해 아래와 같은 개인정보를 수집합니다.
+                pLAWcess(이하 &ldquo;서비스&rdquo;)는 멘토링 매칭 서비스 제공을 위해 아래와 같은 개인정보를 수집합니다.
               </p>
               <ul className="mt-3 list-disc list-inside space-y-1 text-base text-text-body">
                 <li>필수: 이름, 이메일 주소, 학번, 학년/졸업연도</li>

--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -1,5 +1,11 @@
 import LandingNavbar from '@/components/landing/LandingNavbar';
 import Footer from '@/components/layout/Footer';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'pLAWcess | 개인정보처리방침',
+  description: 'pLAWcess 개인정보처리방침',
+};
 
 export default function PrivacyPage() {
   return (

--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -1,0 +1,99 @@
+import LandingNavbar from '@/components/landing/LandingNavbar';
+import Footer from '@/components/layout/Footer';
+
+export default function PrivacyPage() {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <LandingNavbar />
+      <main className="flex-1 bg-page-bg">
+        <div className="mx-auto max-w-3xl px-6 py-16 sm:py-24">
+          <h1 className="text-3xl font-extrabold text-text-primary tracking-tight">
+            개인정보처리방침
+          </h1>
+          <p className="mt-3 text-sm text-text-secondary">
+            시행일: 2026년 4월 15일
+          </p>
+
+          <div className="mt-10 space-y-10">
+            <section>
+              <h2 className="text-xl font-bold text-text-primary">
+                1. 수집하는 개인정보 항목
+              </h2>
+              <p className="mt-4 text-base leading-relaxed text-text-body">
+                pLAWcess(이하 "서비스")는 멘토링 매칭 서비스 제공을 위해 아래와 같은 개인정보를 수집합니다.
+              </p>
+              <ul className="mt-3 list-disc list-inside space-y-1 text-base text-text-body">
+                <li>필수: 이름, 이메일 주소, 학번, 학년/졸업연도</li>
+                <li>선택: LEET 점수, 학점(GPA), 어학 점수, 자기소개서, 지원 희망 학교</li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-text-primary">
+                2. 개인정보 수집 및 이용 목적
+              </h2>
+              <ul className="mt-4 list-disc list-inside space-y-1 text-base text-text-body">
+                <li>멘토-멘티 매칭 서비스 제공</li>
+                <li>서비스 이용에 관한 공지사항 전달</li>
+                <li>서비스 개선을 위한 통계 분석(익명 처리 후)</li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-text-primary">
+                3. 개인정보 보유 및 이용 기간
+              </h2>
+              <p className="mt-4 text-base leading-relaxed text-text-body">
+                회원 탈퇴 시 즉시 파기합니다. 단, 관계 법령에 따라 보존이 필요한 경우 해당 기간 동안 보관합니다.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-text-primary">
+                4. 개인정보의 파기 절차 및 방법
+              </h2>
+              <p className="mt-4 text-base leading-relaxed text-text-body">
+                전자적 파일 형태로 저장된 개인정보는 기록을 재생할 수 없는 기술적 방법을 사용하여 삭제합니다.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-text-primary">
+                5. 개인정보 처리 위탁
+              </h2>
+              <p className="mt-4 text-base leading-relaxed text-text-body">
+                현재 개인정보 처리를 외부에 위탁하지 않습니다.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-text-primary">
+                6. 이용자의 권리
+              </h2>
+              <p className="mt-4 text-base leading-relaxed text-text-body">
+                이용자는 언제든지 자신의 개인정보를 조회, 수정, 삭제할 수 있습니다. 관련 요청은 아래 문의처로 연락해주세요.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-text-primary">
+                7. 문의처
+              </h2>
+              <p className="mt-4 text-base leading-relaxed text-text-body">
+                개인정보 관련 문의는{' '}
+                <a
+                  href="mailto:kusisedu@gmail.com"
+                  className="text-brand hover:underline"
+                >
+                  kusisedu@gmail.com
+                </a>
+                으로 연락해주세요.
+              </p>
+            </section>
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/apps/web/src/app/terms/page.tsx
+++ b/apps/web/src/app/terms/page.tsx
@@ -26,7 +26,7 @@ export default function TermsPage() {
                 제1조 (목적)
               </h2>
               <p className="mt-4 text-base leading-relaxed text-text-body">
-                이 약관은 pLAWcess(이하 "서비스")가 제공하는 로스쿨 입시 멘토링 플랫폼 서비스의 이용 조건 및 절차, 이용자와 서비스 간의 권리·의무 관계를 규정함을 목적으로 합니다.
+                이 약관은 pLAWcess(이하 &ldquo;서비스&rdquo;)가 제공하는 로스쿨 입시 멘토링 플랫폼 서비스의 이용 조건 및 절차, 이용자와 서비스 간의 권리·의무 관계를 규정함을 목적으로 합니다.
               </p>
             </section>
 

--- a/apps/web/src/app/terms/page.tsx
+++ b/apps/web/src/app/terms/page.tsx
@@ -1,5 +1,11 @@
 import LandingNavbar from '@/components/landing/LandingNavbar';
 import Footer from '@/components/layout/Footer';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'pLAWcess | 이용약관',
+  description: 'pLAWcess 이용약관',
+};
 
 export default function TermsPage() {
   return (

--- a/apps/web/src/app/terms/page.tsx
+++ b/apps/web/src/app/terms/page.tsx
@@ -1,0 +1,107 @@
+import LandingNavbar from '@/components/landing/LandingNavbar';
+import Footer from '@/components/layout/Footer';
+
+export default function TermsPage() {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <LandingNavbar />
+      <main className="flex-1 bg-page-bg">
+        <div className="mx-auto max-w-3xl px-6 py-16 sm:py-24">
+          <h1 className="text-3xl font-extrabold text-text-primary tracking-tight">
+            이용약관
+          </h1>
+          <p className="mt-3 text-sm text-text-secondary">
+            시행일: 2026년 4월 15일
+          </p>
+
+          <div className="mt-10 space-y-10">
+            <section>
+              <h2 className="text-xl font-bold text-text-primary">
+                제1조 (목적)
+              </h2>
+              <p className="mt-4 text-base leading-relaxed text-text-body">
+                이 약관은 pLAWcess(이하 "서비스")가 제공하는 로스쿨 입시 멘토링 플랫폼 서비스의 이용 조건 및 절차, 이용자와 서비스 간의 권리·의무 관계를 규정함을 목적으로 합니다.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-text-primary">
+                제2조 (이용 자격)
+              </h2>
+              <p className="mt-4 text-base leading-relaxed text-text-body">
+                서비스는 고려대학교 자유전공학부 재학생 및 졸업생을 대상으로 제공됩니다. 이 외의 사용자는 서비스 이용이 제한될 수 있습니다.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-text-primary">
+                제3조 (서비스 이용)
+              </h2>
+              <ul className="mt-4 list-disc list-inside space-y-1 text-base text-text-body">
+                <li>서비스는 무료로 제공됩니다.</li>
+                <li>이용자는 서비스 이용 시 정확한 정보를 입력해야 합니다.</li>
+                <li>멘토 매칭 결과는 AI 분석을 기반으로 하며, 최종 확정은 운영팀이 검토합니다.</li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-text-primary">
+                제4조 (금지 행위)
+              </h2>
+              <ul className="mt-4 list-disc list-inside space-y-1 text-base text-text-body">
+                <li>타인의 정보를 도용하거나 허위 정보를 입력하는 행위</li>
+                <li>서비스의 정상적인 운영을 방해하는 행위</li>
+                <li>서비스를 통해 얻은 정보를 무단으로 상업적으로 이용하는 행위</li>
+                <li>멘토링 과정에서 상대방에게 불쾌감을 주는 행위</li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-text-primary">
+                제5조 (서비스 변경 및 중단)
+              </h2>
+              <p className="mt-4 text-base leading-relaxed text-text-body">
+                서비스는 운영상 또는 기술상의 이유로 서비스 내용을 변경하거나 일시 중단할 수 있습니다. 중요한 변경사항은 사전에 공지합니다.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-text-primary">
+                제6조 (면책 조항)
+              </h2>
+              <p className="mt-4 text-base leading-relaxed text-text-body">
+                서비스는 멘토링 연결 플랫폼으로서 멘토링 결과(합격 여부 등)에 대한 책임을 지지 않습니다. 멘토링 내용의 정확성 및 유용성은 멘토 개인의 경험에 기반합니다.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-text-primary">
+                제7조 (준거법)
+              </h2>
+              <p className="mt-4 text-base leading-relaxed text-text-body">
+                이 약관은 대한민국 법령에 따라 해석되며, 분쟁 발생 시 서울중앙지방법원을 관할 법원으로 합니다.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-text-primary">
+                문의
+              </h2>
+              <p className="mt-4 text-base leading-relaxed text-text-body">
+                약관 관련 문의는{' '}
+                <a
+                  href="mailto:kusisedu@gmail.com"
+                  className="text-brand hover:underline"
+                >
+                  kusisedu@gmail.com
+                </a>
+                으로 연락해주세요.
+              </p>
+            </section>
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/apps/web/src/components/landing/LandingNavbar.tsx
+++ b/apps/web/src/components/landing/LandingNavbar.tsx
@@ -3,10 +3,26 @@ import Link from 'next/link';
 export default function LandingNavbar() {
   return (
     <header className="sticky top-0 z-50 h-16 bg-white border-b border-border flex items-center px-6 justify-between shrink-0">
+      {/* Left: Logo */}
       <Link href="/" className="text-brand font-bold text-lg tracking-tight">
         pLAWcess
       </Link>
-      <div className="flex items-center gap-3">
+
+      {/* Center: Nav items */}
+      <nav className="flex items-center gap-6">
+        <Link
+          href="/about"
+          className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors"
+        >
+          서비스 소개
+        </Link>
+        <Link
+          href="/about#faq"
+          className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors"
+        >
+          FAQ
+        </Link>
+        {/* DEV ONLY - remove before deploy */}
         <Link
           href="/mentor/dashboard"
           className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors"
@@ -19,6 +35,11 @@ export default function LandingNavbar() {
         >
           어드민
         </Link>
+        {/* /DEV ONLY */}
+      </nav>
+
+      {/* Right: Action buttons */}
+      <div className="flex items-center gap-3">
         <Link
           href="/login"
           className="px-4 py-2 text-sm font-medium text-brand border border-brand rounded-md hover:bg-brand/5 transition-colors"

--- a/apps/web/src/components/landing/LandingNavbar.tsx
+++ b/apps/web/src/components/landing/LandingNavbar.tsx
@@ -22,20 +22,22 @@ export default function LandingNavbar() {
         >
           FAQ
         </Link>
-        {/* DEV ONLY - remove before deploy */}
-        <Link
-          href="/mentor/dashboard"
-          className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors"
-        >
-          멘토
-        </Link>
-        <Link
-          href="/admin/dashboard"
-          className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors"
-        >
-          어드민
-        </Link>
-        {/* /DEV ONLY */}
+        {process.env.NODE_ENV === 'development' && (
+          <>
+            <Link
+              href="/mentor/dashboard"
+              className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors"
+            >
+              멘토
+            </Link>
+            <Link
+              href="/admin/dashboard"
+              className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors"
+            >
+              어드민
+            </Link>
+          </>
+        )}
       </nav>
 
       {/* Right: Action buttons */}

--- a/apps/web/src/components/landing/LandingNavbar.tsx
+++ b/apps/web/src/components/landing/LandingNavbar.tsx
@@ -1,6 +1,17 @@
+'use client';
+
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const NAV_ITEMS = [
+  { href: '/about', label: '서비스 소개' },
+  { href: '/faq', label: 'FAQ' },
+  { href: '/announcements', label: '공지사항' },
+];
 
 export default function LandingNavbar() {
+  const pathname = usePathname();
+
   return (
     <header className="sticky top-0 z-50 h-16 bg-white border-b border-border flex items-center px-6 justify-between shrink-0">
       {/* Left: Logo */}
@@ -9,19 +20,20 @@ export default function LandingNavbar() {
       </Link>
 
       {/* Center: Nav items */}
-      <nav className="flex items-center gap-6">
-        <Link
-          href="/about"
-          className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors"
-        >
-          서비스 소개
-        </Link>
-        <Link
-          href="/about#faq"
-          className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors"
-        >
-          FAQ
-        </Link>
+      <nav className="flex items-center gap-6" aria-label="주요 메뉴">
+        {NAV_ITEMS.map(({ href, label }) => (
+          <Link
+            key={href}
+            href={href}
+            className={`text-sm font-medium transition-colors ${
+              pathname === href
+                ? 'text-text-primary'
+                : 'text-text-secondary hover:text-text-primary'
+            }`}
+          >
+            {label}
+          </Link>
+        ))}
         {process.env.NODE_ENV === 'development' && (
           <>
             <Link

--- a/apps/web/src/components/landing/about/AboutHero.tsx
+++ b/apps/web/src/components/landing/about/AboutHero.tsx
@@ -1,0 +1,25 @@
+export default function AboutHero() {
+  return (
+    <section className="relative overflow-hidden py-24 sm:py-32 bg-page-bg">
+      {/* Background Glow */}
+      <div
+        className="absolute top-0 left-1/2 -z-10 h-[1000px] w-[1000px] -translate-x-1/2 [mask-image:radial-gradient(closest-side,white,transparent)]"
+        aria-hidden="true"
+      >
+        <div className="h-full w-full bg-linear-to-b from-brand-light/40 to-white" />
+      </div>
+
+      <div className="mx-auto max-w-5xl px-6 text-center">
+        <p className="text-base font-bold uppercase tracking-wider text-brand">
+          About pLAWcess
+        </p>
+        <h1 className="mt-2 text-4xl font-extrabold text-text-primary tracking-tight leading-tight sm:text-5xl">
+          로스쿨 입시, 혼자 준비하지 않아도 됩니다
+        </h1>
+        <p className="mx-auto mt-6 max-w-2xl text-lg text-text-secondary leading-relaxed">
+          자유전공학부 합격 선배와 연결되는 유일한 플랫폼
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/landing/about/FAQ.tsx
+++ b/apps/web/src/components/landing/about/FAQ.tsx
@@ -1,0 +1,56 @@
+type FAQItem = {
+  question: string;
+  answer: string;
+};
+
+const FAQ_ITEMS: FAQItem[] = [
+  {
+    question: '누가 멘토가 되나요?',
+    answer:
+      '고려대학교 자유전공학부 출신으로 법학대학원에 합격한 선배들이 멘토로 참여합니다. 멘토는 pLAWcess 운영팀의 검토를 거쳐 등록됩니다.',
+  },
+  {
+    question: '멘토링은 어떤 방식으로 진행되나요?',
+    answer:
+      'AI 매칭 후 멘티-멘토 1:1로 연결되며, 구체적인 진행 방식(온라인/오프라인, 빈도 등)은 멘토와 멘티가 직접 조율합니다.',
+  },
+  {
+    question: '지원 자격이 있나요?',
+    answer:
+      '고려대학교 자유전공학부 재학생 또는 졸업생이라면 누구나 지원할 수 있습니다.',
+  },
+  {
+    question: '비용이 드나요?',
+    answer: 'pLAWcess 멘토링 프로그램은 무료로 운영됩니다.',
+  },
+];
+
+export default function FAQ() {
+  return (
+    <section id="faq" className="py-24 sm:py-32 bg-white">
+      <div className="mx-auto max-w-3xl px-6">
+        <div className="text-center">
+          <h2 className="text-base font-bold uppercase tracking-wider text-brand">
+            FAQ
+          </h2>
+          <p className="mt-2 text-3xl font-extrabold tracking-tight text-text-primary sm:text-4xl">
+            자주 묻는 질문
+          </p>
+        </div>
+
+        <div className="mt-16 divide-y divide-border">
+          {FAQ_ITEMS.map((item) => (
+            <div key={item.question} className="py-8">
+              <dt className="text-lg font-semibold text-text-primary">
+                {item.question}
+              </dt>
+              <dd className="mt-3 text-base leading-relaxed text-text-secondary">
+                {item.answer}
+              </dd>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/landing/about/FAQ.tsx
+++ b/apps/web/src/components/landing/about/FAQ.tsx
@@ -27,7 +27,7 @@ const FAQ_ITEMS: FAQItem[] = [
 
 export default function FAQ() {
   return (
-    <section id="faq" className="py-24 sm:py-32 bg-white">
+    <section className="py-24 sm:py-32 bg-white">
       <div className="mx-auto max-w-3xl px-6">
         <div className="text-center">
           <h2 className="text-base font-bold uppercase tracking-wider text-brand">

--- a/apps/web/src/components/landing/about/FAQ.tsx
+++ b/apps/web/src/components/landing/about/FAQ.tsx
@@ -38,7 +38,7 @@ export default function FAQ() {
           </p>
         </div>
 
-        <div className="mt-16 divide-y divide-border">
+        <dl className="mt-16 divide-y divide-border">
           {FAQ_ITEMS.map((item) => (
             <div key={item.question} className="py-8">
               <dt className="text-lg font-semibold text-text-primary">
@@ -49,7 +49,7 @@ export default function FAQ() {
               </dd>
             </div>
           ))}
-        </div>
+        </dl>
       </div>
     </section>
   );

--- a/apps/web/src/components/landing/about/ServiceIntro.tsx
+++ b/apps/web/src/components/landing/about/ServiceIntro.tsx
@@ -1,0 +1,58 @@
+const POINTS = [
+  '실제 합격자 데이터 기반',
+  'AI 자동 멘토 매칭',
+  '1:1 멘토링 연결',
+];
+
+export default function ServiceIntro() {
+  return (
+    <section className="py-24 sm:py-32 bg-white">
+      <div className="mx-auto max-w-5xl px-6">
+        <div className="grid grid-cols-1 gap-16 lg:grid-cols-2 lg:items-center">
+          {/* Left: Description */}
+          <div>
+            <h2 className="text-3xl font-extrabold text-text-primary tracking-tight sm:text-4xl">
+              pLAWcess란?
+            </h2>
+            <p className="mt-6 text-lg text-text-body leading-relaxed">
+              pLAWcess는 고려대학교 자유전공학부 학생의 로스쿨 입시를 돕기 위해
+              만들어진 멘토링 플랫폼입니다.
+            </p>
+            <p className="mt-4 text-lg text-text-body leading-relaxed">
+              합격 선배의 실제 데이터를 바탕으로 AI가 나에게 맞는 멘토를
+              연결해줍니다.
+            </p>
+          </div>
+
+          {/* Right: Checklist */}
+          <div className="rounded-2xl border border-border bg-page-bg p-8">
+            <ul className="space-y-5">
+              {POINTS.map((point) => (
+                <li key={point} className="flex items-center gap-3">
+                  <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-brand/10 text-brand">
+                    <svg
+                      className="h-4 w-4"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth="2.5"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M5 13l4 4L19 7"
+                      />
+                    </svg>
+                  </div>
+                  <span className="text-base font-medium text-text-primary">
+                    {point}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/landing/about/TargetAudience.tsx
+++ b/apps/web/src/components/landing/about/TargetAudience.tsx
@@ -1,0 +1,72 @@
+type Target = {
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+};
+
+const TARGETS: Target[] = [
+  {
+    title: '로스쿨 진학을 고려 중인 자유전공학부 학생',
+    description: '막연한 로스쿨 진학 목표를 구체적인 계획으로 만들어드립니다.',
+    icon: (
+      <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 14l9-5-9-5-9 5 9 5z" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 14l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14z" />
+      </svg>
+    ),
+  },
+  {
+    title: '어떤 스펙을 쌓아야 할지 막막한 분',
+    description: '합격자 데이터를 통해 효과적인 준비 방향을 알 수 있습니다.',
+    icon: (
+      <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+      </svg>
+    ),
+  },
+  {
+    title: '실제 합격자의 경험을 듣고 싶은 분',
+    description: '직접 합격한 선배 멘토와 1:1로 연결되어 생생한 이야기를 들을 수 있습니다.',
+    icon: (
+      <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+      </svg>
+    ),
+  },
+];
+
+export default function TargetAudience() {
+  return (
+    <section className="py-24 sm:py-32 bg-page-bg">
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl text-center">
+          <h2 className="text-base font-bold uppercase tracking-wider text-brand">
+            For you
+          </h2>
+          <p className="mt-2 text-3xl font-extrabold tracking-tight text-text-primary sm:text-4xl">
+            이런 분들을 위한 서비스예요
+          </p>
+        </div>
+
+        <div className="mx-auto mt-16 grid max-w-2xl grid-cols-1 gap-8 sm:mt-20 lg:max-w-none lg:grid-cols-3">
+          {TARGETS.map((target) => (
+            <div
+              key={target.title}
+              className="relative flex flex-col rounded-3xl bg-white p-8 shadow-xl shadow-brand/5 ring-1 ring-slate-200/50"
+            >
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-brand/10 text-brand ring-1 ring-brand/20">
+                {target.icon}
+              </div>
+              <h3 className="mt-6 text-lg font-bold text-text-primary leading-snug">
+                {target.title}
+              </h3>
+              <p className="mt-3 text-base leading-relaxed text-text-secondary">
+                {target.description}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/layout/Footer.tsx
+++ b/apps/web/src/components/layout/Footer.tsx
@@ -1,10 +1,34 @@
+import Link from 'next/link';
+
 export default function Footer() {
   return (
     <footer className="text-xs text-text-secondary border-t border-border bg-white shrink-0">
       <div className="max-w-5xl mx-auto px-6 py-5 space-y-1 text-center">
-        <p><span className="font-semibold text-text-primary">pLAWcess</span> | Copyright © pLAWcess ALL rights Reserved</p>
+        <p>
+          <span className="font-semibold text-text-primary">pLAWcess</span>
+          {' '}| Copyright © pLAWcess ALL rights Reserved
+        </p>
         <p>Creators: 임태경 오지훈 송인보 한승주 김하연</p>
-        <p>Contact: kusisedu@gmail.com | 고려대학교 자유전공학부</p>
+        <div className="flex items-center justify-center gap-4 pt-1">
+          <Link
+            href="/privacy"
+            className="hover:text-text-primary underline-offset-2 hover:underline transition-colors"
+          >
+            개인정보처리방침
+          </Link>
+          <Link
+            href="/terms"
+            className="hover:text-text-primary underline-offset-2 hover:underline transition-colors"
+          >
+            이용약관
+          </Link>
+          <a
+            href="mailto:kusisedu@gmail.com"
+            className="hover:text-text-primary underline-offset-2 hover:underline transition-colors"
+          >
+            문의하기
+          </a>
+        </div>
       </div>
     </footer>
   );


### PR DESCRIPTION
## Summary

- `/about` 서비스 소개 페이지 신규 (AboutHero, ServiceIntro, TargetAudience 섹션)
- `/faq` FAQ 단독 페이지 신규
- `/announcements` 공지사항 Coming Soon 페이지 신규 (동적 구현은 후속 브랜치)
- `/privacy` 개인정보처리방침, `/terms` 이용약관 정적 페이지 추가
- `LandingNavbar` 3열 구조 개편 — 서비스소개·FAQ·공지사항 nav item + 현재 페이지 active 스타일 + dev 전용 멘토/어드민 `NODE_ENV` 가드
- `Footer` 개편 — 개인정보처리방침·이용약관·문의하기 링크로 대체
- 404 페이지 홈으로 리다이렉트 수정

## Test Plan

- [ ] `/about`, `/faq`, `/announcements`, `/privacy`, `/terms` 정상 접속
- [ ] Navbar에서 현재 페이지 항목 active 스타일(진한 색) 적용 확인
- [ ] Footer 링크 3개 작동 확인
- [ ] 빌드 환경에서 멘토·어드민 nav item 미노출 확인
- [ ] 404 페이지 → 홈(/) 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)