### PR TITLE
feat(#89): 기본정보 API 연동 — 하드코딩 제거 및 DB 저장

### DIFF
--- a/apps/api/src/app/api/mentee/basic-info/route.ts
+++ b/apps/api/src/app/api/mentee/basic-info/route.ts
@@ -1,0 +1,206 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@plawcess/database";
+import { getTokenFromCookie } from "@/lib/auth";
+
+function getUserId(req: NextRequest): string | null {
+  return getTokenFromCookie(req)?.user_id ?? null;
+}
+
+function getProcessYear(req: NextRequest): number {
+  const raw = req.nextUrl.searchParams.get("year");
+  if (!raw) return new Date().getFullYear();
+  const match = raw.match(/\d{4}/);
+  return match ? parseInt(match[0]) : new Date().getFullYear();
+}
+
+// DB enum ↔ 한국어 레이블 변환
+function genderToLabel(g: string | null): string {
+  if (g === "male") return "남성";
+  if (g === "female") return "여성";
+  return "";
+}
+
+function labelToGender(label: string): string | null {
+  if (label === "남성") return "male";
+  if (label === "여성") return "female";
+  return null;
+}
+
+const ACADEMIC_STATUS_MAP: Record<string, string> = {
+  enrolled: "재학",
+  on_leave: "휴학",
+  completed: "수료",
+  graduated: "졸업",
+  expelled: "제적",
+};
+const LABEL_TO_STATUS: Record<string, string> = {
+  재학: "enrolled",
+  휴학: "on_leave",
+  수료: "completed",
+  "졸업 유예": "on_leave",
+  졸업: "graduated",
+};
+
+function statusToLabel(s: string | null): string {
+  return s ? (ACADEMIC_STATUS_MAP[s] ?? "") : "";
+}
+
+function labelToStatus(label: string): string | null {
+  return LABEL_TO_STATUS[label] ?? null;
+}
+
+// ----------------------------------------------------------------
+// GET /api/mentee/basic-info?year=2026학년도
+// ----------------------------------------------------------------
+export async function GET(req: NextRequest) {
+  const userId = getUserId(req);
+  if (!userId) {
+    return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
+  }
+
+  const processYear = getProcessYear(req);
+
+  const [user, record] = await Promise.all([
+    prisma.user.findUnique({
+      where: { user_id: userId },
+      select: {
+        name: true,
+        school_name: true,
+        gender: true,
+        first_major: true,
+        second_major: true,
+        academic_status: true,
+      },
+    }),
+    prisma.menteeRecord.findUnique({
+      where: { user_id_process_year: { user_id: userId, process_year: processYear } },
+      select: {
+        birth_date: true,
+        university_entry_year: true,
+        graduation_year: true,
+        target_school_ga: true,
+        target_school_na: true,
+        is_special_admission: true,
+      },
+    }),
+  ]);
+
+  if (!user) {
+    return NextResponse.json({ error: "사용자를 찾을 수 없습니다." }, { status: 404 });
+  }
+
+  // birth_date → "YYYY.MM.DD." 형식
+  const birthDate = record?.birth_date
+    ? record.birth_date.toISOString().slice(0, 10).replace(/-/g, ".") + "."
+    : "";
+
+  return NextResponse.json({
+    personal: {
+      name: user.name,
+      affiliation: user.school_name ?? "",
+      birthDate,
+      gender: genderToLabel(user.gender),
+      major1: user.first_major ?? "",
+      major2: user.second_major ?? "",
+      admissionYear: record?.university_entry_year?.toString() ?? "",
+      academicStatus: statusToLabel(user.academic_status),
+      graduationYear: record?.graduation_year?.toString() ?? "",
+    },
+    admission: {
+      // DB에는 가/나군 제1지망 학교만 저장됨. 제2지망·전형 타입은 DB 미지원.
+      가: { first: record?.target_school_ga ?? "" },
+      나: { first: record?.target_school_na ?? "" },
+      isSpecialAdmission: record?.is_special_admission ?? false,
+    },
+  });
+}
+
+// ----------------------------------------------------------------
+// PATCH /api/mentee/basic-info?year=2026학년도
+// Body: { personal?, admission? }
+// ----------------------------------------------------------------
+export async function PATCH(req: NextRequest) {
+  const userId = getUserId(req);
+  if (!userId) {
+    return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
+  }
+
+  const processYear = getProcessYear(req);
+
+  let body: {
+    personal?: {
+      birthDate?: string;
+      gender?: string;
+      major1?: string;
+      major2?: string;
+      admissionYear?: string;
+      academicStatus?: string;
+      graduationYear?: string;
+    };
+    admission?: {
+      가?: { first?: string };
+      나?: { first?: string };
+      isSpecialAdmission?: boolean;
+    };
+  };
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "요청 본문이 올바르지 않습니다." }, { status: 400 });
+  }
+
+  const user = await prisma.user.findUnique({ where: { user_id: userId } });
+  if (!user) {
+    return NextResponse.json({ error: "사용자를 찾을 수 없습니다." }, { status: 404 });
+  }
+
+  // User 테이블 업데이트 (gender, major, academic_status)
+  const userUpdate: Record<string, unknown> = {};
+  if (body.personal) {
+    const { gender, major1, major2, academicStatus } = body.personal;
+    if (gender !== undefined) userUpdate.gender = labelToGender(gender);
+    if (major1 !== undefined) userUpdate.first_major = major1;
+    if (major2 !== undefined) userUpdate.second_major = major2;
+    if (academicStatus !== undefined) userUpdate.academic_status = labelToStatus(academicStatus);
+  }
+  if (Object.keys(userUpdate).length > 0) {
+    await prisma.user.update({ where: { user_id: userId }, data: userUpdate });
+  }
+
+  // MenteeRecord 업데이트 (birth_date, university_entry_year, graduation_year, target_school)
+  const recordUpdate: Record<string, unknown> = {};
+  if (body.personal) {
+    const { birthDate, admissionYear, graduationYear } = body.personal;
+    if (birthDate !== undefined) {
+      // "YYYY.MM.DD." → Date (비어있으면 null)
+      const cleaned = birthDate.replace(/\.$/, "").replace(/\./g, "-");
+      const parsed = new Date(cleaned);
+      recordUpdate.birth_date = !isNaN(parsed.getTime()) ? parsed : null;
+    }
+    if (admissionYear !== undefined) {
+      const year = parseInt(admissionYear);
+      recordUpdate.university_entry_year = isNaN(year) ? null : year;
+    }
+    if (graduationYear !== undefined) {
+      const year = parseInt(graduationYear);
+      recordUpdate.graduation_year = isNaN(year) ? null : year;
+    }
+  }
+  if (body.admission) {
+    const { 가: ga, 나: na, isSpecialAdmission } = body.admission;
+    if (ga?.first !== undefined) recordUpdate.target_school_ga = ga.first || null;
+    if (na?.first !== undefined) recordUpdate.target_school_na = na.first || null;
+    if (isSpecialAdmission !== undefined) recordUpdate.is_special_admission = isSpecialAdmission;
+  }
+
+  if (Object.keys(recordUpdate).length > 0) {
+    await prisma.menteeRecord.upsert({
+      where: { user_id_process_year: { user_id: userId, process_year: processYear } },
+      create: { user_id: userId, process_year: processYear, ...recordUpdate },
+      update: recordUpdate,
+    });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/apps/web/src/app/mentee/dashboard/basic-info/page.tsx
+++ b/apps/web/src/app/mentee/dashboard/basic-info/page.tsx
@@ -1,47 +1,128 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import SelectField from '@/components/ui/SelectField';
 import { EditButton, EditButtons } from '@/components/ui/EditButton';
 import {
   type PersonalInfo,
   type AdmissionInfo,
-  initialPersonalInfo,
-  initialAdmissionInfo,
+  emptyPersonalInfo,
+  emptyAdmissionInfo,
   SCHOOL_OPTIONS,
   TYPE_OPTIONS,
   fieldRows,
 } from '@/constants/basic-info';
+import { getBasicInfo, patchBasicInfo } from '@/lib/api';
+
+const YEAR = '2026학년도';
 
 function formatBirthDate(value: string) {
   return value;
 }
 
 export default function BasicInfoPage() {
-  const [personalInfo, setPersonalInfo] = useState<PersonalInfo>(initialPersonalInfo);
-  const [draft, setDraft] = useState<PersonalInfo>(initialPersonalInfo);
+  const [personalInfo, setPersonalInfo] = useState<PersonalInfo>(emptyPersonalInfo);
+  const [draft, setDraft] = useState<PersonalInfo>(emptyPersonalInfo);
   const [isEditing, setIsEditing] = useState(false);
   const [birthDateError, setBirthDateError] = useState('');
+  const [personalSaving, setPersonalSaving] = useState(false);
 
-  const [admissionInfo, setAdmissionInfo] = useState<AdmissionInfo>(initialAdmissionInfo);
-  const [admissionDraft, setAdmissionDraft] = useState<AdmissionInfo>(initialAdmissionInfo);
+  const [admissionInfo, setAdmissionInfo] = useState<AdmissionInfo>(emptyAdmissionInfo);
+  const [admissionDraft, setAdmissionDraft] = useState<AdmissionInfo>(emptyAdmissionInfo);
   const [isAdmissionEditing, setIsAdmissionEditing] = useState(false);
+  const [admissionSaving, setAdmissionSaving] = useState(false);
 
-  function handleSave() {
-    if (!/^\d{4}\.\d{2}\.\d{2}\.$/.test(draft.birthDate)) {
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState('');
+
+  // API에서 기본정보 로드
+  useEffect(() => {
+    getBasicInfo(YEAR)
+      .then((data) => {
+        const personal: PersonalInfo = {
+          ...emptyPersonalInfo,
+          name: data.personal.name,
+          affiliation: data.personal.affiliation,
+          birthDate: data.personal.birthDate,
+          gender: data.personal.gender,
+          major1: data.personal.major1,
+          major2: data.personal.major2,
+          admissionYear: data.personal.admissionYear,
+          academicStatus: data.personal.academicStatus,
+          graduationYear: data.personal.graduationYear,
+          // militaryStatus는 DB 미지원 — 빈 값 유지
+        };
+        const admission: AdmissionInfo = {
+          가: {
+            first: { school: data.admission.가.first, type: data.admission.isSpecialAdmission ? '특별전형' : '일반전형' },
+            second: emptyAdmissionInfo.가.second,  // DB 미지원
+          },
+          나: {
+            first: { school: data.admission.나.first, type: data.admission.isSpecialAdmission ? '특별전형' : '일반전형' },
+            second: emptyAdmissionInfo.나.second,  // DB 미지원
+          },
+        };
+        setPersonalInfo(personal);
+        setAdmissionInfo(admission);
+      })
+      .catch(() => setLoadError('기본정보를 불러오지 못했습니다.'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  async function handleSave() {
+    if (!/^\d{4}\.\d{2}\.\d{2}\.$/.test(draft.birthDate) && draft.birthDate !== '') {
       setBirthDateError('YYYY.MM.DD. 형식으로 입력해주세요 (예: 2000.03.15.)');
       return;
     }
     setBirthDateError('');
-    setPersonalInfo(draft);
-    setIsEditing(false);
+    setPersonalSaving(true);
+    try {
+      await patchBasicInfo(YEAR, {
+        personal: {
+          birthDate: draft.birthDate,
+          gender: draft.gender,
+          major1: draft.major1,
+          major2: draft.major2,
+          admissionYear: draft.admissionYear,
+          academicStatus: draft.academicStatus,
+          graduationYear: draft.graduationYear,
+          // militaryStatus는 DB 미지원 — 저장하지 않음
+        },
+      });
+      setPersonalInfo(draft);
+      setIsEditing(false);
+    } catch {
+      setBirthDateError('저장에 실패했습니다. 다시 시도해주세요.');
+    } finally {
+      setPersonalSaving(false);
+    }
   }
+
   function handleCancel() { setBirthDateError(''); setIsEditing(false); }
   function handleChange(key: keyof PersonalInfo, value: string) {
     setDraft((prev) => ({ ...prev, [key]: value }));
   }
 
-  function handleAdmissionSave() { setAdmissionInfo(admissionDraft); setIsAdmissionEditing(false); }
+  async function handleAdmissionSave() {
+    setAdmissionSaving(true);
+    try {
+      await patchBasicInfo(YEAR, {
+        admission: {
+          가: { first: admissionDraft.가.first.school },
+          나: { first: admissionDraft.나.first.school },
+          // 제1지망 type 기준으로 is_special_admission 결정 (가군 기준)
+          isSpecialAdmission: admissionDraft.가.first.type === '특별전형',
+        },
+      });
+      setAdmissionInfo(admissionDraft);
+      setIsAdmissionEditing(false);
+    } catch {
+      // 저장 실패 시 편집 상태 유지
+    } finally {
+      setAdmissionSaving(false);
+    }
+  }
+
   function handleAdmissionCancel() { setIsAdmissionEditing(false); }
   function handleAdmissionChange(
     group: '가' | '나',
@@ -58,6 +139,18 @@ export default function BasicInfoPage() {
     }));
   }
 
+  if (loading) {
+    return (
+      <div className="flex flex-col gap-6 max-w-3xl mx-auto w-full">
+        <div>
+          <h1 className="text-2xl font-bold text-text-primary">개인정보</h1>
+          <p className="text-sm text-text-secondary mt-1">기본 프로필과 희망 학교 정보를 입력해주세요</p>
+        </div>
+        <div className="text-sm text-text-secondary py-10 text-center">불러오는 중...</div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col gap-6 max-w-3xl mx-auto w-full">
       {/* 페이지 타이틀 */}
@@ -65,6 +158,12 @@ export default function BasicInfoPage() {
         <h1 className="text-2xl font-bold text-text-primary">개인정보</h1>
         <p className="text-sm text-text-secondary mt-1">기본 프로필과 희망 학교 정보를 입력해주세요</p>
       </div>
+
+      {loadError && (
+        <div className="text-sm text-red-500 bg-red-50 border border-red-200 rounded-lg px-4 py-3">
+          {loadError}
+        </div>
+      )}
 
       {/* 개인정보 카드 */}
       <div className="bg-white rounded-xl border border-border shadow-sm">
@@ -82,7 +181,7 @@ export default function BasicInfoPage() {
             </div>
           </div>
           {isEditing
-            ? <EditButtons onCancel={handleCancel} onSave={handleSave} />
+            ? <EditButtons onCancel={handleCancel} onSave={handleSave} disabled={personalSaving} />
             : <EditButton onClick={() => { setDraft(personalInfo); setIsEditing(true); }} />
           }
         </div>
@@ -130,7 +229,7 @@ export default function BasicInfoPage() {
         <div className="flex items-center justify-between mb-6">
           <h2 className="text-base font-semibold text-text-primary">희망 학교 및 전형</h2>
           {isAdmissionEditing
-            ? <EditButtons onCancel={handleAdmissionCancel} onSave={handleAdmissionSave} />
+            ? <EditButtons onCancel={handleAdmissionCancel} onSave={handleAdmissionSave} disabled={admissionSaving} />
             : <EditButton onClick={() => { setAdmissionDraft(admissionInfo); setIsAdmissionEditing(true); }} />
           }
         </div>

--- a/apps/web/src/constants/basic-info.ts
+++ b/apps/web/src/constants/basic-info.ts
@@ -6,38 +6,38 @@ export type PersonalInfo = {
   major1: string;
   major2: string;
   admissionYear: string;
-  militaryStatus: string;
+  militaryStatus: string;   // DB 미지원 — 로컬 상태로만 유지
   academicStatus: string;
   graduationYear: string;
 };
 
 export type AdmissionEntry = { school: string; type: string };
 export type AdmissionInfo = {
-  가: { first: AdmissionEntry; second: AdmissionEntry };
-  나: { first: AdmissionEntry; second: AdmissionEntry };
+  가: { first: AdmissionEntry; second: AdmissionEntry };  // second는 DB 미지원
+  나: { first: AdmissionEntry; second: AdmissionEntry };  // second는 DB 미지원
 };
 
-export const initialPersonalInfo: PersonalInfo = {
-  name: '김단추',
-  affiliation: '고려대학교 자유전공학부',
-  birthDate: '2000.03.15.',
-  gender: '남성',
-  major1: '컴퓨터학과',
-  major2: '공공거버넌스와리더십',
-  admissionYear: '2020',
-  militaryStatus: '군필여고생',
-  academicStatus: '재학',
-  graduationYear: '2026',
+export const emptyPersonalInfo: PersonalInfo = {
+  name: '',
+  affiliation: '',
+  birthDate: '',
+  gender: '',
+  major1: '',
+  major2: '',
+  admissionYear: '',
+  militaryStatus: '',
+  academicStatus: '',
+  graduationYear: '',
 };
 
-export const initialAdmissionInfo: AdmissionInfo = {
+export const emptyAdmissionInfo: AdmissionInfo = {
   가: {
-    first: { school: '고려대학교', type: '일반전형' },
-    second: { school: '-', type: '-' },
+    first: { school: '', type: '일반전형' },
+    second: { school: '', type: '' },
   },
   나: {
-    first: { school: '서울대학교', type: '일반전형' },
-    second: { school: '-', type: '-' },
+    first: { school: '', type: '일반전형' },
+    second: { school: '', type: '' },
   },
 };
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -103,3 +103,58 @@ export async function patchQuantitative(
   writeLocalCache(year, data);
   return data;
 }
+
+// ----------------------------------------------------------------
+// Basic Info
+// ----------------------------------------------------------------
+
+export type BasicInfoPersonal = {
+  name: string;
+  affiliation: string;
+  birthDate: string;
+  gender: string;
+  major1: string;
+  major2: string;
+  admissionYear: string;
+  academicStatus: string;
+  graduationYear: string;
+};
+
+export type BasicInfoAdmission = {
+  // DB에 저장되는 필드: 가/나군 제1지망 학교, 특별전형 여부
+  가: { first: string };
+  나: { first: string };
+  isSpecialAdmission: boolean;
+};
+
+export type BasicInfoData = {
+  personal: BasicInfoPersonal;
+  admission: BasicInfoAdmission;
+};
+
+export async function getBasicInfo(year: string): Promise<BasicInfoData> {
+  const res = await fetch(
+    `${API_BASE}/api/mentee/basic-info?year=${encodeURIComponent(year)}`,
+    { headers: headers(), credentials: "include" }
+  );
+  if (!res.ok) throw new Error("기본정보 조회 실패");
+  return res.json();
+}
+
+export async function patchBasicInfo(
+  year: string,
+  body: {
+    personal?: Partial<Omit<BasicInfoPersonal, "name" | "affiliation">>;
+    admission?: {
+      가?: { first?: string };
+      나?: { first?: string };
+      isSpecialAdmission?: boolean;
+    };
+  }
+): Promise<void> {
+  const res = await fetch(
+    `${API_BASE}/api/mentee/basic-info?year=${encodeURIComponent(year)}`,
+    { method: "PATCH", headers: headers(), credentials: "include", body: JSON.stringify(body) }
+  );
+  if (!res.ok) throw new Error("기본정보 저장 실패");
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
         version: 7.6.0
       '@prisma/client':
         specifier: ^7.6.0
-        version: 7.6.0(prisma@7.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.6.0(prisma@7.6.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
@@ -58,7 +58,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.2.2
-        version: 16.2.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.2.2(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       prisma:
         specifier: ^7.6.0
         version: 7.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
@@ -104,7 +104,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.2.2
-        version: 16.2.2(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.2.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       tailwindcss:
         specifier: ^4
         version: 4.2.2
@@ -119,7 +119,7 @@ importers:
         version: 7.6.0
       '@prisma/client':
         specifier: ^7.6.0
-        version: 7.6.0(prisma@7.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.6.0(prisma@7.6.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
       pg:
         specifier: ^8.13.3
         version: 8.20.0
@@ -2894,7 +2894,7 @@ snapshots:
 
   '@prisma/client-runtime-utils@7.6.0': {}
 
-  '@prisma/client@7.6.0(prisma@7.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)':
+  '@prisma/client@7.6.0(prisma@7.6.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@prisma/client-runtime-utils': 7.6.0
     optionalDependencies:


### PR DESCRIPTION
- GET/PATCH /api/mentee/basic-info 엔드포인트 추가
- User(gender, major, academic_status) + MenteeRecord(birth_date, admissionYear, graduationYear, 가/나군 학교) 저장
- 프론트 basic-info 페이지 API 로드/저장 연동 (militaryStatus·제2지망은 DB 미지원으로 로컬 유지)

solves #89 