### PR TITLE
feat: 회원가입 폼 개편 + 로그인 라벨을 아이디로 변경

### DIFF
--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -16,7 +16,7 @@ const ROLE_REDIRECT: Record<string, string> = {
 
 export default function LoginPage() {
   const router = useRouter();
-  const [email, setEmail] = useState('');
+  const [loginId, setLoginId] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
@@ -28,11 +28,13 @@ export default function LoginPage() {
 
     let res: Response;
     try {
+      // Option A: BE가 아직 email 기반 로그인이라 사용자가 아이디 자리에 email을 입력해야 함.
+      //           #120 머지 후 페이로드 키를 loginId로 전환 예정.
       res = await fetch(`${API_BASE}/api/auth/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ email, password }),
+        body: JSON.stringify({ email: loginId, password }),
       });
     } catch {
       setError('서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.');
@@ -103,15 +105,15 @@ export default function LoginPage() {
           <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-8">
             <form onSubmit={handleSubmit} className="flex flex-col gap-5">
               <div className="flex flex-col gap-1.5">
-                <label htmlFor="email" className="text-sm font-medium text-text-primary">
-                  이메일
+                <label htmlFor="loginId" className="text-sm font-medium text-text-primary">
+                  아이디
                 </label>
                 <input
-                  id="email"
-                  type="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  placeholder="example@email.com"
+                  id="loginId"
+                  type="text"
+                  value={loginId}
+                  onChange={(e) => setLoginId(e.target.value)}
+                  placeholder="아이디를 입력하세요"
                   required
                   className="w-full px-3 py-2.5 text-sm border border-border-input rounded-md bg-white text-text-primary placeholder:text-text-placeholder focus:outline-none focus:border-brand transition-colors"
                 />

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -1,20 +1,69 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import Footer from '@/components/layout/Footer';
 
 const API_BASE = '';
 
+type Role = 'mentee' | 'mentor';
+type Gender = 'male' | 'female';
+
+type FormState = {
+  role: Role;
+  name: string;
+  loginId: string;
+  email: string;
+  password: string;
+  passwordConfirm: string;
+  birthDate: string;       // YYYY.MM.DD.
+  gender: Gender | '';
+  phone: string;
+  studentId: string;
+  enrollmentFile: File | null;
+};
+
+const EMPTY_FORM: FormState = {
+  role: 'mentee',
+  name: '',
+  loginId: '',
+  email: '',
+  password: '',
+  passwordConfirm: '',
+  birthDate: '',
+  gender: '',
+  phone: '',
+  studentId: '',
+  enrollmentFile: null,
+};
+
+function todayDots() {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  const d = String(now.getDate()).padStart(2, '0');
+  return `${y}.${m}.${d}.`;
+}
+
 export default function SignupPage() {
   const router = useRouter();
-  const [form, setForm] = useState({ name: '', email: '', password: '', passwordConfirm: '' });
+  const [form, setForm] = useState<FormState>({ ...EMPTY_FORM, birthDate: todayDots() });
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
-  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
-    setForm((prev) => ({ ...prev, [e.target.name]: e.target.value }));
+  function update<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  }
+
+  function handleFile(file: File | null) {
+    if (file && file.size > 10 * 1024 * 1024) {
+      setError('파일 크기는 10MB 이하여야 합니다.');
+      return;
+    }
+    setError('');
+    update('enrollmentFile', file);
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -25,9 +74,19 @@ export default function SignupPage() {
       setError('비밀번호가 일치하지 않습니다.');
       return;
     }
+    if (!/^\d{4}\.\d{2}\.\d{2}\.$/.test(form.birthDate)) {
+      setError('생년월일은 YYYY.MM.DD. 형식으로 입력해주세요.');
+      return;
+    }
+    if (!form.gender) {
+      setError('성별을 선택해주세요.');
+      return;
+    }
 
     setLoading(true);
 
+    // Option A: 추가 필드(loginId, birthDate, gender, phone, studentId, enrollmentFile, role)는
+    //           BE 미지원이므로 일단 무시. #120/#83/#84에서 BE 확장 후 페이로드에 포함 예정.
     const res = await fetch(`${API_BASE}/api/auth/signup`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -53,8 +112,8 @@ export default function SignupPage() {
           pLAWcess
         </Link>
       </header>
-      <main className="flex-1 bg-page-bg flex justify-center items-start px-4 pt-20">
-        <div className="w-full max-w-sm py-16">
+      <main className="flex-1 bg-page-bg flex justify-center items-start px-4 pt-12 pb-20">
+        <div className="w-full max-w-md">
           <div className="text-center mb-8">
             <h1 className="text-2xl font-bold text-text-primary">회원가입</h1>
             <p className="mt-2 text-sm text-text-secondary">pLAWcess에 오신 것을 환영합니다</p>
@@ -62,71 +121,204 @@ export default function SignupPage() {
 
           <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-8">
             <form onSubmit={handleSubmit} className="flex flex-col gap-5">
-              <div className="flex flex-col gap-1.5">
-                <label htmlFor="name" className="text-sm font-medium text-text-primary">이름</label>
+              {/* 멘티/멘토 토글 */}
+              <div className="grid grid-cols-2 gap-1 p-1 bg-page-bg rounded-md">
+                {(['mentee', 'mentor'] as const).map((r) => (
+                  <button
+                    key={r}
+                    type="button"
+                    onClick={() => update('role', r)}
+                    className={`py-2.5 text-sm font-medium rounded-md transition-colors ${
+                      form.role === r
+                        ? 'bg-brand text-white'
+                        : 'text-text-secondary hover:text-text-primary'
+                    }`}
+                  >
+                    {r === 'mentee' ? '멘티' : '멘토'}
+                  </button>
+                ))}
+              </div>
+
+              {/* 이름 */}
+              <Field label="이름" htmlFor="name">
                 <input
                   id="name"
-                  name="name"
                   type="text"
                   value={form.name}
-                  onChange={handleChange}
+                  onChange={(e) => update('name', e.target.value)}
                   placeholder="홍길동"
                   required
-                  className="w-full px-3 py-2.5 text-sm border border-border-input rounded-md bg-white text-text-primary placeholder:text-text-placeholder focus:outline-none focus:border-brand transition-colors"
+                  className={inputClass}
                 />
-              </div>
+              </Field>
 
-              <div className="flex flex-col gap-1.5">
-                <label htmlFor="email" className="text-sm font-medium text-text-primary">이메일</label>
+              {/* 아이디 */}
+              <Field label="아이디" htmlFor="loginId">
                 <input
-                  id="email"
-                  name="email"
-                  type="email"
-                  value={form.email}
-                  onChange={handleChange}
-                  placeholder="example@email.com"
+                  id="loginId"
+                  type="text"
+                  value={form.loginId}
+                  onChange={(e) => update('loginId', e.target.value)}
+                  placeholder="영문, 숫자 조합"
                   required
-                  className="w-full px-3 py-2.5 text-sm border border-border-input rounded-md bg-white text-text-primary placeholder:text-text-placeholder focus:outline-none focus:border-brand transition-colors"
+                  className={inputClass}
                 />
-              </div>
+              </Field>
 
-              <div className="flex flex-col gap-1.5">
-                <label htmlFor="password" className="text-sm font-medium text-text-primary">비밀번호</label>
+              {/* 이메일 + 인증하기 */}
+              <Field label="이메일" htmlFor="email">
+                <div className="flex gap-2">
+                  <input
+                    id="email"
+                    type="email"
+                    value={form.email}
+                    onChange={(e) => update('email', e.target.value)}
+                    placeholder="your.email@example.com"
+                    required
+                    className={`${inputClass} flex-1`}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => alert('이메일 인증 기능은 곧 추가됩니다.')}
+                    className="px-4 py-2.5 text-sm font-medium text-white bg-brand rounded-md hover:bg-brand-dark transition-colors whitespace-nowrap"
+                  >
+                    인증하기
+                  </button>
+                </div>
+              </Field>
+
+              {/* 비밀번호 */}
+              <Field label="비밀번호" htmlFor="password">
                 <input
                   id="password"
-                  name="password"
                   type="password"
                   value={form.password}
-                  onChange={handleChange}
-                  placeholder="8자 이상 입력하세요"
+                  onChange={(e) => update('password', e.target.value)}
+                  placeholder="비밀번호를 입력하세요"
                   required
                   minLength={8}
-                  className="w-full px-3 py-2.5 text-sm border border-border-input rounded-md bg-white text-text-primary placeholder:text-text-placeholder focus:outline-none focus:border-brand transition-colors"
+                  className={inputClass}
                 />
-              </div>
+              </Field>
 
-              <div className="flex flex-col gap-1.5">
-                <label htmlFor="passwordConfirm" className="text-sm font-medium text-text-primary">비밀번호 확인</label>
+              {/* 비밀번호 확인 */}
+              <Field label="비밀번호 확인" htmlFor="passwordConfirm">
                 <input
                   id="passwordConfirm"
-                  name="passwordConfirm"
                   type="password"
                   value={form.passwordConfirm}
-                  onChange={handleChange}
+                  onChange={(e) => update('passwordConfirm', e.target.value)}
                   placeholder="비밀번호를 다시 입력하세요"
                   required
-                  className="w-full px-3 py-2.5 text-sm border border-border-input rounded-md bg-white text-text-primary placeholder:text-text-placeholder focus:outline-none focus:border-brand transition-colors"
+                  className={inputClass}
                 />
-              </div>
+              </Field>
+
+              {/* 생년월일 */}
+              <Field label="생년월일" htmlFor="birthDate">
+                <input
+                  id="birthDate"
+                  type="text"
+                  value={form.birthDate}
+                  onChange={(e) => update('birthDate', e.target.value)}
+                  placeholder="2000.01.01."
+                  required
+                  className={inputClass}
+                />
+              </Field>
+
+              {/* 성별 */}
+              <Field label="성별">
+                <div className="grid grid-cols-2 gap-1 p-1 bg-page-bg rounded-md">
+                  {(['male', 'female'] as const).map((g) => (
+                    <button
+                      key={g}
+                      type="button"
+                      onClick={() => update('gender', g)}
+                      className={`py-2.5 text-sm font-medium rounded-md transition-colors ${
+                        form.gender === g
+                          ? 'bg-brand text-white'
+                          : 'text-text-secondary hover:text-text-primary'
+                      }`}
+                    >
+                      {g === 'male' ? '남성' : '여성'}
+                    </button>
+                  ))}
+                </div>
+              </Field>
+
+              {/* 전화번호 + SMS 인증 */}
+              <Field label="전화번호" htmlFor="phone">
+                <div className="flex gap-2">
+                  <input
+                    id="phone"
+                    type="tel"
+                    value={form.phone}
+                    onChange={(e) => update('phone', e.target.value)}
+                    placeholder="010-0000-0000"
+                    required
+                    className={`${inputClass} flex-1`}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => alert('SMS 인증 기능은 곧 추가됩니다.')}
+                    className="px-4 py-2.5 text-sm font-medium text-white bg-brand rounded-md hover:bg-brand-dark transition-colors whitespace-nowrap"
+                  >
+                    SMS 인증
+                  </button>
+                </div>
+              </Field>
+
+              {/* 학부생 학번 */}
+              <Field label="학부생 학번" htmlFor="studentId">
+                <input
+                  id="studentId"
+                  type="text"
+                  value={form.studentId}
+                  onChange={(e) => update('studentId', e.target.value)}
+                  placeholder="학번을 입력하세요"
+                  required
+                  className={inputClass}
+                />
+              </Field>
+
+              {/* 학부 재학증명서 업로드 */}
+              <Field label="학부 재학증명서 업로드">
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".pdf,.jpg,.jpeg,.png"
+                  className="hidden"
+                  onChange={(e) => handleFile(e.target.files?.[0] ?? null)}
+                />
+                <div
+                  onClick={() => fileInputRef.current?.click()}
+                  className="flex flex-col items-center justify-center py-8 border-2 border-dashed border-border rounded-md cursor-pointer hover:bg-gray-50 transition-colors"
+                >
+                  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="text-text-placeholder mb-2">
+                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                    <polyline points="17 8 12 3 7 8" />
+                    <line x1="12" y1="3" x2="12" y2="15" />
+                  </svg>
+                  {form.enrollmentFile ? (
+                    <span className="text-sm text-text-primary">{form.enrollmentFile.name}</span>
+                  ) : (
+                    <>
+                      <span className="text-sm text-text-secondary">클릭하거나 파일을 드래그하여 업로드</span>
+                      <span className="text-xs text-text-placeholder mt-1">PDF, JPG, PNG (최대 10MB)</span>
+                    </>
+                  )}
+                </div>
+              </Field>
 
               {error && <p className="text-sm text-red-500">{error}</p>}
 
               <button
                 type="submit"
                 disabled={loading}
-                className="w-full py-2.5 text-sm font-semibold text-white bg-brand rounded-md hover:bg-brand-dark transition-colors mt-1 disabled:opacity-50"
+                className="w-full py-3 text-sm font-semibold text-white bg-brand rounded-md hover:bg-brand-dark transition-colors mt-2 disabled:opacity-50"
               >
-                {loading ? '가입 중...' : '회원가입'}
+                {loading ? '가입 중...' : '계정 만들기'}
               </button>
 
               <p className="text-center text-sm text-text-secondary">
@@ -140,6 +332,28 @@ export default function SignupPage() {
         </div>
       </main>
       <Footer />
+    </div>
+  );
+}
+
+const inputClass =
+  'w-full px-3 py-2.5 text-sm border border-border-input rounded-md bg-white text-text-primary placeholder:text-text-placeholder focus:outline-none focus:border-brand transition-colors';
+
+function Field({
+  label,
+  htmlFor,
+  children,
+}: {
+  label: string;
+  htmlFor?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label htmlFor={htmlFor} className="text-sm font-medium text-text-primary">
+        {label}
+      </label>
+      {children}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

### 회원가입 (`/signup`)
이슈 #120 합의 사항(아이디·이메일 분리)에 맞춰 폼 구조를 미리 개편. 멘티/멘토 토글, 이름, 아이디, 이메일(+인증하기 버튼), 비밀번호/확인, 생년월일, 성별, 전화번호(+SMS 인증), 학부생 학번, 학부 재학증명서 업로드 필드 추가.

- `인증하기` / `SMS 인증` 버튼은 alert 안내만 (실 연동은 별도 — #83 이메일 인증, #93 휴대폰 인증)
- 재학증명서 파일은 로컬 state에만 보유 (실 업로드 인프라 결정 후 연동)
- 클라이언트 검증: 비밀번호 일치, 생년월일 형식(YYYY.MM.DD.), 성별 선택 필수, 파일 10MB 이하

### 로그인 (`/login`)
- 라벨 `이메일` → `아이디`, state 변수 `email` → `loginId`, input type → text
- placeholder: "아이디를 입력하세요"

### 옵션 A 정책
BE가 아직 email 기반이라:
- 회원가입: `name`/`email`/`password`만 BE에 전송. 추가 필드(loginId, birthDate, gender, phone, studentId, role, enrollmentFile)는 폼에서 받기만 하고 무시
- 로그인: 사용자가 입력한 값을 `email` 키로 BE에 전송 (사용자가 아이디 자리에 email을 입력해야 로그인됨)

각 파일에 코드 주석으로 `#120 머지 후 페이로드 전환` 가이드 명시.

## Test plan
- [x] 로컬 `pnpm build:web` 통과
- [x] `/signup` — 모든 필드 입력 가능, 인증/SMS 버튼 클릭 시 alert, 파일 선택 동작 (10MB 검증), 비밀번호 불일치 에러, 생년월일 형식 에러, 성별 미선택 에러
- [ ] 회원가입 후 `/login`으로 이동 → 회원가입 시 입력한 email로 로그인 → 정상 redirect
- [ ] dev 빠른 로그인 버튼 그대로 동작