### PR TITLE
feat(#91, #100): 병역여부·희망 진로 DB 컬럼 + DB 워크플로우 정리

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,68 @@ pnpm build:web
 pnpm build:api
 
 # DB
-pnpm db:generate    # Prisma Client 생성
-pnpm db:push        # 스키마 반영
-pnpm db:migrate     # 마이그레이션 실행
+pnpm db:generate          # Prisma Client 생성
+pnpm db:push              # 스키마를 dev DB에 즉시 반영 (마이그레이션 X)
+pnpm db:migrate           # 로컬 dev DB에 새 마이그레이션 생성·적용 (prisma migrate dev)
+pnpm db:migrate:deploy    # 운영(Supabase)에 미적용 마이그레이션 배포 (prisma migrate deploy)
 ```
+
+## DB 스키마 변경 워크플로우
+
+운영 DB는 Supabase, 마이그레이션은 Prisma가 `_prisma_migrations` 테이블에 추적. 다음 4단계로 끝.
+
+### 1. `schema.prisma` 수정
+`packages/database/prisma/schema.prisma`에 필드/모델/enum 변경.
+
+### 2. 마이그레이션 SQL 파일 작성
+`packages/database/prisma/migrations/YYYYMMDDHHMMSS_descriptive_name/migration.sql` 폴더 만들고 SQL 직접 작성.
+
+```sql
+-- 예시
+ALTER TABLE "users" ADD COLUMN "new_field" TEXT;
+```
+
+SQL을 손으로 쓰기 귀찮으면 자동 생성:
+```bash
+cd packages/database
+node_modules/.bin/prisma migrate diff \
+  --from-schema-datasource prisma/schema.prisma \
+  --to-schema-datamodel prisma/schema.prisma \
+  --script
+```
+출력을 `migration.sql`에 붙여넣기.
+
+### 3. 커밋
+```bash
+git add packages/database/prisma/schema.prisma \
+        packages/database/prisma/migrations/YYYYMMDDHHMMSS_*
+git commit -m "feat(#xxx): ..."
+```
+
+### 4. Supabase에 반영
+```bash
+pnpm db:migrate:deploy
+```
+Prisma가 `_prisma_migrations`를 보고 미적용 마이그레이션의 SQL을 실행 + 추적 행 추가. **SQL Editor 직접 실행 안 해도 됨.**
+
+### 5. 코드 동기화 (필요 시)
+```bash
+pnpm db:generate
+```
+(`postinstall`로 자동되긴 함)
+
+### `db:migrate:deploy`가 hang 될 때
+`.env`의 `DATABASE_URL`이 pgbouncer 풀러(포트 6543)를 가리키면 마이그레이션 스텝에서 멈출 수 있음. 그때만 임시로 DIRECT_URL 강제:
+```bash
+cd packages/database
+DIRECT_URL_VAL=$(grep "^DIRECT_URL=" .env | cut -d= -f2- | tr -d '"')
+DATABASE_URL="$DIRECT_URL_VAL" node_modules/.bin/prisma migrate deploy --schema=prisma/schema.prisma
+```
+
+### 잘못 적용됐을 때
+- **이미 SQL Editor에서 직접 실행해버린 마이그레이션이 있다면**: `node_modules/.bin/prisma migrate resolve --applied <migration_name> --schema=prisma/schema.prisma` 로 추적만 마크 (스키마는 안 건드림)
+- **잘못 적용된 마이그레이션을 되돌리려면**: 새 마이그레이션 폴더에 `DROP COLUMN ...` SQL 작성 후 deploy (마이그레이션은 forward-only)
+
 
 ## 페이지 라우팅
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build:api": "pnpm --filter api build",
     "db:generate": "pnpm --filter @plawcess/database generate",
     "db:push": "pnpm --filter @plawcess/database push",
-    "db:migrate": "pnpm --filter @plawcess/database migrate"
+    "db:migrate": "pnpm --filter @plawcess/database migrate",
+    "db:migrate:deploy": "pnpm --filter @plawcess/database migrate:deploy"
   }
 }

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -9,6 +9,7 @@
     "postinstall": "prisma generate --schema=prisma/schema.prisma",
     "push": "prisma db push --schema=prisma/schema.prisma",
     "migrate": "prisma migrate dev --schema=prisma/schema.prisma",
+    "migrate:deploy": "prisma migrate deploy --schema=prisma/schema.prisma",
     "studio": "prisma studio --schema=prisma/schema.prisma",
     "build": "tsc"
   },

--- a/packages/database/prisma/migrations/20260503000000_add_military_status_and_career_goal/migration.sql
+++ b/packages/database/prisma/migrations/20260503000000_add_military_status_and_career_goal/migration.sql
@@ -1,0 +1,14 @@
+-- CreateEnum: 병역여부 (#91)
+CREATE TYPE "MilitaryStatus" AS ENUM ('completed', 'not_completed', 'not_applicable');
+
+-- CreateEnum: 희망 진로 (#100)
+CREATE TYPE "CareerGoal" AS ENUM ('lawyer', 'prosecutor', 'judge');
+
+-- AlterTable: users에 병역여부 컬럼 추가 (#91)
+ALTER TABLE "users"
+  ADD COLUMN "military_status" "MilitaryStatus";
+
+-- AlterTable: mentee_records에 희망 진로 컬럼 추가 (#100)
+--   FE 정성 데이터 대시보드의 변호사/검사/판사 선택값을 저장
+ALTER TABLE "mentee_records"
+  ADD COLUMN "career_goal" "CareerGoal";

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -36,6 +36,18 @@ enum AcademicStatus {
   expelled        // 제적
 }
 
+enum MilitaryStatus {
+  completed       // 군필
+  not_completed   // 미필
+  not_applicable  // 해당없음 (여성 등)
+}
+
+enum CareerGoal {
+  lawyer          // 변호사
+  prosecutor      // 검사
+  judge           // 판사
+}
+
 enum AccountStatus {
   active
   inactive
@@ -92,6 +104,7 @@ model User {
   second_major    String?         @db.VarChar(100)
   school_name     String?         @db.VarChar(100)
   academic_status AcademicStatus?
+  military_status MilitaryStatus?
   account_status  AccountStatus   @default(active)
   current_role    CurrentRole     @default(none)
 
@@ -164,6 +177,7 @@ model MenteeRecord {
   qualitative_activities Json?    // { volunteer, conference, thesis, club, external }
   core_keywords          String?  @db.VarChar(500)
   story_summary          String?  @db.Text
+  career_goal            CareerGoal?  // 변호사 / 검사 / 판사 (정성 대시보드 선택)
 
   // AI 분석 결과 (LLM Output)
   star_analysis          Json?    // STAR 구조화 결과


### PR DESCRIPTION
## Summary

### #91 — 병역여부 DB 추가
- `User.military_status` enum 컬럼 추가 (`MilitaryStatus`: completed/not_completed/not_applicable)
- 옵션 3(#118) 방향과 호환되도록 처음부터 `User`에 둠

### #100 — 희망 진로 DB 추가
- `MenteeRecord.career_goal` enum 컬럼 추가 (`CareerGoal`: lawyer/prosecutor/judge)
- FE 정성 데이터 대시보드(#99)의 변호사/검사/판사 선택값을 사이클별로 저장

### 부수
- `migrations/20260503000000_add_military_status_and_career_goal/migration.sql` 신설
- `pnpm db:migrate:deploy` 스크립트 추가 (운영 배포용 `prisma migrate deploy`)
- README에 DB 스키마 변경 워크플로우 섹션 추가 (4단계 가이드 + 트러블슈팅)

### Supabase 적용 상태
- 운영 DB에 SQL Editor로 컬럼·enum 생성 완료
- `_prisma_migrations` 테이블에 `migrate resolve --applied`로 새 마이그레이션 마크 완료
- `prisma migrate status` → "Database schema is up to date!" 확인됨

Closes #91
Closes #100

## Test plan
- [x] 로컬 `pnpm db:generate` 통과 (스키마 유효성)
- [x] Supabase에 컬럼·enum 생성 완료
- [x] `_prisma_migrations` 추적 정렬됨
- [ ] FE/BE에서 새 필드 사용은 별도 PR로 진행