### PR TITLE
feat(#123): 아이디 중복 확인 BE+FE 구현

### DIFF
--- a/apps/api/src/app/api/auth/check-login-id/route.ts
+++ b/apps/api/src/app/api/auth/check-login-id/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@plawcess/database";
+
+const LOGIN_ID_REGEX = /^[a-zA-Z0-9_]{4,30}$/;
+
+export async function POST(req: NextRequest) {
+  let body: { loginId?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "요청 형식이 올바르지 않습니다." }, { status: 400 });
+  }
+
+  const { loginId } = body;
+  if (!loginId) {
+    return NextResponse.json({ error: "아이디는 필수입니다." }, { status: 400 });
+  }
+
+  if (!LOGIN_ID_REGEX.test(loginId)) {
+    return NextResponse.json(
+      { available: false, reason: "format" },
+      { status: 400 }
+    );
+  }
+
+  const existing = await prisma.user.findUnique({
+    where: { login_id: loginId },
+  });
+
+  if (existing) {
+    return NextResponse.json({ available: false, reason: "taken" }, { status: 200 });
+  }
+
+  return NextResponse.json({ available: true }, { status: 200 });
+}

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -24,6 +24,11 @@ type FormState = {
   enrollmentFile: File | null;
 };
 
+type CheckResult = {
+  ok: boolean;
+  message: string;
+};
+
 const EMPTY_FORM: FormState = {
   role: 'mentee',
   name: '',
@@ -51,10 +56,65 @@ export default function SignupPage() {
   const [form, setForm] = useState<FormState>({ ...EMPTY_FORM, birthDate: todayDots() });
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [checkResult, setCheckResult] = useState<CheckResult | null>(null);
+  const [checkLoading, setCheckLoading] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   function update<K extends keyof FormState>(key: K, value: FormState[K]) {
     setForm((prev) => ({ ...prev, [key]: value }));
+    // loginId 변경 시 체크 결과 초기화
+    if (key === 'loginId') {
+      setCheckResult(null);
+    }
+  }
+
+  async function handleCheckLoginId() {
+    const { loginId } = form;
+    if (!loginId) {
+      setError('아이디를 입력해주세요.');
+      return;
+    }
+
+    setCheckLoading(true);
+    setError('');
+
+    try {
+      const res = await fetch(`${API_BASE}/api/auth/check-login-id`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ loginId }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setCheckResult({
+          ok: false,
+          message: '아이디 형식이 올바르지 않습니다. (영문/숫자/언더스코어 4~30자)',
+        });
+        return;
+      }
+
+      if (data.available) {
+        setCheckResult({
+          ok: true,
+          message: '사용 가능한 아이디입니다.',
+        });
+      } else {
+        setCheckResult({
+          ok: false,
+          message: '이미 사용 중인 아이디입니다.',
+        });
+      }
+    } catch (err) {
+      setCheckResult({
+        ok: false,
+        message: '중복 확인에 실패했습니다. 다시 시도해주세요.',
+      });
+    } finally {
+      setCheckLoading(false);
+    }
   }
 
   function handleFile(file: File | null) {
@@ -69,6 +129,11 @@ export default function SignupPage() {
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError('');
+
+    if (!checkResult?.ok) {
+      setError('아이디 중복확인을 해주세요.');
+      return;
+    }
 
     if (form.password !== form.passwordConfirm) {
       setError('비밀번호가 일치하지 않습니다.');
@@ -159,15 +224,30 @@ export default function SignupPage() {
 
               {/* 아이디 */}
               <Field label="아이디" htmlFor="loginId">
-                <input
-                  id="loginId"
-                  type="text"
-                  value={form.loginId}
-                  onChange={(e) => update('loginId', e.target.value)}
-                  placeholder="영문, 숫자 조합"
-                  required
-                  className={inputClass}
-                />
+                <div className="flex gap-2">
+                  <input
+                    id="loginId"
+                    type="text"
+                    value={form.loginId}
+                    onChange={(e) => update('loginId', e.target.value)}
+                    placeholder="영문, 숫자 조합"
+                    required
+                    className={`${inputClass} flex-1`}
+                  />
+                  <button
+                    type="button"
+                    onClick={handleCheckLoginId}
+                    disabled={!form.loginId || checkLoading}
+                    className="px-4 py-2.5 text-sm font-medium text-white bg-brand rounded-md hover:bg-brand-dark transition-colors whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {checkLoading ? '확인 중...' : '중복확인'}
+                  </button>
+                </div>
+                {checkResult && (
+                  <p className={`text-xs ${checkResult.ok ? 'text-green-600' : 'text-red-500'}`}>
+                    {checkResult.message}
+                  </p>
+                )}
               </Field>
 
               {/* 이메일 + 인증하기 */}


### PR DESCRIPTION
BE: POST /api/auth/check-login-id 라우트 추가
- 아이디 형식 정규식 검증 (영문/숫자/언더스코어 4~30자)
- 중복 여부 확인 및 응답 (available/taken)

FE: 회원가입 페이지 아이디 필드 개편
- 아이디 input + 중복확인 버튼 추가
- 확인 결과 상태 관리 및 UI 반영
- 폼 제출 시 중복확인 완료 여부 검증