### PR TITLE
131 featbe menteebasic info api 병역여부도 불러오게 수정

### DIFF
--- a/apps/api/src/app/api/auth/login/route.ts
+++ b/apps/api/src/app/api/auth/login/route.ts
@@ -25,7 +25,7 @@ export async function POST(req: NextRequest) {
 
   const user = await prisma.user.findFirst({
     where: queryKey,
-    select: { user_id: true, name: true, login_id: true, email: true, current_role: true, account_status: true, password_hash: true },
+    select: { user_id: true, name: true, login_id: true, email: true, current_role: true, account_status: true, military_status: true, password_hash: true },
   });
 
   if (!user || !user.password_hash) {

--- a/apps/api/src/app/api/auth/signup/route.ts
+++ b/apps/api/src/app/api/auth/signup/route.ts
@@ -38,8 +38,8 @@ export async function POST(req: NextRequest) {
   const password_hash = await bcrypt.hash(password, 12);
 
   const user = await prisma.user.create({
-    data: { name, login_id: loginId, email, password_hash, current_role: "mentee" },
-    select: { user_id: true, name: true, login_id: true, email: true, current_role: true },
+    data: { name, login_id: loginId, email, password_hash, current_role: "mentee", military_status: "not_applicable" },
+    select: { user_id: true, name: true, login_id: true, email: true, current_role: true, military_status: true },
   });
 
   const token = signToken({ user_id: user.user_id, current_role: user.current_role });

--- a/apps/web/src/app/mentee/dashboard/basic-info/page.tsx
+++ b/apps/web/src/app/mentee/dashboard/basic-info/page.tsx
@@ -52,7 +52,7 @@ export default function BasicInfoPage() {
           admissionYear: data.personal.admissionYear,
           academicStatus: data.personal.academicStatus,
           graduationYear: data.personal.graduationYear,
-          // militaryStatus는 DB 미지원 — 빈 값 유지
+          militaryStatus: data.personal.militaryStatus
         };
         const admission: AdmissionInfo = {
           가: {
@@ -88,7 +88,7 @@ export default function BasicInfoPage() {
           admissionYear: draft.admissionYear,
           academicStatus: draft.academicStatus,
           graduationYear: draft.graduationYear,
-          // militaryStatus는 DB 미지원 — 저장하지 않음
+          militaryStatus: draft.militaryStatus
         },
       });
       setPersonalInfo(draft);

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -118,6 +118,7 @@ export type BasicInfoPersonal = {
   admissionYear: string;
   academicStatus: string;
   graduationYear: string;
+  militaryStatus: string;
 };
 
 export type BasicInfoAdmission = {

--- a/packages/database/prisma/migrations/20260504130000_backfill_military_status_default/migration.sql
+++ b/packages/database/prisma/migrations/20260504130000_backfill_military_status_default/migration.sql
@@ -1,0 +1,5 @@
+-- Backfill #131: 기존 사용자 military_status NULL → not_applicable
+--   가입 시 기본값 정책에 맞춰 기존 데이터도 일관되게 정리
+UPDATE "users"
+  SET "military_status" = 'not_applicable'
+  WHERE "military_status" IS NULL;


### PR DESCRIPTION
## 요약

  `/api/auth/login`·`/api/auth/signup` 응답에 `military_status` 필드를 추가하고, 가입 시 기본값을 `not_applicable`(해당없음)로 부여. 기존     
  사용자도 NULL → `not_applicable`로 백필.

  `/api/auth/me`·`/api/mentee/basic-info`·`/api/mentor/basic-info`는 #118에서 이미 `military_status`를 노출 중이라 추가 변경 없음.

  `basic-info` 페이지가 GET/PATCH 양쪽에 `militaryStatus`를 연결하도록 수정.


  ## 변경 내용

  ### API
  - **`/api/auth/login`**: `select`에 `military_status: true` 추가 → 응답 `user.military_status` 노출 (raw enum)
  - **`/api/auth/signup`**:
    - `data`에 `military_status: "not_applicable"` 추가 → 신규 가입자는 기본값 `해당없음`
    - `select`에 `military_status: true` 추가

  ### DB 마이그레이션
  - `20260504130000_backfill_military_status_default/migration.sql` 추가
  - `UPDATE users SET military_status='not_applicable' WHERE military_status IS NULL` — 기존 17건 갱신 완료

  ### FE (`apps/web`)
  - `lib/api.ts` `BasicInfoPersonal` 타입에 `militaryStatus: string` 추가
  - `app/mentee/dashboard/basic-info/page.tsx`:
    - GET 응답 매핑에 `militaryStatus` 포함 (이전엔 "DB 미지원"으로 무시)
    - PATCH body에 `draft.militaryStatus` 포함 → 실제 저장 동작

  > `constants/basic-info.ts`의 `fieldRows`에는 이미 병역여부 SelectField(`['군필','미필','해당없음']`)가 정의돼 있어 UI 자체는 그대로.       
  GET/PATCH 연결만 활성화된 셈.

  ## 응답 형식

  | 라우트 | 형식 | 예시 |
  |---|---|---|
  | `/api/auth/login`, `signup`, `me` | raw enum | `"military_status": "not_applicable"` |
  | `/api/mentee/basic-info`, `/api/mentor/basic-info` | 한국어 라벨 | `"militaryStatus": "해당없음"` |

  FE는 raw enum이 필요한 곳에서 `labels.ts`의 `militaryToLabel()`로 변환하면 됨.

  ## FE 영향

  - 응답 객체에 새 필드(`military_status`) 추가 — 기존 코드는 무시해도 무방, 노출이 필요한 화면에서 사용
  - 가입 직후 사용자에게 보이는 기본값은 "해당없음" — 회원정보 수정 페이지에서 바꿀 수 있음 (basic-info PATCH 이미 동작)

  ## 검증

  - [x] `pnpm --filter api build` PASS
  - [x] `pnpm --filter web build` PASS
  - [x] BE: 가입 → 로그인 → me → basic-info round trip (curl로 확인)
  - [x] BE: PATCH `{"militaryStatus":"군필"}` → DB 갱신 확인
  - [x] FE: 브라우저에서 회원정보 수정 페이지에서 군필/미필/해당없음 선택 → 저장 → 새로고침 시 유지