### PR TITLE
feat(#120): 로그인 ID(login_id)와 이메일 분리

### DIFF
--- a/apps/api/src/app/api/auth/login/route.ts
+++ b/apps/api/src/app/api/auth/login/route.ts
@@ -4,30 +4,37 @@ import { prisma } from "@plawcess/database";
 import { signToken, makeAuthCookie } from "@/lib/auth";
 
 export async function POST(req: NextRequest) {
-  let body: { email?: string; password?: string };
+  let body: { loginId?: string; email?: string; password?: string };
   try {
     body = await req.json();
   } catch {
     return NextResponse.json({ error: "요청 형식이 올바르지 않습니다." }, { status: 400 });
   }
 
-  const { email, password } = body;
-  if (!email || !password) {
-    return NextResponse.json({ error: "이메일과 비밀번호를 입력해주세요." }, { status: 400 });
+  const { loginId, email, password } = body;
+  // 과도기: loginId가 우선, 없으면 email로 조회 (기존 dummy 유저·테스트 admin 호환)
+  const queryKey = loginId
+    ? { login_id: loginId, is_deleted: false }
+    : email
+      ? { email, is_deleted: false }
+      : null;
+
+  if (!queryKey || !password) {
+    return NextResponse.json({ error: "아이디와 비밀번호를 입력해주세요." }, { status: 400 });
   }
 
-  const user = await prisma.user.findUnique({
-    where: { email, is_deleted: false },
-    select: { user_id: true, name: true, email: true, current_role: true, account_status: true, password_hash: true },
+  const user = await prisma.user.findFirst({
+    where: queryKey,
+    select: { user_id: true, name: true, login_id: true, email: true, current_role: true, account_status: true, password_hash: true },
   });
 
   if (!user || !user.password_hash) {
-    return NextResponse.json({ error: "이메일 또는 비밀번호가 올바르지 않습니다." }, { status: 401 });
+    return NextResponse.json({ error: "아이디 또는 비밀번호가 올바르지 않습니다." }, { status: 401 });
   }
 
   const isValid = await bcrypt.compare(password, user.password_hash);
   if (!isValid) {
-    return NextResponse.json({ error: "이메일 또는 비밀번호가 올바르지 않습니다." }, { status: 401 });
+    return NextResponse.json({ error: "아이디 또는 비밀번호가 올바르지 않습니다." }, { status: 401 });
   }
 
   if (user.account_status === "blocked") {

--- a/apps/api/src/app/api/auth/me/route.ts
+++ b/apps/api/src/app/api/auth/me/route.ts
@@ -10,7 +10,7 @@ export async function GET(req: NextRequest) {
 
   const user = await prisma.user.findUnique({
     where: { user_id: payload.user_id, is_deleted: false },
-    select: { user_id: true, name: true, email: true, current_role: true, account_status: true },
+    select: { user_id: true, name: true, login_id: true, email: true, current_role: true, account_status: true },
   });
 
   if (!user) {

--- a/apps/api/src/app/api/auth/signup/route.ts
+++ b/apps/api/src/app/api/auth/signup/route.ts
@@ -3,32 +3,43 @@ import bcrypt from "bcryptjs";
 import { prisma } from "@plawcess/database";
 import { signToken, makeAuthCookie } from "@/lib/auth";
 
+const LOGIN_ID_REGEX = /^[a-zA-Z0-9_]{4,30}$/;
+
 export async function POST(req: NextRequest) {
-  let body: { name?: string; email?: string; password?: string };
+  let body: { name?: string; loginId?: string; email?: string; password?: string };
   try {
     body = await req.json();
   } catch {
     return NextResponse.json({ error: "요청 형식이 올바르지 않습니다." }, { status: 400 });
   }
 
-  const { name, email, password } = body;
-  if (!name || !email || !password) {
-    return NextResponse.json({ error: "이름, 이메일, 비밀번호는 필수입니다." }, { status: 400 });
+  const { name, loginId, email, password } = body;
+  if (!name || !loginId || !email || !password) {
+    return NextResponse.json({ error: "이름, 아이디, 이메일, 비밀번호는 필수입니다." }, { status: 400 });
+  }
+  if (!LOGIN_ID_REGEX.test(loginId)) {
+    return NextResponse.json({ error: "아이디는 영문/숫자/언더스코어 4~30자여야 합니다." }, { status: 400 });
   }
   if (password.length < 8) {
     return NextResponse.json({ error: "비밀번호는 8자 이상이어야 합니다." }, { status: 400 });
   }
 
-  const existing = await prisma.user.findUnique({ where: { email } });
-  if (existing) {
+  const [emailDup, loginIdDup] = await Promise.all([
+    prisma.user.findUnique({ where: { email } }),
+    prisma.user.findUnique({ where: { login_id: loginId } }),
+  ]);
+  if (emailDup) {
     return NextResponse.json({ error: "이미 사용 중인 이메일입니다." }, { status: 409 });
+  }
+  if (loginIdDup) {
+    return NextResponse.json({ error: "이미 사용 중인 아이디입니다." }, { status: 409 });
   }
 
   const password_hash = await bcrypt.hash(password, 12);
 
   const user = await prisma.user.create({
-    data: { name, email, password_hash, current_role: "mentee" },
-    select: { user_id: true, name: true, email: true, current_role: true },
+    data: { name, login_id: loginId, email, password_hash, current_role: "mentee" },
+    select: { user_id: true, name: true, login_id: true, email: true, current_role: true },
   });
 
   const token = signToken({ user_id: user.user_id, current_role: user.current_role });

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -28,13 +28,11 @@ export default function LoginPage() {
 
     let res: Response;
     try {
-      // Option A: BE가 아직 email 기반 로그인이라 사용자가 아이디 자리에 email을 입력해야 함.
-      //           #120 머지 후 페이로드 키를 loginId로 전환 예정.
       res = await fetch(`${API_BASE}/api/auth/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ email: loginId, password }),
+        body: JSON.stringify({ loginId, password }),
       });
     } catch {
       setError('서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.');

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -85,13 +85,18 @@ export default function SignupPage() {
 
     setLoading(true);
 
-    // Option A: 추가 필드(loginId, birthDate, gender, phone, studentId, enrollmentFile, role)는
-    //           BE 미지원이므로 일단 무시. #120/#83/#84에서 BE 확장 후 페이로드에 포함 예정.
+    // #120: loginId까지 BE 지원. birthDate/gender/phone/studentId/enrollmentFile/role은
+    //       추후 BE 확장 시 추가 (#83 이메일 인증, 학번/재학증명서 처리 등 별도 이슈)
     const res = await fetch(`${API_BASE}/api/auth/signup`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({ name: form.name, email: form.email, password: form.password }),
+      body: JSON.stringify({
+        name: form.name,
+        loginId: form.loginId,
+        email: form.email,
+        password: form.password,
+      }),
     });
 
     const data = await res.json();

--- a/apps/web/src/components/layout/Navbar.tsx
+++ b/apps/web/src/components/layout/Navbar.tsx
@@ -33,6 +33,7 @@ export default function Navbar() {
       const userData: AuthUser = {
         user_id: data.user.user_id,
         name: data.user.name,
+        login_id: data.user.login_id ?? null,
         email: data.user.email,
         current_role: data.user.current_role,
       };

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -30,7 +30,7 @@ function headers() {
 const LS_PREFIX = "plawcess:";
 const USER_KEY = `${LS_PREFIX}user`;
 
-export type AuthUser = { user_id: string; name: string; email: string; current_role: string };
+export type AuthUser = { user_id: string; name: string; login_id: string | null; email: string; current_role: string };
 
 export function saveUser(user: AuthUser) {
   try { localStorage.setItem(USER_KEY, JSON.stringify(user)); } catch {}

--- a/packages/database/prisma/migrations/20260503010000_add_login_id/migration.sql
+++ b/packages/database/prisma/migrations/20260503010000_add_login_id/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable: users.login_id 추가 (#120)
+--   사용자가 로그인 폼에 직접 타이핑하는 ID. email과 별개.
+--   기존 dummy 유저는 NULL 허용 (필요 시 수동 정리). 신규 가입자는 BE에서 필수 검증.
+ALTER TABLE "users"
+  ADD COLUMN "login_id" VARCHAR(50);
+
+CREATE UNIQUE INDEX "users_login_id_key" ON "users"("login_id");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -94,6 +94,7 @@ enum MatchStatus {
 // ----------------------------------------------------------------
 model User {
   user_id         String          @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  login_id        String?         @unique @db.VarChar(50)  // 사용자가 직접 정하는 로그인 ID. 신규 가입자는 필수, 기존 dummy 유저는 NULL
   name            String          @db.VarChar(50)
   birth_year      Int?
   gender          Gender?


### PR DESCRIPTION
## Summary

이슈 #120: 기존에 email을 로그인 키로 쓰던 구조에서 사용자 직접 정하는 `login_id`를 분리.

> 💡 이 PR은 PR #121(회원가입 폼 개편) 위에 stacked. PR #121이 먼저 머지되면 이 PR diff에서 폼 개편 commit이 자동으로 빠집니다.

### DB
- `User.login_id String? @unique @db.VarChar(50)` 추가
- 마이그레이션 `20260503010000_add_login_id` (Supabase 적용·추적 완료)
- 기존 dummy 유저는 NULL 허용 (필요 시 수동 정리. unique 제약은 NULL 허용)

### BE
- **signup** — `loginId` 필수 페이로드. 4-30자 영문/숫자/언더스코어 정규식 검증. email + login_id 양쪽 unique 검사. select에 login_id 포함
- **login** — `loginId` 우선 조회, 없으면 `email` 폴백 (테스트 admin·기존 dummy 유저 호환 위한 과도기). select에 login_id 포함
- **me** — 응답 user 객체에 `login_id` 포함

### FE
- `AuthUser` 타입에 `login_id: string | null` 추가
- `Navbar.tsx`: `/me` 응답에서 `login_id` 매핑
- `signup/page.tsx`: 페이로드에 `loginId` 포함 (옵션 A 주석 제거)
- `login/page.tsx`: `email: loginId` 워크어라운드 → 정상 `loginId` 키로 전송

Closes #120

## Test plan
- [x] 로컬 `pnpm build:web`, `pnpm build:api` 통과
- [x] Supabase 마이그레이션 적용 + `migrate status` "up to date" 확인
- [ ] 새 회원가입 → 폼에 입력한 `loginId`로 로그인 가능
- [ ] 동일 `loginId` 또는 동일 email로 재가입 시 409 에러
- [ ] 4자 미만/30자 초과/특수문자 포함 `loginId`는 400 에러
- [ ] 기존 dummy 유저 (login_id=NULL)는 email 폴백으로 로그인 가능
- [ ] dev `[dev용] Admin으로 빠른 로그인` 그대로 동작

## 후속 이슈
- #83 이메일 인증 — `인증하기` 버튼 활성화 (회원가입 시 email 검증)
- #84 비밀번호 찾기 — `loginId` 입력 → email 발송
- #93 휴대폰 인증 — `SMS 인증` 버튼 활성화
- 학번/재학증명서 처리 — 별도 이슈 분리 필요