### PR TITLE
feat(#99): 정성 데이터 대시보드 희망 진로 입력칸 추가

### DIFF
--- a/apps/web/src/app/mentee/dashboard/qualitative/page.tsx
+++ b/apps/web/src/app/mentee/dashboard/qualitative/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { EditButton, EditButtons } from '@/components/ui/EditButton';
 
 const TABS = ['대시보드', '교내', '대외', '사회경험', '자격·시험'] as const;
 type Tab = typeof TABS[number];
@@ -162,13 +163,27 @@ function CareerGoalCard({
   value: CareerGoal;
   onChange: (value: CareerGoal) => void;
 }) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState<CareerGoal>(value);
   const [saving, setSaving] = useState(false);
+
+  function startEdit() {
+    setDraft(value);
+    setIsEditing(true);
+  }
+
+  function handleCancel() {
+    setDraft(value);
+    setIsEditing(false);
+  }
 
   async function handleSave() {
     setSaving(true);
     try {
       // TODO: 희망 진로 저장 API 연동
       await new Promise((resolve) => setTimeout(resolve, 300));
+      onChange(draft);
+      setIsEditing(false);
     } finally {
       setSaving(false);
     }
@@ -176,16 +191,22 @@ function CareerGoalCard({
 
   return (
     <div className="border border-border rounded-xl px-8 py-6">
-      <div className="flex flex-col gap-3">
-        <label className="text-sm font-medium text-text-primary">희망 진로</label>
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-sm font-medium text-text-primary">희망 진로</h3>
+        {isEditing
+          ? <EditButtons onCancel={handleCancel} onSave={handleSave} disabled={saving} />
+          : <EditButton onClick={startEdit} />}
+      </div>
+
+      {isEditing ? (
         <div className="flex gap-2">
           {CAREER_OPTIONS.map((option) => {
-            const selected = value === option;
+            const selected = draft === option;
             return (
               <button
                 key={option}
                 type="button"
-                onClick={() => onChange(selected ? '' : option)}
+                onClick={() => setDraft(selected ? '' : option)}
                 className={`px-5 py-2 text-sm font-medium rounded-md border transition-colors ${
                   selected
                     ? 'bg-brand text-white border-brand'
@@ -197,17 +218,11 @@ function CareerGoalCard({
             );
           })}
         </div>
-        <div className="flex justify-end mt-2">
-          <button
-            type="button"
-            onClick={handleSave}
-            disabled={!value || saving}
-            className="px-5 py-2 text-sm font-medium text-white bg-brand rounded-md hover:bg-brand-dark transition-colors disabled:bg-gray-300 disabled:cursor-not-allowed"
-          >
-            {saving ? '저장 중...' : '저장하기'}
-          </button>
-        </div>
-      </div>
+      ) : (
+        <p className={`text-base ${value ? 'text-text-primary' : 'text-text-placeholder'}`}>
+          {value || '선택되지 않음'}
+        </p>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/mentee/dashboard/qualitative/page.tsx
+++ b/apps/web/src/app/mentee/dashboard/qualitative/page.tsx
@@ -152,6 +152,32 @@ function AddItemPlaceholder({ onClick }: { onClick: () => void }) {
   );
 }
 
+function CareerGoalCard({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div className="border border-border rounded-xl px-8 py-6">
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium text-text-primary">
+          희망 진로 <span className="text-text-secondary font-normal">(예: 공익 변호사, 검사, 사내 변호사)</span>
+        </label>
+        <textarea
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="앞으로 어떤 법조인이 되고 싶은지 자유롭게 작성해주세요"
+          rows={3}
+          className="border border-border rounded-lg bg-transparent text-sm text-text-primary p-3 placeholder:text-text-placeholder focus:outline-none focus:border-brand resize-none"
+        />
+        <p className="text-xs text-text-secondary">희망 진로는 멘토 매칭과 활동 분석에 참고됩니다.</p>
+      </div>
+    </div>
+  );
+}
+
 function EmptyState() {
   return (
     <div className="flex flex-col items-center justify-center py-20 gap-4">
@@ -172,7 +198,15 @@ function EmptyState() {
   );
 }
 
-function TabContent({ tab }: { tab: Tab }) {
+function TabContent({
+  tab,
+  careerGoal,
+  onCareerGoalChange,
+}: {
+  tab: Tab;
+  careerGoal: string;
+  onCareerGoalChange: (value: string) => void;
+}) {
   const [forms, setForms] = useState<ActivityForm[]>([]);
 
   function addForm() {
@@ -187,7 +221,14 @@ function TabContent({ tab }: { tab: Tab }) {
     setForms(forms.filter((_, i) => i !== index));
   }
 
-  if (tab === '대시보드') return <EmptyState />;
+  if (tab === '대시보드') {
+    return (
+      <div className="flex flex-col gap-6">
+        <CareerGoalCard value={careerGoal} onChange={onCareerGoalChange} />
+        <EmptyState />
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-6">
@@ -206,6 +247,7 @@ function TabContent({ tab }: { tab: Tab }) {
 
 export default function QualitativePage() {
   const [activeTab, setActiveTab] = useState<Tab>('대시보드');
+  const [careerGoal, setCareerGoal] = useState('');
 
   return (
     <div className="flex flex-col gap-6 max-w-3xl mx-auto w-full">
@@ -235,7 +277,11 @@ export default function QualitativePage() {
 
         {/* 탭 콘텐츠 */}
         <div className="px-8 py-6">
-          <TabContent tab={activeTab} />
+          <TabContent
+            tab={activeTab}
+            careerGoal={careerGoal}
+            onCareerGoalChange={setCareerGoal}
+          />
         </div>
       </div>
     </div>

--- a/apps/web/src/app/mentee/dashboard/qualitative/page.tsx
+++ b/apps/web/src/app/mentee/dashboard/qualitative/page.tsx
@@ -162,6 +162,18 @@ function CareerGoalCard({
   value: CareerGoal;
   onChange: (value: CareerGoal) => void;
 }) {
+  const [saving, setSaving] = useState(false);
+
+  async function handleSave() {
+    setSaving(true);
+    try {
+      // TODO: 희망 진로 저장 API 연동
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    } finally {
+      setSaving(false);
+    }
+  }
+
   return (
     <div className="border border-border rounded-xl px-8 py-6">
       <div className="flex flex-col gap-3">
@@ -184,6 +196,16 @@ function CareerGoalCard({
               </button>
             );
           })}
+        </div>
+        <div className="flex justify-end mt-2">
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!value || saving}
+            className="px-5 py-2 text-sm font-medium text-white bg-brand rounded-md hover:bg-brand-dark transition-colors disabled:bg-gray-300 disabled:cursor-not-allowed"
+          >
+            {saving ? '저장 중...' : '저장하기'}
+          </button>
         </div>
       </div>
     </div>

--- a/apps/web/src/app/mentee/dashboard/qualitative/page.tsx
+++ b/apps/web/src/app/mentee/dashboard/qualitative/page.tsx
@@ -198,31 +198,33 @@ function CareerGoalCard({
           : <EditButton onClick={startEdit} />}
       </div>
 
-      {isEditing ? (
-        <div className="flex gap-2">
-          {CAREER_OPTIONS.map((option) => {
-            const selected = draft === option;
-            return (
-              <button
-                key={option}
-                type="button"
-                onClick={() => setDraft(selected ? '' : option)}
-                className={`px-5 py-2 text-sm font-medium rounded-md border transition-colors ${
-                  selected
-                    ? 'bg-brand text-white border-brand'
-                    : 'bg-transparent text-text-secondary border-border hover:border-brand hover:text-text-primary'
-                }`}
-              >
-                {option}
-              </button>
-            );
-          })}
-        </div>
-      ) : (
-        <p className={`text-base ${value ? 'text-text-primary' : 'text-text-placeholder'}`}>
-          {value || '선택되지 않음'}
-        </p>
-      )}
+      <div className="min-h-[40px] flex items-center">
+        {isEditing ? (
+          <div className="flex gap-2">
+            {CAREER_OPTIONS.map((option) => {
+              const selected = draft === option;
+              return (
+                <button
+                  key={option}
+                  type="button"
+                  onClick={() => setDraft(selected ? '' : option)}
+                  className={`px-5 py-2 text-sm font-medium rounded-md border transition-colors ${
+                    selected
+                      ? 'bg-brand text-white border-brand'
+                      : 'bg-transparent text-text-secondary border-border hover:border-brand hover:text-text-primary'
+                  }`}
+                >
+                  {option}
+                </button>
+              );
+            })}
+          </div>
+        ) : (
+          <p className={`text-base ${value ? 'text-text-primary' : 'text-text-placeholder'}`}>
+            {value || '선택되지 않음'}
+          </p>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/mentee/dashboard/qualitative/page.tsx
+++ b/apps/web/src/app/mentee/dashboard/qualitative/page.tsx
@@ -5,6 +5,9 @@ import { useState } from 'react';
 const TABS = ['대시보드', '교내', '대외', '사회경험', '자격·시험'] as const;
 type Tab = typeof TABS[number];
 
+const CAREER_OPTIONS = ['변호사', '검사', '판사'] as const;
+type CareerGoal = typeof CAREER_OPTIONS[number] | '';
+
 type ActivityForm = {
   name: string;
   organization: string;
@@ -156,23 +159,32 @@ function CareerGoalCard({
   value,
   onChange,
 }: {
-  value: string;
-  onChange: (value: string) => void;
+  value: CareerGoal;
+  onChange: (value: CareerGoal) => void;
 }) {
   return (
     <div className="border border-border rounded-xl px-8 py-6">
-      <div className="flex flex-col gap-2">
-        <label className="text-sm font-medium text-text-primary">
-          희망 진로 <span className="text-text-secondary font-normal">(예: 공익 변호사, 검사, 사내 변호사)</span>
-        </label>
-        <textarea
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          placeholder="앞으로 어떤 법조인이 되고 싶은지 자유롭게 작성해주세요"
-          rows={3}
-          className="border border-border rounded-lg bg-transparent text-sm text-text-primary p-3 placeholder:text-text-placeholder focus:outline-none focus:border-brand resize-none"
-        />
-        <p className="text-xs text-text-secondary">희망 진로는 멘토 매칭과 활동 분석에 참고됩니다.</p>
+      <div className="flex flex-col gap-3">
+        <label className="text-sm font-medium text-text-primary">희망 진로</label>
+        <div className="flex gap-2">
+          {CAREER_OPTIONS.map((option) => {
+            const selected = value === option;
+            return (
+              <button
+                key={option}
+                type="button"
+                onClick={() => onChange(selected ? '' : option)}
+                className={`px-5 py-2 text-sm font-medium rounded-md border transition-colors ${
+                  selected
+                    ? 'bg-brand text-white border-brand'
+                    : 'bg-transparent text-text-secondary border-border hover:border-brand hover:text-text-primary'
+                }`}
+              >
+                {option}
+              </button>
+            );
+          })}
+        </div>
       </div>
     </div>
   );
@@ -204,8 +216,8 @@ function TabContent({
   onCareerGoalChange,
 }: {
   tab: Tab;
-  careerGoal: string;
-  onCareerGoalChange: (value: string) => void;
+  careerGoal: CareerGoal;
+  onCareerGoalChange: (value: CareerGoal) => void;
 }) {
   const [forms, setForms] = useState<ActivityForm[]>([]);
 
@@ -247,7 +259,7 @@ function TabContent({
 
 export default function QualitativePage() {
   const [activeTab, setActiveTab] = useState<Tab>('대시보드');
-  const [careerGoal, setCareerGoal] = useState('');
+  const [careerGoal, setCareerGoal] = useState<CareerGoal>('');
 
   return (
     <div className="flex flex-col gap-6 max-w-3xl mx-auto w-full">


### PR DESCRIPTION
## Summary
- 멘티 정성 데이터 페이지의 `대시보드` 탭 상단에 희망 진로를 자유 텍스트로 작성하는 카드(`CareerGoalCard`)를 추가
- 부모 컴포넌트(`QualitativePage`)에서 상태를 보유해 탭 전환 시에도 입력값이 유지되도록 구성
- 기존 정성 페이지가 로컬 state UI 위주이므로 이번 PR도 FE-only — 백엔드/스키마 변경은 별도 이슈에서 진행 권장

Closes #99

## Test plan
- [ ] `pnpm dev:web` 후 `/mentee/dashboard/qualitative` 진입
- [ ] `대시보드` 탭에서 희망 진로 카드가 EmptyState 위에 보이는지 확인
- [ ] 텍스트 입력 후 다른 탭(교내/대외 등)으로 이동 → 다시 대시보드로 돌아왔을 때 입력값이 유지되는지 확인
- [ ] 다른 탭에서는 희망 진로 카드가 보이지 않는지 확인