### PR TITLE
feat(#124): 회원탈퇴 기능 구현

### DIFF
--- a/apps/api/src/app/api/auth/delete-account/route.ts
+++ b/apps/api/src/app/api/auth/delete-account/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import bcrypt from "bcryptjs";
+import { prisma } from "@plawcess/database";
+import { getTokenFromCookie, makeClearCookie } from "@/lib/auth";
+
+export async function DELETE(req: NextRequest) {
+  // 1. 인증: 토큰에서 user_id 추출
+  const tokenPayload = getTokenFromCookie(req);
+  if (!tokenPayload) {
+    return NextResponse.json({ error: "인증이 필요합니다." }, { status: 401 });
+  }
+
+  const userId = tokenPayload.user_id;
+
+  // 2. 요청 본체에서 password 추출
+  let body: { password?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "요청 형식이 올바르지 않습니다." }, { status: 400 });
+  }
+
+  const { password } = body;
+  if (!password) {
+    return NextResponse.json({ error: "비밀번호를 입력해주세요." }, { status: 400 });
+  }
+
+  // 3. 사용자 조회
+  const user = await prisma.user.findUnique({
+    where: { user_id: userId },
+    select: { user_id: true, password_hash: true, is_deleted: true },
+  });
+
+  if (!user) {
+    return NextResponse.json({ error: "사용자를 찾을 수 없습니다." }, { status: 404 });
+  }
+
+  // 4. 이미 탈퇴한 계정 확인
+  if (user.is_deleted) {
+    return NextResponse.json({ error: "이미 탈퇴한 계정입니다." }, { status: 400 });
+  }
+
+  // 5. 비밀번호 검증
+  if (!user.password_hash) {
+    return NextResponse.json({ error: "비밀번호가 설정되지 않은 계정입니다." }, { status: 400 });
+  }
+
+  const isValid = await bcrypt.compare(password, user.password_hash);
+  if (!isValid) {
+    return NextResponse.json({ error: "비밀번호가 올바르지 않습니다." }, { status: 401 });
+  }
+
+  // 6. 탈퇴 처리 (soft delete + anonymize)
+  await prisma.user.update({
+    where: { user_id: userId },
+    data: {
+      is_deleted: true,
+      deleted_at: new Date(),
+      name: "탈퇴한 사용자",
+      phone: null,
+      student_id: null,
+      email: `deleted_${userId}@removed.com`,
+      account_status: "inactive",
+    },
+  });
+
+  // 7. 인증 쿠키 만료 및 응답
+  return NextResponse.json(
+    { success: true },
+    { headers: { "Set-Cookie": makeClearCookie() } }
+  );
+}

--- a/apps/web/src/app/mentee/settings/DeleteAccountModal.tsx
+++ b/apps/web/src/app/mentee/settings/DeleteAccountModal.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useState } from 'react';
+
+interface Props {
+  open: boolean;
+  isLoading: boolean;
+  onClose: () => void;
+  onConfirm: (password: string) => Promise<void>;
+}
+
+export default function DeleteAccountModal({ open, isLoading, onClose, onConfirm }: Props) {
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  if (!open) return null;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    setIsSubmitting(true);
+
+    try {
+      await onConfirm(password);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '오류가 발생했습니다.');
+      setIsSubmitting(false);
+    }
+  }
+
+  function handleClose() {
+    if (!isSubmitting && !isLoading) {
+      setPassword('');
+      setError('');
+      onClose();
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
+      <div className="absolute inset-0 bg-black/40" onClick={handleClose} />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="회원 탈퇴"
+        className="relative bg-white rounded-2xl shadow-xl w-full max-w-md p-6"
+      >
+        {/* 헤더 */}
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-text-primary">회원 탈퇴</h2>
+          <button
+            type="button"
+            onClick={handleClose}
+            disabled={isSubmitting || isLoading}
+            aria-label="닫기"
+            className="text-text-placeholder hover:text-text-primary disabled:opacity-50"
+          >
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        {/* 본문 */}
+        <div className="mb-6">
+          <p className="text-sm text-text-secondary mb-3">
+            계정을 탈퇴하려면 비밀번호를 입력해주세요.
+          </p>
+          <p className="text-xs text-text-placeholder">
+            탈퇴 후에는 모든 개인정보가 익명화되며 복구할 수 없습니다.
+          </p>
+        </div>
+
+        {/* 폼 */}
+        <form onSubmit={handleSubmit} className="space-y-4 mb-6">
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-text-primary mb-2">
+              비밀번호
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="비밀번호 입력"
+              disabled={isSubmitting || isLoading}
+              className="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:border-brand disabled:bg-page-bg disabled:text-text-placeholder"
+            />
+          </div>
+
+          {error && (
+            <div className="px-3 py-2 bg-red-50 border border-red-200 rounded text-sm text-red-700">
+              {error}
+            </div>
+          )}
+        </form>
+
+        {/* 버튼 */}
+        <div className="flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={handleClose}
+            disabled={isSubmitting || isLoading}
+            className="px-4 py-2 text-sm text-text-secondary hover:text-text-primary disabled:opacity-50"
+          >
+            취소
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!password || isSubmitting || isLoading}
+            className="px-4 py-2 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {isSubmitting || isLoading ? '처리 중...' : '탈퇴'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/mentee/settings/page.tsx
+++ b/apps/web/src/app/mentee/settings/page.tsx
@@ -1,3 +1,67 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { clearAllCache } from '@/lib/api';
+import DeleteAccountModal from './DeleteAccountModal';
+
 export default function MenteeSettingsPage() {
-  return <h1>멘티 설정</h1>;
+  const router = useRouter();
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  async function handleDeleteAccount(password: string) {
+    setIsLoading(true);
+    try {
+      const res = await fetch('/api/auth/delete-account', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ password }),
+      });
+
+      if (!res.ok) {
+        const error = await res.json();
+        throw new Error(error.error || '회원탈퇴 중 오류가 발생했습니다.');
+      }
+
+      // 캐시 정리 및 로그인 페이지로 이동
+      clearAllCache();
+      router.push('/login');
+    } catch (error) {
+      throw error;
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto py-8 px-4">
+      <h1 className="text-2xl font-bold mb-8">설정</h1>
+
+      {/* 회원 탈퇴 섹션 */}
+      <div className="border border-red-200 bg-red-50 rounded-lg p-6 mt-12">
+        <div className="mb-4">
+          <h2 className="text-lg font-semibold text-red-900 mb-2">회원 탈퇴</h2>
+          <p className="text-sm text-red-700">
+            계정을 탈퇴하면 모든 데이터가 삭제되며 복구할 수 없습니다. 신중하게 결정해주세요.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowDeleteModal(true)}
+          className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors text-sm font-medium"
+        >
+          회원 탈퇴
+        </button>
+      </div>
+
+      <DeleteAccountModal
+        open={showDeleteModal}
+        isLoading={isLoading}
+        onClose={() => setShowDeleteModal(false)}
+        onConfirm={handleDeleteAccount}
+      />
+    </div>
+  );
 }


### PR DESCRIPTION
- BE: DELETE /api/auth/delete-account 라우트 추가 (비밀번호 검증 후 soft delete + anonymize)
- FE: 멘티 설정 페이지에 회원탈퇴 섹션 및 모달 추가
- 탈퇴 시 name='탈퇴한 사용자', email=deleted_{user_id}@removed.com, phone/student_id=null로 익명화

solves #124 