### PR TITLE
feat(#105): 멘토 페이지 구성 (사이드바 5개 + 스켈레톤)

### DIFF
--- a/apps/web/src/app/mentor/archive/layout.tsx
+++ b/apps/web/src/app/mentor/archive/layout.tsx
@@ -1,0 +1,27 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import jwt from 'jsonwebtoken';
+import DashboardShell from '@/components/layout/DashboardShell';
+
+const COOKIE_NAME = 'plawcess_token';
+
+export default async function MentorArchiveLayout({ children }: { children: React.ReactNode }) {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(COOKIE_NAME)?.value;
+
+  if (!token) {
+    redirect('/login');
+  }
+
+  try {
+    const secret = process.env.JWT_SECRET;
+    if (!secret) {
+      throw new Error('JWT_SECRET not set');
+    }
+    jwt.verify(token, secret);
+  } catch {
+    redirect('/login');
+  }
+
+  return <DashboardShell>{children}</DashboardShell>;
+}

--- a/apps/web/src/app/mentor/archive/page.tsx
+++ b/apps/web/src/app/mentor/archive/page.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+export default function MentorArchivePage() {
+  return (
+    <div className="flex flex-col gap-6 max-w-3xl mx-auto w-full">
+      <div>
+        <h1 className="text-2xl font-bold text-text-primary">합격 아카이브</h1>
+        <p className="text-sm text-text-secondary mt-1">
+          자유전공학부 출신 로스쿨 합격 선배들의 익명 케이스를 확인하세요
+        </p>
+      </div>
+
+      <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-10 text-center text-sm text-text-secondary">
+        준비 중입니다.
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/mentor/dashboard/basic-info/page.tsx
+++ b/apps/web/src/app/mentor/dashboard/basic-info/page.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+export default function MentorBasicInfoPage() {
+  return (
+    <div className="flex flex-col gap-6 max-w-3xl mx-auto w-full">
+      <div>
+        <h1 className="text-2xl font-bold text-text-primary">기본정보</h1>
+        <p className="text-sm text-text-secondary mt-1">
+          멘티 시절 작성한 기본정보가 자동으로 표시됩니다. 멘토로 직접 가입한 경우 비어있을 수 있습니다.
+        </p>
+      </div>
+
+      <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-10 text-center text-sm text-text-secondary">
+        준비 중입니다.
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/mentor/dashboard/qualitative/page.tsx
+++ b/apps/web/src/app/mentor/dashboard/qualitative/page.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+export default function MentorQualitativePage() {
+  return (
+    <div className="flex flex-col gap-6 max-w-3xl mx-auto w-full">
+      <div>
+        <h1 className="text-2xl font-bold text-text-primary">정성 데이터</h1>
+        <p className="text-sm text-text-secondary mt-1">
+          멘티 시절 작성한 정성 데이터가 자동으로 표시됩니다. 멘토로 직접 가입한 경우 비어있을 수 있습니다.
+        </p>
+      </div>
+
+      <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-10 text-center text-sm text-text-secondary">
+        준비 중입니다.
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/mentor/dashboard/quantitative/page.tsx
+++ b/apps/web/src/app/mentor/dashboard/quantitative/page.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+export default function MentorQuantitativePage() {
+  return (
+    <div className="flex flex-col gap-6 max-w-3xl mx-auto w-full">
+      <div>
+        <h1 className="text-2xl font-bold text-text-primary">정량 데이터</h1>
+        <p className="text-sm text-text-secondary mt-1">
+          멘티 시절 작성한 정량 데이터가 자동으로 표시됩니다. 멘토로 직접 가입한 경우 비어있을 수 있습니다.
+        </p>
+      </div>
+
+      <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-10 text-center text-sm text-text-secondary">
+        준비 중입니다.
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -11,11 +11,15 @@ const menteeNavItems = [
   { label: '합격 아카이브', href: '/mentee/archive' },
 ];
 
-const mentorNavItems = [
-  { label: '대시보드', href: '/mentor/dashboard' },
-];
+type NavItem = { label: string; href: string; match?: string; exact?: boolean };
 
-type NavItem = { label: string; href: string; match?: string };
+const mentorNavItems: NavItem[] = [
+  { label: '프로세스 대시보드', href: '/mentor/dashboard', exact: true },
+  { label: '기본정보', href: '/mentor/dashboard/basic-info' },
+  { label: '정량 데이터', href: '/mentor/dashboard/quantitative' },
+  { label: '정성 데이터', href: '/mentor/dashboard/qualitative' },
+  { label: '합격 아카이브', href: '/mentor/archive' },
+];
 
 const adminNavItems: NavItem[] = [
   { label: '회원관리', href: '/admin/users' },
@@ -39,7 +43,9 @@ export default function Sidebar() {
       <nav className="flex flex-col gap-1 px-2">
         {navItems.map((item) => {
           const matchPath = item.match ?? item.href;
-          const isActive = pathname === matchPath || pathname.startsWith(matchPath + '/');
+          const isActive = item.exact
+            ? pathname === matchPath
+            : pathname === matchPath || pathname.startsWith(matchPath + '/');
           return (
             <Link
               key={item.href}


### PR DESCRIPTION
## Summary
- 멘토 사이드바를 1개 → 5개 항목으로 확장 (프로세스 대시보드 / 기본정보 / 정량 데이터 / 정성 데이터 / 합격 아카이브)
- 신규 스켈레톤 페이지 추가: \`/mentor/dashboard/{basic-info,quantitative,qualitative}\`, \`/mentor/archive\`
- Sidebar에 \`exact\` 매칭 플래그 추가 — 부모 경로(\`/mentor/dashboard\`)가 자식 경로 prefix를 포함할 때 동시 활성화되는 문제 방지

## Notes
- 각 페이지의 세부 기능은 후속 이슈에서 채워질 예정 (이슈 본문에 언급됨)
- 기존 \`/mentor/dashboard\` 페이지(매칭된 멘티 카드 목록)는 "프로세스 대시보드"로 그대로 유지
- 멘토 데이터는 멘티 → 멘토 권한 전환 케이스 기준이며, 신규 멘토 직접 가입 시 NULL 처리됨을 안내 문구에 반영

## Test plan
- [ ] 멘토 권한 계정으로 로그인 → 사이드바에 5개 항목 노출 확인
- [ ] 각 메뉴 클릭 시 해당 페이지 진입 확인
- [ ] \`/mentor/dashboard/basic-info\` 진입 시 사이드바에서 "기본정보"만 활성화되고 "프로세스 대시보드"는 비활성 확인
- [ ] 비로그인 상태에서 멘토 페이지 접근 → \`/login\` 리다이렉트 확인

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)