### PR TITLE
118 refactorbedb user에 사람 속성 통합 record는 사이클별 데이터로 정리 옵션 3

### DIFF
--- a/apps/api/src/app/api/auth/me/route.ts
+++ b/apps/api/src/app/api/auth/me/route.ts
@@ -10,7 +10,26 @@ export async function GET(req: NextRequest) {
 
   const user = await prisma.user.findUnique({
     where: { user_id: payload.user_id, is_deleted: false },
-    select: { user_id: true, name: true, login_id: true, email: true, current_role: true, account_status: true },
+    select: {
+      user_id: true,
+      login_id: true,
+      name: true,
+      email: true,
+      current_role: true,
+      account_status: true,
+      // 신상 — FE가 헤더/프로필에서 사용
+      birth_date: true,
+      gender: true,
+      military_status: true,
+      undergrad_school_name: true,
+      undergrad_first_major: true,
+      undergrad_second_major: true,
+      undergrad_entry_year: true,
+      undergrad_graduation_year: true,
+      current_lawschool: true,
+      graduated_lawschool: true,
+      lawschool_grade: true,
+    },
   });
 
   if (!user) {

--- a/apps/api/src/app/api/mentee/basic-info/route.ts
+++ b/apps/api/src/app/api/mentee/basic-info/route.ts
@@ -1,14 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@plawcess/database";
+import { prisma, Prisma } from "@plawcess/database";
 import { getTokenFromCookie } from "@/lib/auth";
 import {
-  genderToLabel, labelToGender,
-  statusToLabel, labelToStatus,
-  militaryToLabel, labelToMilitary,
-  dateToLabel, labelToDate,
+  genderToLabel,
+  statusToLabel,
+  militaryToLabel,
+  dateToLabel,
   yearToLabel,
 } from "@/lib/labels";
-import { splitPayload, MENTEE_RECORD_FIELDS } from "@/lib/payload-split";
+import { splitPayload, MENTEE_RECORD_FIELDS, flattenPersonal, PersonalPatchInput } from "@/lib/payload-split";
 
 function getUserId(req: NextRequest): string | null {
   return getTokenFromCookie(req)?.user_id ?? null;
@@ -98,16 +98,7 @@ export async function PATCH(req: NextRequest) {
   const processYear = getProcessYear(req);
 
   let body: {
-    personal?: {
-      birthDate?: string;
-      gender?: string;
-      militaryStatus?: string;
-      major1?: string;
-      major2?: string;
-      admissionYear?: string;
-      academicStatus?: string;
-      graduationYear?: string;
-    };
+    personal?: PersonalPatchInput;
     admission?: {
       가?: { first?: string };
       나?: { first?: string };
@@ -121,24 +112,7 @@ export async function PATCH(req: NextRequest) {
   }
 
   // 1) 중첩 본문 → 평탄화 + DB 컬럼명 + 라벨 변환
-  const flat: Record<string, unknown> = {};
-  if (body.personal) {
-    const p = body.personal;
-    if (p.birthDate !== undefined) flat.birth_date = labelToDate(p.birthDate);
-    if (p.gender !== undefined) flat.gender = labelToGender(p.gender);
-    if (p.militaryStatus !== undefined) flat.military_status = labelToMilitary(p.militaryStatus);
-    if (p.major1 !== undefined) flat.undergrad_first_major = p.major1;
-    if (p.major2 !== undefined) flat.undergrad_second_major = p.major2;
-    if (p.admissionYear !== undefined) {
-      const n = parseInt(p.admissionYear, 10);
-      flat.undergrad_entry_year = isNaN(n) ? null : n;
-    }
-    if (p.graduationYear !== undefined) {
-      const n = parseInt(p.graduationYear, 10);
-      flat.undergrad_graduation_year = isNaN(n) ? null : n;
-    }
-    if (p.academicStatus !== undefined) flat.academic_status = labelToStatus(p.academicStatus);
-  }
+  const flat: Record<string, unknown> = body.personal ? flattenPersonal(body.personal) : {};
   if (body.admission) {
     const { 가: ga, 나: na, isSpecialAdmission } = body.admission;
     if (ga?.first !== undefined) flat.target_school_ga = ga.first || null;
@@ -156,7 +130,7 @@ export async function PATCH(req: NextRequest) {
   }
 
   // 4) 트랜잭션으로 두 테이블 동시 반영
-  const ops = [];
+  const ops: Prisma.PrismaPromise<unknown>[] = [];
   if (Object.keys(userData).length > 0) {
     ops.push(prisma.user.update({ where: { user_id: userId }, data: userData }));
   }

--- a/apps/api/src/app/api/mentee/basic-info/route.ts
+++ b/apps/api/src/app/api/mentee/basic-info/route.ts
@@ -1,6 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@plawcess/database";
 import { getTokenFromCookie } from "@/lib/auth";
+import {
+  genderToLabel, labelToGender,
+  statusToLabel, labelToStatus,
+  militaryToLabel, labelToMilitary,
+  dateToLabel, labelToDate,
+  yearToLabel,
+} from "@/lib/labels";
+import { splitPayload, MENTEE_RECORD_FIELDS } from "@/lib/payload-split";
 
 function getUserId(req: NextRequest): string | null {
   return getTokenFromCookie(req)?.user_id ?? null;
@@ -13,44 +21,9 @@ function getProcessYear(req: NextRequest): number {
   return match ? parseInt(match[0]) : new Date().getFullYear();
 }
 
-// DB enum ↔ 한국어 레이블 변환
-function genderToLabel(g: string | null): string {
-  if (g === "male") return "남성";
-  if (g === "female") return "여성";
-  return "";
-}
-
-function labelToGender(label: string): string | null {
-  if (label === "남성") return "male";
-  if (label === "여성") return "female";
-  return null;
-}
-
-const ACADEMIC_STATUS_MAP: Record<string, string> = {
-  enrolled: "재학",
-  on_leave: "휴학",
-  completed: "수료",
-  graduated: "졸업",
-  expelled: "제적",
-};
-const LABEL_TO_STATUS: Record<string, string> = {
-  재학: "enrolled",
-  휴학: "on_leave",
-  수료: "completed",
-  "졸업 유예": "on_leave",
-  졸업: "graduated",
-};
-
-function statusToLabel(s: string | null): string {
-  return s ? (ACADEMIC_STATUS_MAP[s] ?? "") : "";
-}
-
-function labelToStatus(label: string): string | null {
-  return LABEL_TO_STATUS[label] ?? null;
-}
-
 // ----------------------------------------------------------------
 // GET /api/mentee/basic-info?year=2026학년도
+// 응답: User(신상) + MenteeRecord(사이클 학적·희망학교) 합성
 // ----------------------------------------------------------------
 export async function GET(req: NextRequest) {
   const userId = getUserId(req);
@@ -65,19 +38,20 @@ export async function GET(req: NextRequest) {
       where: { user_id: userId },
       select: {
         name: true,
-        school_name: true,
+        birth_date: true,
         gender: true,
-        first_major: true,
-        second_major: true,
-        academic_status: true,
+        military_status: true,
+        undergrad_school_name: true,
+        undergrad_first_major: true,
+        undergrad_second_major: true,
+        undergrad_entry_year: true,
+        undergrad_graduation_year: true,
       },
     }),
     prisma.menteeRecord.findUnique({
       where: { user_id_process_year: { user_id: userId, process_year: processYear } },
       select: {
-        birth_date: true,
-        university_entry_year: true,
-        graduation_year: true,
+        academic_status: true,
         target_school_ga: true,
         target_school_na: true,
         is_special_admission: true,
@@ -89,25 +63,20 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "사용자를 찾을 수 없습니다." }, { status: 404 });
   }
 
-  // birth_date → "YYYY.MM.DD." 형식
-  const birthDate = record?.birth_date
-    ? record.birth_date.toISOString().slice(0, 10).replace(/-/g, ".") + "."
-    : "";
-
   return NextResponse.json({
     personal: {
       name: user.name,
-      affiliation: user.school_name ?? "",
-      birthDate,
+      affiliation: user.undergrad_school_name ?? "",
+      birthDate: dateToLabel(user.birth_date),
       gender: genderToLabel(user.gender),
-      major1: user.first_major ?? "",
-      major2: user.second_major ?? "",
-      admissionYear: record?.university_entry_year?.toString() ?? "",
-      academicStatus: statusToLabel(user.academic_status),
-      graduationYear: record?.graduation_year?.toString() ?? "",
+      militaryStatus: militaryToLabel(user.military_status),
+      major1: user.undergrad_first_major ?? "",
+      major2: user.undergrad_second_major ?? "",
+      admissionYear: yearToLabel(user.undergrad_entry_year),
+      graduationYear: yearToLabel(user.undergrad_graduation_year),
+      academicStatus: statusToLabel(record?.academic_status),
     },
     admission: {
-      // DB에는 가/나군 제1지망 학교만 저장됨. 제2지망·전형 타입은 DB 미지원.
       가: { first: record?.target_school_ga ?? "" },
       나: { first: record?.target_school_na ?? "" },
       isSpecialAdmission: record?.is_special_admission ?? false,
@@ -117,7 +86,8 @@ export async function GET(req: NextRequest) {
 
 // ----------------------------------------------------------------
 // PATCH /api/mentee/basic-info?year=2026학년도
-// Body: { personal?, admission? }
+// Body: { personal?: {...}, admission?: {...} }   ← FE 호환성 유지
+// 내부: 평탄화 → splitPayload → User.update + MenteeRecord.upsert (트랜잭션)
 // ----------------------------------------------------------------
 export async function PATCH(req: NextRequest) {
   const userId = getUserId(req);
@@ -131,6 +101,7 @@ export async function PATCH(req: NextRequest) {
     personal?: {
       birthDate?: string;
       gender?: string;
+      militaryStatus?: string;
       major1?: string;
       major2?: string;
       admissionYear?: string;
@@ -143,63 +114,63 @@ export async function PATCH(req: NextRequest) {
       isSpecialAdmission?: boolean;
     };
   };
-
   try {
     body = await req.json();
   } catch {
     return NextResponse.json({ error: "요청 본문이 올바르지 않습니다." }, { status: 400 });
   }
 
-  const user = await prisma.user.findUnique({ where: { user_id: userId } });
-  if (!user) {
-    return NextResponse.json({ error: "사용자를 찾을 수 없습니다." }, { status: 404 });
-  }
-
-  // User 테이블 업데이트 (gender, major, academic_status)
-  const userUpdate: Record<string, unknown> = {};
+  // 1) 중첩 본문 → 평탄화 + DB 컬럼명 + 라벨 변환
+  const flat: Record<string, unknown> = {};
   if (body.personal) {
-    const { gender, major1, major2, academicStatus } = body.personal;
-    if (gender !== undefined) userUpdate.gender = labelToGender(gender);
-    if (major1 !== undefined) userUpdate.first_major = major1;
-    if (major2 !== undefined) userUpdate.second_major = major2;
-    if (academicStatus !== undefined) userUpdate.academic_status = labelToStatus(academicStatus);
-  }
-  if (Object.keys(userUpdate).length > 0) {
-    await prisma.user.update({ where: { user_id: userId }, data: userUpdate });
-  }
-
-  // MenteeRecord 업데이트 (birth_date, university_entry_year, graduation_year, target_school)
-  const recordUpdate: Record<string, unknown> = {};
-  if (body.personal) {
-    const { birthDate, admissionYear, graduationYear } = body.personal;
-    if (birthDate !== undefined) {
-      // "YYYY.MM.DD." → Date (비어있으면 null)
-      const cleaned = birthDate.replace(/\.$/, "").replace(/\./g, "-");
-      const parsed = new Date(cleaned);
-      recordUpdate.birth_date = !isNaN(parsed.getTime()) ? parsed : null;
+    const p = body.personal;
+    if (p.birthDate !== undefined) flat.birth_date = labelToDate(p.birthDate);
+    if (p.gender !== undefined) flat.gender = labelToGender(p.gender);
+    if (p.militaryStatus !== undefined) flat.military_status = labelToMilitary(p.militaryStatus);
+    if (p.major1 !== undefined) flat.undergrad_first_major = p.major1;
+    if (p.major2 !== undefined) flat.undergrad_second_major = p.major2;
+    if (p.admissionYear !== undefined) {
+      const n = parseInt(p.admissionYear, 10);
+      flat.undergrad_entry_year = isNaN(n) ? null : n;
     }
-    if (admissionYear !== undefined) {
-      const year = parseInt(admissionYear);
-      recordUpdate.university_entry_year = isNaN(year) ? null : year;
+    if (p.graduationYear !== undefined) {
+      const n = parseInt(p.graduationYear, 10);
+      flat.undergrad_graduation_year = isNaN(n) ? null : n;
     }
-    if (graduationYear !== undefined) {
-      const year = parseInt(graduationYear);
-      recordUpdate.graduation_year = isNaN(year) ? null : year;
-    }
+    if (p.academicStatus !== undefined) flat.academic_status = labelToStatus(p.academicStatus);
   }
   if (body.admission) {
     const { 가: ga, 나: na, isSpecialAdmission } = body.admission;
-    if (ga?.first !== undefined) recordUpdate.target_school_ga = ga.first || null;
-    if (na?.first !== undefined) recordUpdate.target_school_na = na.first || null;
-    if (isSpecialAdmission !== undefined) recordUpdate.is_special_admission = isSpecialAdmission;
+    if (ga?.first !== undefined) flat.target_school_ga = ga.first || null;
+    if (na?.first !== undefined) flat.target_school_na = na.first || null;
+    if (isSpecialAdmission !== undefined) flat.is_special_admission = isSpecialAdmission;
   }
 
-  if (Object.keys(recordUpdate).length > 0) {
-    await prisma.menteeRecord.upsert({
-      where: { user_id_process_year: { user_id: userId, process_year: processYear } },
-      create: { user_id: userId, process_year: processYear, ...recordUpdate },
-      update: recordUpdate,
-    });
+  // 2) User / MenteeRecord 분기
+  const { userData, recordData } = splitPayload(flat, MENTEE_RECORD_FIELDS);
+
+  // 3) 사용자 존재 확인
+  const exists = await prisma.user.findUnique({ where: { user_id: userId }, select: { user_id: true } });
+  if (!exists) {
+    return NextResponse.json({ error: "사용자를 찾을 수 없습니다." }, { status: 404 });
+  }
+
+  // 4) 트랜잭션으로 두 테이블 동시 반영
+  const ops = [];
+  if (Object.keys(userData).length > 0) {
+    ops.push(prisma.user.update({ where: { user_id: userId }, data: userData }));
+  }
+  if (Object.keys(recordData).length > 0) {
+    ops.push(
+      prisma.menteeRecord.upsert({
+        where: { user_id_process_year: { user_id: userId, process_year: processYear } },
+        create: { user_id: userId, process_year: processYear, ...recordData },
+        update: recordData,
+      }),
+    );
+  }
+  if (ops.length > 0) {
+    await prisma.$transaction(ops);
   }
 
   return NextResponse.json({ success: true });

--- a/apps/api/src/app/api/mentor/basic-info/route.ts
+++ b/apps/api/src/app/api/mentor/basic-info/route.ts
@@ -1,15 +1,15 @@
 // apps/api/src/app/api/mentor/basic-info/route.ts
 import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@plawcess/database";
+import { prisma, Prisma } from "@plawcess/database";
 import { getTokenFromCookie } from "@/lib/auth";
 import {
-  genderToLabel, labelToGender,
-  statusToLabel, labelToStatus,
-  militaryToLabel, labelToMilitary,
-  dateToLabel, labelToDate,
+  genderToLabel,
+  statusToLabel,
+  militaryToLabel,
+  dateToLabel,
   yearToLabel,
 } from "@/lib/labels";
-import { splitPayload, MENTOR_RECORD_FIELDS } from "@/lib/payload-split";
+import { splitPayload, MENTOR_RECORD_FIELDS, flattenPersonal, PersonalPatchInput } from "@/lib/payload-split";
 
 function getUserId(req: NextRequest): string | null {
   return getTokenFromCookie(req)?.user_id ?? null;
@@ -95,15 +95,7 @@ export async function PATCH(req: NextRequest) {
   const processYear = getProcessYear(req);
 
   let body: {
-    personal?: {
-      birthDate?: string;
-      gender?: string;
-      militaryStatus?: string;
-      major1?: string;
-      major2?: string;
-      admissionYear?: string;
-      academicStatus?: string;
-      graduationYear?: string;
+    personal?: PersonalPatchInput & {
       currentLawschool?: string;
       graduatedLawschool?: string;
       lawschoolGrade?: number | null;
@@ -115,23 +107,9 @@ export async function PATCH(req: NextRequest) {
     return NextResponse.json({ error: "요청 본문이 올바르지 않습니다." }, { status: 400 });
   }
 
-  const flat: Record<string, unknown> = {};
+  const flat: Record<string, unknown> = body.personal ? flattenPersonal(body.personal) : {};
   if (body.personal) {
     const p = body.personal;
-    if (p.birthDate !== undefined) flat.birth_date = labelToDate(p.birthDate);
-    if (p.gender !== undefined) flat.gender = labelToGender(p.gender);
-    if (p.militaryStatus !== undefined) flat.military_status = labelToMilitary(p.militaryStatus);
-    if (p.major1 !== undefined) flat.undergrad_first_major = p.major1;
-    if (p.major2 !== undefined) flat.undergrad_second_major = p.major2;
-    if (p.admissionYear !== undefined) {
-      const n = parseInt(p.admissionYear, 10);
-      flat.undergrad_entry_year = isNaN(n) ? null : n;
-    }
-    if (p.graduationYear !== undefined) {
-      const n = parseInt(p.graduationYear, 10);
-      flat.undergrad_graduation_year = isNaN(n) ? null : n;
-    }
-    if (p.academicStatus !== undefined) flat.academic_status = labelToStatus(p.academicStatus);
     if (p.currentLawschool !== undefined) flat.current_lawschool = p.currentLawschool || null;
     if (p.graduatedLawschool !== undefined) flat.graduated_lawschool = p.graduatedLawschool || null;
     if (p.lawschoolGrade !== undefined) flat.lawschool_grade = p.lawschoolGrade;
@@ -144,7 +122,7 @@ export async function PATCH(req: NextRequest) {
     return NextResponse.json({ error: "사용자를 찾을 수 없습니다." }, { status: 404 });
   }
 
-  const ops = [];
+  const ops: Prisma.PrismaPromise<unknown>[] = [];
   if (Object.keys(userData).length > 0) {
     ops.push(prisma.user.update({ where: { user_id: userId }, data: userData }));
   }

--- a/apps/api/src/app/api/mentor/basic-info/route.ts
+++ b/apps/api/src/app/api/mentor/basic-info/route.ts
@@ -1,0 +1,165 @@
+// apps/api/src/app/api/mentor/basic-info/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@plawcess/database";
+import { getTokenFromCookie } from "@/lib/auth";
+import {
+  genderToLabel, labelToGender,
+  statusToLabel, labelToStatus,
+  militaryToLabel, labelToMilitary,
+  dateToLabel, labelToDate,
+  yearToLabel,
+} from "@/lib/labels";
+import { splitPayload, MENTOR_RECORD_FIELDS } from "@/lib/payload-split";
+
+function getUserId(req: NextRequest): string | null {
+  return getTokenFromCookie(req)?.user_id ?? null;
+}
+
+function getProcessYear(req: NextRequest): number {
+  const raw = req.nextUrl.searchParams.get("year");
+  if (!raw) return new Date().getFullYear();
+  const match = raw.match(/\d{4}/);
+  return match ? parseInt(match[0]) : new Date().getFullYear();
+}
+
+// ----------------------------------------------------------------
+// GET /api/mentor/basic-info?year=2026
+// 응답: User(신상 + 로스쿨) + MentorRecord(학적 스냅샷) 합성
+// ----------------------------------------------------------------
+export async function GET(req: NextRequest) {
+  const userId = getUserId(req);
+  if (!userId) {
+    return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
+  }
+
+  const processYear = getProcessYear(req);
+
+  const [user, record] = await Promise.all([
+    prisma.user.findUnique({
+      where: { user_id: userId },
+      select: {
+        name: true,
+        birth_date: true,
+        gender: true,
+        military_status: true,
+        undergrad_school_name: true,
+        undergrad_first_major: true,
+        undergrad_second_major: true,
+        undergrad_entry_year: true,
+        undergrad_graduation_year: true,
+        current_lawschool: true,
+        graduated_lawschool: true,
+        lawschool_grade: true,
+      },
+    }),
+    prisma.mentorRecord.findUnique({
+      where: { user_id_process_year: { user_id: userId, process_year: processYear } },
+      select: { academic_status: true },
+    }),
+  ]);
+
+  if (!user) {
+    return NextResponse.json({ error: "사용자를 찾을 수 없습니다." }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    personal: {
+      name: user.name,
+      affiliation: user.undergrad_school_name ?? "",
+      birthDate: dateToLabel(user.birth_date),
+      gender: genderToLabel(user.gender),
+      militaryStatus: militaryToLabel(user.military_status),
+      major1: user.undergrad_first_major ?? "",
+      major2: user.undergrad_second_major ?? "",
+      admissionYear: yearToLabel(user.undergrad_entry_year),
+      graduationYear: yearToLabel(user.undergrad_graduation_year),
+      academicStatus: statusToLabel(record?.academic_status),
+      currentLawschool: user.current_lawschool ?? "",
+      graduatedLawschool: user.graduated_lawschool ?? "",
+      lawschoolGrade: user.lawschool_grade ?? null,
+    },
+  });
+}
+
+// ----------------------------------------------------------------
+// PATCH /api/mentor/basic-info?year=2026
+// Body: { personal?: {...} }   ← 멘토는 admission(가/나군) 대신 lawschool 필드를 갖는다.
+// 내부: 평탄화 → splitPayload → User.update + MentorRecord.upsert
+// ----------------------------------------------------------------
+export async function PATCH(req: NextRequest) {
+  const userId = getUserId(req);
+  if (!userId) {
+    return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
+  }
+
+  const processYear = getProcessYear(req);
+
+  let body: {
+    personal?: {
+      birthDate?: string;
+      gender?: string;
+      militaryStatus?: string;
+      major1?: string;
+      major2?: string;
+      admissionYear?: string;
+      academicStatus?: string;
+      graduationYear?: string;
+      currentLawschool?: string;
+      graduatedLawschool?: string;
+      lawschoolGrade?: number | null;
+    };
+  };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "요청 본문이 올바르지 않습니다." }, { status: 400 });
+  }
+
+  const flat: Record<string, unknown> = {};
+  if (body.personal) {
+    const p = body.personal;
+    if (p.birthDate !== undefined) flat.birth_date = labelToDate(p.birthDate);
+    if (p.gender !== undefined) flat.gender = labelToGender(p.gender);
+    if (p.militaryStatus !== undefined) flat.military_status = labelToMilitary(p.militaryStatus);
+    if (p.major1 !== undefined) flat.undergrad_first_major = p.major1;
+    if (p.major2 !== undefined) flat.undergrad_second_major = p.major2;
+    if (p.admissionYear !== undefined) {
+      const n = parseInt(p.admissionYear, 10);
+      flat.undergrad_entry_year = isNaN(n) ? null : n;
+    }
+    if (p.graduationYear !== undefined) {
+      const n = parseInt(p.graduationYear, 10);
+      flat.undergrad_graduation_year = isNaN(n) ? null : n;
+    }
+    if (p.academicStatus !== undefined) flat.academic_status = labelToStatus(p.academicStatus);
+    if (p.currentLawschool !== undefined) flat.current_lawschool = p.currentLawschool || null;
+    if (p.graduatedLawschool !== undefined) flat.graduated_lawschool = p.graduatedLawschool || null;
+    if (p.lawschoolGrade !== undefined) flat.lawschool_grade = p.lawschoolGrade;
+  }
+
+  const { userData, recordData } = splitPayload(flat, MENTOR_RECORD_FIELDS);
+
+  const exists = await prisma.user.findUnique({ where: { user_id: userId }, select: { user_id: true } });
+  if (!exists) {
+    return NextResponse.json({ error: "사용자를 찾을 수 없습니다." }, { status: 404 });
+  }
+
+  const ops = [];
+  if (Object.keys(userData).length > 0) {
+    ops.push(prisma.user.update({ where: { user_id: userId }, data: userData }));
+  }
+  if (Object.keys(recordData).length > 0) {
+    ops.push(
+      prisma.mentorRecord.upsert({
+        where: { user_id_process_year: { user_id: userId, process_year: processYear } },
+        create: { user_id: userId, process_year: processYear, ...recordData },
+        update: recordData,
+      }),
+    );
+  }
+  if (ops.length > 0) {
+    await prisma.$transaction(ops);
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/apps/api/src/lib/labels.ts
+++ b/apps/api/src/lib/labels.ts
@@ -1,0 +1,73 @@
+// apps/api/src/lib/labels.ts
+// DB enum ↔ FE 한국어 라벨 변환.
+// 기존 FE는 한국어 라벨로 통신해 왔으므로 변환은 BE에서 처리한다.
+
+// ---------- gender ----------
+export function genderToLabel(g: string | null | undefined): string {
+  if (g === "male") return "남성";
+  if (g === "female") return "여성";
+  return "";
+}
+export function labelToGender(label: string): string | null {
+  if (label === "남성") return "male";
+  if (label === "여성") return "female";
+  return null;
+}
+
+// ---------- academic_status ----------
+const ACADEMIC_STATUS_TO_LABEL: Record<string, string> = {
+  enrolled: "재학",
+  on_leave: "휴학",
+  completed: "수료",
+  graduated: "졸업",
+  expelled: "제적",
+};
+const LABEL_TO_ACADEMIC_STATUS: Record<string, string> = {
+  재학: "enrolled",
+  휴학: "on_leave",
+  수료: "completed",
+  "졸업 유예": "on_leave",
+  졸업: "graduated",
+};
+export function statusToLabel(s: string | null | undefined): string {
+  return s ? (ACADEMIC_STATUS_TO_LABEL[s] ?? "") : "";
+}
+export function labelToStatus(label: string): string | null {
+  return LABEL_TO_ACADEMIC_STATUS[label] ?? null;
+}
+
+// ---------- military_status ----------
+const MILITARY_TO_LABEL: Record<string, string> = {
+  completed: "군필",
+  not_completed: "미필",
+  not_applicable: "해당없음",
+};
+const LABEL_TO_MILITARY: Record<string, string> = {
+  군필: "completed",
+  미필: "not_completed",
+  해당없음: "not_applicable",
+};
+export function militaryToLabel(m: string | null | undefined): string {
+  return m ? (MILITARY_TO_LABEL[m] ?? "") : "";
+}
+export function labelToMilitary(label: string): string | null {
+  return LABEL_TO_MILITARY[label] ?? null;
+}
+
+// ---------- birth_date ↔ "YYYY.MM.DD." ----------
+// 기존 FE 컨벤션 유지: 화면 입력은 "YYYY.MM.DD." (마침표 포함, 끝에 . 한 번 더)
+export function dateToLabel(d: Date | null | undefined): string {
+  if (!d) return "";
+  return d.toISOString().slice(0, 10).replace(/-/g, ".") + ".";
+}
+export function labelToDate(label: string): Date | null {
+  if (!label) return null;
+  const cleaned = label.replace(/\.$/, "").replace(/\./g, "-");
+  const parsed = new Date(cleaned);
+  return isNaN(parsed.getTime()) ? null : parsed;
+}
+
+// ---------- year Int → 표시 문자열 (입력은 호출 측에서 parseInt) ----------
+export function yearToLabel(y: number | null | undefined): string {
+  return y == null ? "" : y.toString();
+}

--- a/apps/api/src/lib/payload-split.ts
+++ b/apps/api/src/lib/payload-split.ts
@@ -1,0 +1,55 @@
+// apps/api/src/lib/payload-split.ts
+// 하이브리드 PATCH: 단일 엔드포인트로 들어온 본문을 User 필드와 Record 필드로 분리한다.
+// FE는 평탄한 객체를 보내고, BE는 어느 테이블로 가는지를 캡슐화한다.
+
+export const USER_FIELDS = new Set<string>([
+  // 신상
+  "birth_date", "gender", "military_status", "phone",
+  // 학부
+  "undergrad_school_name",
+  "undergrad_first_major", "undergrad_second_major",
+  "undergrad_entry_year", "undergrad_graduation_year",
+  // 로스쿨
+  "current_lawschool", "graduated_lawschool", "lawschool_grade",
+]);
+
+export const MENTEE_RECORD_FIELDS = new Set<string>([
+  "academic_status",
+  "target_school_ga", "target_school_na", "is_special_admission",
+  "has_leet_experience", "leet_exam_years", "first_leet_year",
+  "has_law_class", "law_class_subjects",
+  "career_goal",
+  // 정성/AI/기타는 정성 라우트에서 처리
+]);
+
+export const MENTOR_RECORD_FIELDS = new Set<string>([
+  "academic_status",
+  "has_law_class", "law_class_subjects",
+  "is_special_admission",
+  "personal_statement_summary",
+  "strengths_weaknesses",
+  "career_goal",
+  "leet_exam_year",
+]);
+
+export type SplitResult = {
+  userData: Record<string, unknown>;
+  recordData: Record<string, unknown>;
+};
+
+/**
+ * 평탄화된 페이로드(`{ field_name: value, ... }`)를 USER_FIELDS / recordFieldSet에 따라 분기.
+ * 어느 집합에도 속하지 않는 키는 무시한다(스루풋 방어).
+ */
+export function splitPayload(
+  payload: Record<string, unknown>,
+  recordFieldSet: Set<string>,
+): SplitResult {
+  const userData: Record<string, unknown> = {};
+  const recordData: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(payload)) {
+    if (USER_FIELDS.has(key)) userData[key] = value;
+    else if (recordFieldSet.has(key)) recordData[key] = value;
+  }
+  return { userData, recordData };
+}

--- a/apps/api/src/lib/payload-split.ts
+++ b/apps/api/src/lib/payload-split.ts
@@ -2,6 +2,10 @@
 // 하이브리드 PATCH: 단일 엔드포인트로 들어온 본문을 User 필드와 Record 필드로 분리한다.
 // FE는 평탄한 객체를 보내고, BE는 어느 테이블로 가는지를 캡슐화한다.
 
+import {
+  labelToGender, labelToStatus, labelToMilitary, labelToDate,
+} from "./labels";
+
 export const USER_FIELDS = new Set<string>([
   // 신상
   "birth_date", "gender", "military_status", "phone",
@@ -52,4 +56,41 @@ export function splitPayload(
     else if (recordFieldSet.has(key)) recordData[key] = value;
   }
   return { userData, recordData };
+}
+
+// ----------------------------------------------------------------
+// 공용 personal-블록 평탄화
+// ----------------------------------------------------------------
+export type PersonalPatchInput = {
+  birthDate?: string;
+  gender?: string;
+  militaryStatus?: string;
+  major1?: string;
+  major2?: string;
+  admissionYear?: string;
+  graduationYear?: string;
+  academicStatus?: string;
+};
+
+/**
+ * 멘티/멘토 공통 personal 블록을 DB 컬럼명+enum 값으로 평탄화.
+ * 호출 측은 반환값에 role-specific 필드(admission / lawschool 등)를 spread해 추가한다.
+ */
+export function flattenPersonal(p: PersonalPatchInput): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (p.birthDate !== undefined) out.birth_date = labelToDate(p.birthDate);
+  if (p.gender !== undefined) out.gender = labelToGender(p.gender);
+  if (p.militaryStatus !== undefined) out.military_status = labelToMilitary(p.militaryStatus);
+  if (p.major1 !== undefined) out.undergrad_first_major = p.major1;
+  if (p.major2 !== undefined) out.undergrad_second_major = p.major2;
+  if (p.admissionYear !== undefined) {
+    const n = parseInt(p.admissionYear, 10);
+    out.undergrad_entry_year = isNaN(n) ? null : n;
+  }
+  if (p.graduationYear !== undefined) {
+    const n = parseInt(p.graduationYear, 10);
+    out.undergrad_graduation_year = isNaN(n) ? null : n;
+  }
+  if (p.academicStatus !== undefined) out.academic_status = labelToStatus(p.academicStatus);
+  return out;
 }

--- a/docs/api/api-spec.md
+++ b/docs/api/api-spec.md
@@ -1,1 +1,166 @@
-# pLAWcess
+# pLAWcess API 스펙
+
+> 본 문서는 BE/FE 공통 계약이다. BE 변경 시 동시 갱신 필수.
+
+## 인증
+
+모든 보호 엔드포인트는 `plawcess_token` HttpOnly 쿠키(JWT)로 인증한다.
+- `/api/auth/*`, `/api/health`: 공개
+- `/api/mentee/*`: `mentee` 또는 `admin`
+- `/api/mentor/*`: `mentor` 또는 `admin`
+- `/api/admin/*`: `admin`
+
+## 라벨 변환 컨벤션
+
+응답에서 enum 필드는 한국어 라벨로 변환되어 전달된다 (FE 표시용 직접 사용 가능).
+
+| 필드 | DB 값 | 라벨 |
+|---|---|---|
+| `gender` | `male` / `female` | "남성" / "여성" |
+| `academicStatus` | `enrolled` / `on_leave` / `graduated` / `completed` / `expelled` | "재학" / "휴학" / "졸업" / "수료" / "제적" |
+| `militaryStatus` | `completed` / `not_completed` / `not_applicable` | "군필" / "미필" / "해당없음" |
+
+> 예외: `/api/auth/me`는 raw enum 값을 그대로 노출한다 (FE가 다른 컨텍스트와 일관성 위해 직접 변환).
+
+날짜 필드(`birthDate`)는 `"YYYY.MM.DD."` 형식 문자열 (끝에 마침표 포함).
+연도 필드(`admissionYear`, `graduationYear`)는 4자리 숫자 문자열.
+
+---
+
+## `/api/auth/me` — GET
+
+현재 사용자의 신상 + 계정 정보 조회.
+
+**Response 200:**
+```json
+{
+  "user": {
+    "user_id": "uuid",
+    "login_id": "string",
+    "name": "string",
+    "email": "string",
+    "current_role": "none|mentee|mentor|admin",
+    "account_status": "active|inactive|blocked",
+    "birth_date": "2000-01-15",
+    "gender": "male|female|null",
+    "military_status": "completed|not_completed|not_applicable|null",
+    "undergrad_school_name": "string|null",
+    "undergrad_first_major": "string|null",
+    "undergrad_second_major": "string|null",
+    "undergrad_entry_year": 2019,
+    "undergrad_graduation_year": null,
+    "current_lawschool": "string|null",
+    "graduated_lawschool": "string|null",
+    "lawschool_grade": null
+  }
+}
+```
+
+---
+
+## `/api/mentee/basic-info` — GET / PATCH
+
+멘티 기본정보. `User`(신상) + `MenteeRecord`(사이클 학적·희망학교) 합성.
+
+**Query:** `?year=2026` (없으면 현재 연도)
+
+**GET Response 200:**
+```json
+{
+  "personal": {
+    "name": "string",
+    "affiliation": "string",
+    "birthDate": "2000.01.15.",
+    "gender": "남성",
+    "militaryStatus": "군필",
+    "major1": "string",
+    "major2": "string",
+    "admissionYear": "2019",
+    "graduationYear": "",
+    "academicStatus": "재학"
+  },
+  "admission": {
+    "가": { "first": "string" },
+    "나": { "first": "string" },
+    "isSpecialAdmission": false
+  }
+}
+```
+
+**PATCH Body** (모든 필드 선택적):
+```json
+{
+  "personal": {
+    "birthDate": "2000.01.15.",
+    "gender": "남성",
+    "militaryStatus": "군필",
+    "major1": "string",
+    "major2": "string",
+    "admissionYear": "2019",
+    "graduationYear": "2024",
+    "academicStatus": "재학"
+  },
+  "admission": {
+    "가": { "first": "string" },
+    "나": { "first": "string" },
+    "isSpecialAdmission": false
+  }
+}
+```
+
+**PATCH Response 200:** `{ "success": true }`
+
+내부 동작: BE는 본문을 평탄화 → `splitPayload`로 User/Record 필드 분기 → `prisma.$transaction`으로 atomic update + upsert. FE는 어느 필드가 어느 테이블에 가는지 알 필요 없음.
+
+---
+
+## `/api/mentor/basic-info` — GET / PATCH
+
+멘토 기본정보. `User`(신상 + 로스쿨) + `MentorRecord`(학적 스냅샷) 합성.
+
+**Query:** `?year=2026`
+
+**GET Response 200:**
+```json
+{
+  "personal": {
+    "name": "string",
+    "affiliation": "string",
+    "birthDate": "2000.01.15.",
+    "gender": "남성",
+    "militaryStatus": "군필",
+    "major1": "string",
+    "major2": "string",
+    "admissionYear": "2019",
+    "graduationYear": "2024",
+    "academicStatus": "재학",
+    "currentLawschool": "string",
+    "graduatedLawschool": "",
+    "lawschoolGrade": 17
+  }
+}
+```
+
+**PATCH Body** (모든 필드 선택적):
+```json
+{
+  "personal": {
+    "currentLawschool": "string",
+    "graduatedLawschool": "string",
+    "lawschoolGrade": 17,
+    "academicStatus": "재학"
+  }
+}
+```
+
+**PATCH Response 200:** `{ "success": true }`
+
+---
+
+## `/api/mentee/quantitative` — GET / PATCH
+
+(본 리팩토링 영향 없음 — 별도 문서화는 추후 작업)
+
+## `/api/mentee/grades` — POST
+
+(본 리팩토링 영향 없음 — KUPID 성적 크롤링)

--- a/docs/superpowers/handoff/2026-05-04-fe-user-record-split.md
+++ b/docs/superpowers/handoff/2026-05-04-fe-user-record-split.md
@@ -1,0 +1,90 @@
+# [FE] User/Record 스키마 분리에 따른 화면 적용
+
+**Title 후보:** `feat(FE): User/Record 분리 — 신상 필드 입력 UI 추가`
+**Labels:** `frontend`, `enhancement`
+**관련 BE PR:** (BE PR 머지 후 채울 것)
+**Spec:** `docs/superpowers/specs/2026-05-04-user-record-split-design.md`
+**API 계약:** `docs/api/api-spec.md`
+
+## 요약
+
+BE에서 `User`(시간 불변 신상) ↔ `MenteeRecord`/`MentorRecord`(사이클 데이터) 책임을 재배치했음. **응답 형식은 거의 동일**하므로 기존 화면은 그대로 동작. 단, 신규 필드(`militaryStatus`, 학부 입학·졸업연도, 멘토 로스쿨 정보)에 대한 입력 UI 추가가 필요함.
+
+## 변경 사항 — 응답 스키마
+
+### `/api/mentee/basic-info` GET
+
+`personal`에 `militaryStatus` 필드 추가:
+
+```ts
+// Before
+type BasicInfoPersonal = {
+  name: string; affiliation: string; birthDate: string; gender: string;
+  major1: string; major2: string; admissionYear: string;
+  academicStatus: string; graduationYear: string;
+};
+
+// After
+type BasicInfoPersonal = {
+  name: string;
+  affiliation: string;       // 학부 학교명
+  birthDate: string;         // "YYYY.MM.DD." (마침표 포함)
+  gender: '남성' | '여성' | '';
+  militaryStatus: '군필' | '미필' | '해당없음' | '';   // 신규
+  major1: string;            // 학부 제1전공
+  major2: string;            // 학부 제2전공
+  admissionYear: string;     // 학부 입학연도
+  graduationYear: string;    // 학부 졸업연도
+  academicStatus: '재학' | '휴학' | '졸업' | '수료' | '제적' | '';
+};
+```
+
+### `/api/mentor/basic-info` GET (신규)
+
+```ts
+type MentorBasicInfoPersonal = BasicInfoPersonal & {
+  currentLawschool: string;
+  graduatedLawschool: string;
+  lawschoolGrade: number | null;
+};
+
+type MentorBasicInfoData = { personal: MentorBasicInfoPersonal };
+```
+
+### `/api/auth/me` GET
+
+`user` 객체에 다음 필드가 추가됨 (raw enum/값 그대로):
+`birth_date`, `gender`, `military_status`, `undergrad_school_name`, `undergrad_first_major`, `undergrad_second_major`, `undergrad_entry_year`, `undergrad_graduation_year`, `current_lawschool`, `graduated_lawschool`, `lawschool_grade`.
+
+## 신규 입력 UI 요구사항
+
+`apps/web/src/app/mentee/dashboard/basic-info/page.tsx`에 추가:
+
+| 필드 | 컴포넌트 | 옵션/검증 |
+|---|---|---|
+| 병역 상태 | SelectField | 군필 / 미필 / 해당없음 |
+
+(학부 입학·졸업연도는 기존 입력 UI가 이미 존재하므로 응답 매핑만 점검)
+
+`apps/web/src/app/mentor/dashboard/basic-info/page.tsx` (신규 페이지) — 멘티 페이지 구조 모방:
+
+| 필드 | 컴포넌트 | 옵션/검증 |
+|---|---|---|
+| 현재 로스쿨 | SchoolPickerModal 재사용 | 학교 선택 |
+| 졸업 로스쿨 | SchoolPickerModal 재사용 | 학교 선택 |
+| 로스쿨 기수 | NumberInput | 1 ~ 30 |
+
+## 영향받는 파일 (FE)
+
+- `apps/web/src/lib/api.ts` — `BasicInfoPersonal` 타입에 `militaryStatus` 추가, `MentorBasicInfo*` 타입 신규 추가
+- `apps/web/src/app/mentee/dashboard/basic-info/page.tsx` — 병역 SelectField 추가
+- `apps/web/src/app/mentor/dashboard/basic-info/page.tsx` — 신규 페이지 작성
+- `apps/web/src/app/mentee/dashboard/quantitative/page.tsx` — **영향 없음**
+- `apps/web/src/components/quantitative/*` — **영향 없음**
+
+## 검증 체크리스트
+
+- [ ] 멘티 기본정보 페이지에서 병역 상태 입력·저장·재조회 round trip 정상
+- [ ] 멘토 기본정보 페이지(신규)에서 로스쿨 정보 입력·저장·재조회 정상
+- [ ] 멘티 → 멘토 전환 사용자 로그인 시, User 신상이 멘토 페이지에 자동 노출됨
+- [ ] 정량 페이지/정성 페이지 회귀(regression) 없음

--- a/packages/database/prisma/migrations/20260504120000_user_record_split/migration.sql
+++ b/packages/database/prisma/migrations/20260504120000_user_record_split/migration.sql
@@ -1,0 +1,32 @@
+-- AlterTable: users — 신상(시간 불변) 통합 (#118)
+--   학부 컬럼 rename, 로스쿨 컬럼 신설, birth_year → birth_date, academic_status는 record로 이동
+ALTER TABLE "users"
+  DROP COLUMN "birth_year",
+  DROP COLUMN "academic_status",
+  DROP COLUMN "school_name",
+  DROP COLUMN "first_major",
+  DROP COLUMN "second_major",
+  ADD COLUMN "birth_date" DATE,
+  ADD COLUMN "undergrad_school_name" VARCHAR(100),
+  ADD COLUMN "undergrad_first_major" VARCHAR(100),
+  ADD COLUMN "undergrad_second_major" VARCHAR(100),
+  ADD COLUMN "undergrad_entry_year" INTEGER,
+  ADD COLUMN "undergrad_graduation_year" INTEGER,
+  ADD COLUMN "current_lawschool" VARCHAR(100),
+  ADD COLUMN "graduated_lawschool" VARCHAR(100),
+  ADD COLUMN "lawschool_grade" INTEGER;
+
+-- AlterTable: mentee_records — User로 이동된 컬럼 제거 + 학적 스냅샷 추가 (#118)
+ALTER TABLE "mentee_records"
+  DROP COLUMN "birth_date",
+  DROP COLUMN "major",
+  DROP COLUMN "graduation_year",
+  DROP COLUMN "university_entry_year",
+  ADD COLUMN "academic_status" "AcademicStatus";
+
+-- AlterTable: mentor_records — User로 이동된 컬럼 제거 + 학적 스냅샷 추가 (#118)
+ALTER TABLE "mentor_records"
+  DROP COLUMN "current_lawschool",
+  DROP COLUMN "graduated_lawschool",
+  DROP COLUMN "graduation_year",
+  ADD COLUMN "academic_status" "AcademicStatus";

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -94,27 +94,35 @@ enum MatchStatus {
 // ----------------------------------------------------------------
 model User {
   user_id         String          @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  login_id        String?         @unique @db.VarChar(50)  // 사용자가 직접 정하는 로그인 ID. 신규 가입자는 필수, 기존 dummy 유저는 NULL
+  login_id        String?         @unique @db.VarChar(50)
   name            String          @db.VarChar(50)
-  birth_year      Int?
+
+  // 신상 (시간 불변)
+  birth_date      DateTime?       @db.Date
   gender          Gender?
+  military_status MilitaryStatus?
   phone           String?         @db.VarChar(20)
   email           String          @unique @db.VarChar(100)
   student_id      String?         @db.VarChar(20)
-  first_major     String?         @db.VarChar(100)
-  second_major    String?         @db.VarChar(100)
-  school_name     String?         @db.VarChar(100)
-  academic_status AcademicStatus?
-  military_status MilitaryStatus?
+
+  // 학부 (시간 불변)
+  undergrad_school_name      String? @db.VarChar(100)
+  undergrad_first_major      String? @db.VarChar(100)
+  undergrad_second_major     String? @db.VarChar(100)
+  undergrad_entry_year       Int?
+  undergrad_graduation_year  Int?
+
+  // 로스쿨 (시간 불변)
+  current_lawschool   String? @db.VarChar(100)
+  graduated_lawschool String? @db.VarChar(100)
+  lawschool_grade     Int?
+
+  // 계정
   account_status  AccountStatus   @default(active)
   current_role    CurrentRole     @default(none)
-
   password_hash   String?         @db.VarChar(100)
 
   // Soft Delete
-  // 탈퇴 시: is_deleted=true, deleted_at=now()
-  //          name="탈퇴한 사용자", phone/student_id=null
-  //          email="deleted_{user_id}@removed.com" (unique 제약 유지)
   is_deleted      Boolean         @default(false)
   deleted_at      DateTime?
 
@@ -143,10 +151,6 @@ model MenteeRecord {
   process_year          Int
 
   // 1단계: 기본정보
-  birth_date            DateTime?         @db.Date
-  major                 String?           @db.VarChar(100)  // 신청 당시 전공 (users.first_major와 별도)
-  graduation_year       Int?
-  university_entry_year Int?
   first_leet_year       Int?
   has_leet_experience   Boolean           @default(false)
   leet_exam_years       Json?             // [2023, 2024] — 표시용, 검색 안 함
@@ -191,6 +195,9 @@ model MenteeRecord {
   strengths_weaknesses  String?           @db.Text
   desired_mentor        String?           @db.Text
 
+  // 신청 시점 학적 스냅샷
+  academic_status       AcademicStatus?
+
   // 작성 상태 (draft ↔ submitted 만 사용)
   record_status         ApplicationStatus @default(draft)
   current_step          Int               @default(1) @db.SmallInt  // 1~4
@@ -218,11 +225,8 @@ model MentorRecord {
   user_id                    String            @db.Uuid
   process_year               Int
 
-  current_lawschool          String?           @db.VarChar(100)
-  graduated_lawschool        String?           @db.VarChar(100)
   leet_score                 Decimal?          @db.Decimal(5, 2)
   gpa                        Decimal?          @db.Decimal(3, 2)
-  graduation_year            Int?
   leet_exam_year             Int?
   has_law_class              Boolean           @default(false)
   law_class_subjects         Json?             // 표시용, 검색 안 함
@@ -230,6 +234,9 @@ model MentorRecord {
   strengths_weaknesses       String?           @db.Text
   career_goal                String?           @db.Text
   is_special_admission       Boolean           @default(false)
+
+  // 신청 시점 학적 스냅샷 (멘토 본인의 로스쿨 학적)
+  academic_status            AcademicStatus?
 
   // 작성 상태
   record_status              ApplicationStatus @default(draft)


### PR DESCRIPTION
## 요약

  `User` ↔ `Record` 간 책임 재배치.
  - **`User`** = 시간이 지나도 안 바뀌는 신상 (생년월일, 학부 학교·전공·입학·졸업연도, 로스쿨, 병역)
  - **`MenteeRecord`/`MentorRecord`** = 사이클별 변동 데이터 (LEET, GPA, 자소서, 신청 시점 학적)

  같은 사람이 재신청하거나 멘티→멘토로 전환할 때, 매번 신상 정보를 다시 입력하던 비효율을 제거.

  ## 주요 변경

  ### DB 스키마
  - `users`: `birth_date`, `undergrad_school_name`, `undergrad_first_major`, `undergrad_second_major`, `undergrad_entry_year`,
  `undergrad_graduation_year`, `current_lawschool`, `graduated_lawschool`, `lawschool_grade` 추가 / `birth_year`, `school_name`,
  `first_major`, `second_major`, `academic_status` 제거
  - `mentee_records`: `birth_date`, `major`, `graduation_year`, `university_entry_year` 제거 → `academic_status` 추가
  - `mentor_records`: `current_lawschool`, `graduated_lawschool`, `graduation_year` 제거 → `academic_status` 추가

  ### API 라우트
  - `/api/mentee/basic-info` (GET/PATCH): User+MenteeRecord 합성 응답, 평탄한 PATCH 본문을 내부에서 두 테이블로 분기 — FE 호환성 유지
  - `/api/mentor/basic-info` (GET/PATCH): 신규 라우트 (로스쿨 필드 포함)
  - `/api/auth/me`: 신상 필드 노출

  ### 신규 공용 모듈
  - `apps/api/src/lib/labels.ts`: enum ↔ 한국어 라벨 변환 (gender/academicStatus/militaryStatus/birthDate)
  - `apps/api/src/lib/payload-split.ts`: 평탄한 PATCH 본문을 `User` / `Record` 필드로 분기 + 공용 `flattenPersonal` 헬퍼

  ## DB 마이그레이션

  `packages/database/prisma/migrations/20260504120000_user_record_split/migration.sql` 포함.

  > ⚠️ 본 브랜치 작성 시 Prisma 7의 schema engine이 hang하는 이슈로 `pg` 클라이언트 직접 실행 + `_prisma_migrations` 수동 기록 방식으로 적용함
   (DB는 정상 반영됨). 동일 Supabase 인스턴스 공유 중이면 추가 작업 불필요. 별도 환경이라면 `prisma migrate deploy`로 적용 가능.

  ## FE 영향

  응답 스키마는 호환되지만 신규 필드 입력 UI 필요:
  - 멘티: `militaryStatus` SelectField (군필/미필/해당없음)
  - 멘토: 기본정보 페이지 신설 (currentLawschool, graduatedLawschool, lawschoolGrade)


  ## 검증

  - [x] `pnpm --filter api build` PASS
  - [x] DB 마이그레이션 적용 후 컬럼 구조 검증 (information_schema 조회)
  - [x] `/api/mentee/quantitative`, `/api/mentee/grades` 라우트 영향 없음 (grep 0건)
  - [ ] `/api/auth/me` 응답에 신규 필드 포함 확인
  - [ ] `/api/mentee/basic-info` PATCH (User + Record 동시 갱신) round trip
  - [ ] `/api/mentor/basic-info` PATCH (로스쿨 필드 포함) round trip
  - [ ] 멘티 → 멘토 전환 시 User 신상 자동 노출 확인
