### PR TITLE
137 be 멘티 멘토 기본 정보 망각 버그

### DIFF
--- a/apps/api/src/app/api/auth/me/route.ts
+++ b/apps/api/src/app/api/auth/me/route.ts
@@ -26,9 +26,6 @@ export async function GET(req: NextRequest) {
       undergrad_second_major: true,
       undergrad_entry_year: true,
       undergrad_graduation_year: true,
-      current_lawschool: true,
-      graduated_lawschool: true,
-      lawschool_grade: true,
     },
   });
 

--- a/apps/api/src/app/api/mentee/basic-info/route.ts
+++ b/apps/api/src/app/api/mentee/basic-info/route.ts
@@ -21,6 +21,10 @@ function getProcessYear(req: NextRequest): number {
   return match ? parseInt(match[0]) : new Date().getFullYear();
 }
 
+type AdmissionSlotInput = { school?: string; isSpecial?: boolean };
+type AdmissionGroupInput = { first?: AdmissionSlotInput; second?: AdmissionSlotInput };
+type AdmissionInput = { 가?: AdmissionGroupInput; 나?: AdmissionGroupInput };
+
 // ----------------------------------------------------------------
 // GET /api/mentee/basic-info?year=2026학년도
 // 응답: User(신상) + MenteeRecord(사이클 학적·희망학교) 합성
@@ -52,9 +56,14 @@ export async function GET(req: NextRequest) {
       where: { user_id_process_year: { user_id: userId, process_year: processYear } },
       select: {
         academic_status: true,
-        target_school_ga: true,
-        target_school_na: true,
-        is_special_admission: true,
+        target_school_ga_first: true,
+        is_special_ga_first: true,
+        target_school_ga_second: true,
+        is_special_ga_second: true,
+        target_school_na_first: true,
+        is_special_na_first: true,
+        target_school_na_second: true,
+        is_special_na_second: true,
       },
     }),
   ]);
@@ -77,16 +86,21 @@ export async function GET(req: NextRequest) {
       academicStatus: statusToLabel(record?.academic_status),
     },
     admission: {
-      가: { first: record?.target_school_ga ?? "" },
-      나: { first: record?.target_school_na ?? "" },
-      isSpecialAdmission: record?.is_special_admission ?? false,
+      가: {
+        first:  { school: record?.target_school_ga_first  ?? "", isSpecial: record?.is_special_ga_first  ?? false },
+        second: { school: record?.target_school_ga_second ?? "", isSpecial: record?.is_special_ga_second ?? false },
+      },
+      나: {
+        first:  { school: record?.target_school_na_first  ?? "", isSpecial: record?.is_special_na_first  ?? false },
+        second: { school: record?.target_school_na_second ?? "", isSpecial: record?.is_special_na_second ?? false },
+      },
     },
   });
 }
 
 // ----------------------------------------------------------------
 // PATCH /api/mentee/basic-info?year=2026학년도
-// Body: { personal?: {...}, admission?: {...} }   ← FE 호환성 유지
+// Body: { personal?: {...}, admission?: { 가?: { first?/second?: { school?, isSpecial? } }, 나?: ... } }
 // 내부: 평탄화 → splitPayload → User.update + MenteeRecord.upsert (트랜잭션)
 // ----------------------------------------------------------------
 export async function PATCH(req: NextRequest) {
@@ -99,11 +113,7 @@ export async function PATCH(req: NextRequest) {
 
   let body: {
     personal?: PersonalPatchInput;
-    admission?: {
-      가?: { first?: string };
-      나?: { first?: string };
-      isSpecialAdmission?: boolean;
-    };
+    admission?: AdmissionInput;
   };
   try {
     body = await req.json();
@@ -114,10 +124,25 @@ export async function PATCH(req: NextRequest) {
   // 1) 중첩 본문 → 평탄화 + DB 컬럼명 + 라벨 변환
   const flat: Record<string, unknown> = body.personal ? flattenPersonal(body.personal) : {};
   if (body.admission) {
-    const { 가: ga, 나: na, isSpecialAdmission } = body.admission;
-    if (ga?.first !== undefined) flat.target_school_ga = ga.first || null;
-    if (na?.first !== undefined) flat.target_school_na = na.first || null;
-    if (isSpecialAdmission !== undefined) flat.is_special_admission = isSpecialAdmission;
+    const groups: Array<{ key: "가" | "나"; col: "ga" | "na" }> = [
+      { key: "가", col: "ga" },
+      { key: "나", col: "na" },
+    ];
+    const ranks: Array<"first" | "second"> = ["first", "second"];
+    for (const { key, col } of groups) {
+      const groupData = body.admission[key];
+      if (!groupData) continue;
+      for (const r of ranks) {
+        const slot = groupData[r];
+        if (!slot) continue;
+        if (slot.school !== undefined) {
+          flat[`target_school_${col}_${r}`] = slot.school || null;
+        }
+        if (slot.isSpecial !== undefined) {
+          flat[`is_special_${col}_${r}`] = slot.isSpecial;
+        }
+      }
+    }
   }
 
   // 2) User / MenteeRecord 분기

--- a/apps/api/src/app/api/mentor/basic-info/route.ts
+++ b/apps/api/src/app/api/mentor/basic-info/route.ts
@@ -47,14 +47,15 @@ export async function GET(req: NextRequest) {
         undergrad_second_major: true,
         undergrad_entry_year: true,
         undergrad_graduation_year: true,
-        current_lawschool: true,
-        graduated_lawschool: true,
-        lawschool_grade: true,
       },
     }),
     prisma.mentorRecord.findUnique({
       where: { user_id_process_year: { user_id: userId, process_year: processYear } },
-      select: { academic_status: true },
+      select: {
+        academic_status: true,
+        lawschool_name: true,
+        lawschool_grade: true,
+      },
     }),
   ]);
 
@@ -74,9 +75,8 @@ export async function GET(req: NextRequest) {
       admissionYear: yearToLabel(user.undergrad_entry_year),
       graduationYear: yearToLabel(user.undergrad_graduation_year),
       academicStatus: statusToLabel(record?.academic_status),
-      currentLawschool: user.current_lawschool ?? "",
-      graduatedLawschool: user.graduated_lawschool ?? "",
-      lawschoolGrade: user.lawschool_grade ?? null,
+      lawschool: record?.lawschool_name ?? "",
+      lawschoolGrade: record?.lawschool_grade ?? null,
     },
   });
 }
@@ -96,8 +96,7 @@ export async function PATCH(req: NextRequest) {
 
   let body: {
     personal?: PersonalPatchInput & {
-      currentLawschool?: string;
-      graduatedLawschool?: string;
+      lawschool?: string;
       lawschoolGrade?: number | null;
     };
   };
@@ -110,8 +109,7 @@ export async function PATCH(req: NextRequest) {
   const flat: Record<string, unknown> = body.personal ? flattenPersonal(body.personal) : {};
   if (body.personal) {
     const p = body.personal;
-    if (p.currentLawschool !== undefined) flat.current_lawschool = p.currentLawschool || null;
-    if (p.graduatedLawschool !== undefined) flat.graduated_lawschool = p.graduatedLawschool || null;
+    if (p.lawschool !== undefined) flat.lawschool_name = p.lawschool || null;
     if (p.lawschoolGrade !== undefined) flat.lawschool_grade = p.lawschoolGrade;
   }
 

--- a/apps/api/src/lib/payload-split.ts
+++ b/apps/api/src/lib/payload-split.ts
@@ -13,8 +13,6 @@ export const USER_FIELDS = new Set<string>([
   "undergrad_school_name",
   "undergrad_first_major", "undergrad_second_major",
   "undergrad_entry_year", "undergrad_graduation_year",
-  // 로스쿨
-  "current_lawschool", "graduated_lawschool", "lawschool_grade",
 ]);
 
 export const MENTEE_RECORD_FIELDS = new Set<string>([
@@ -32,6 +30,7 @@ export const MENTEE_RECORD_FIELDS = new Set<string>([
 
 export const MENTOR_RECORD_FIELDS = new Set<string>([
   "academic_status",
+  "lawschool_name", "lawschool_grade",
   "has_law_class", "law_class_subjects",
   "is_special_admission",
   "personal_statement_summary",

--- a/apps/api/src/lib/payload-split.ts
+++ b/apps/api/src/lib/payload-split.ts
@@ -19,7 +19,11 @@ export const USER_FIELDS = new Set<string>([
 
 export const MENTEE_RECORD_FIELDS = new Set<string>([
   "academic_status",
-  "target_school_ga", "target_school_na", "is_special_admission",
+  // 희망 로스쿨 — 가/나 × 1·2지망 4슬롯, 슬롯별 학교 + 특별전형 boolean
+  "target_school_ga_first", "is_special_ga_first",
+  "target_school_ga_second", "is_special_ga_second",
+  "target_school_na_first", "is_special_na_first",
+  "target_school_na_second", "is_special_na_second",
   "has_leet_experience", "leet_exam_years", "first_leet_year",
   "has_law_class", "law_class_subjects",
   "career_goal",

--- a/apps/web/src/app/mentee/dashboard/basic-info/page.tsx
+++ b/apps/web/src/app/mentee/dashboard/basic-info/page.tsx
@@ -7,12 +7,13 @@ import { EditButton, EditButtons } from '@/components/ui/EditButton';
 import {
   type PersonalInfo,
   type AdmissionInfo,
+  type AdmissionEntry,
   emptyPersonalInfo,
   emptyAdmissionInfo,
   TYPE_OPTIONS,
   fieldRows,
 } from '@/constants/basic-info';
-import { getBasicInfo, patchBasicInfo } from '@/lib/api';
+import { getBasicInfo, patchBasicInfo, type AdmissionSlot } from '@/lib/api';
 
 const YEAR = '2026학년도';
 
@@ -54,15 +55,13 @@ export default function BasicInfoPage() {
           graduationYear: data.personal.graduationYear,
           militaryStatus: data.personal.militaryStatus
         };
+        const fromApi = (s: AdmissionSlot): AdmissionEntry => ({
+          school: s.school,
+          type: s.isSpecial ? '특별전형' : '일반전형',
+        });
         const admission: AdmissionInfo = {
-          가: {
-            first: { school: data.admission.가.first, type: data.admission.isSpecialAdmission ? '특별전형' : '일반전형' },
-            second: emptyAdmissionInfo.가.second,  // DB 미지원
-          },
-          나: {
-            first: { school: data.admission.나.first, type: data.admission.isSpecialAdmission ? '특별전형' : '일반전형' },
-            second: emptyAdmissionInfo.나.second,  // DB 미지원
-          },
+          가: { first: fromApi(data.admission.가.first), second: fromApi(data.admission.가.second) },
+          나: { first: fromApi(data.admission.나.first), second: fromApi(data.admission.나.second) },
         };
         setPersonalInfo(personal);
         setAdmissionInfo(admission);
@@ -108,12 +107,14 @@ export default function BasicInfoPage() {
   async function handleAdmissionSave() {
     setAdmissionSaving(true);
     try {
+      const toApi = (e: AdmissionEntry): AdmissionSlot => ({
+        school: e.school,
+        isSpecial: e.type === '특별전형',
+      });
       await patchBasicInfo(YEAR, {
         admission: {
-          가: { first: admissionDraft.가.first.school },
-          나: { first: admissionDraft.나.first.school },
-          // 제1지망 type 기준으로 is_special_admission 결정 (가군 기준)
-          isSpecialAdmission: admissionDraft.가.first.type === '특별전형',
+          가: { first: toApi(admissionDraft.가.first), second: toApi(admissionDraft.가.second) },
+          나: { first: toApi(admissionDraft.나.first), second: toApi(admissionDraft.나.second) },
         },
       });
       setAdmissionInfo(admissionDraft);

--- a/apps/web/src/app/mentor/dashboard/basic-info/page.tsx
+++ b/apps/web/src/app/mentor/dashboard/basic-info/page.tsx
@@ -27,7 +27,7 @@ export default function MentorBasicInfoPage() {
         setPersonalInfo({
           ...emptyMentorPersonalInfo,
           name: data.personal.name,
-          affiliation: data.personal.currentLawschool,  // "소속 로스쿨" ← currentLawschool
+          affiliation: data.personal.lawschool,  // "소속 로스쿨" ← MentorRecord.lawschool_name
           birthDate: data.personal.birthDate,
           gender: data.personal.gender,
           lawSchoolGrade: data.personal.lawschoolGrade ? `${data.personal.lawschoolGrade}학년도` : '',
@@ -63,7 +63,7 @@ export default function MentorBasicInfoPage() {
           major2: draft.major2,
           admissionYear: draft.admissionYear,
           graduationYear: draft.graduationYear,
-          currentLawschool: draft.affiliation,  // FE affiliation ("소속 로스쿨") → BE currentLawschool
+          lawschool: draft.affiliation,  // FE affiliation ("소속 로스쿨") → BE MentorRecord.lawschool_name
           lawschoolGrade: Number.isFinite(gradeNum) ? gradeNum : null,
         },
       });

--- a/apps/web/src/app/mentor/dashboard/basic-info/page.tsx
+++ b/apps/web/src/app/mentor/dashboard/basic-info/page.tsx
@@ -8,7 +8,7 @@ import {
   emptyMentorPersonalInfo,
   fieldRows,
 } from '@/constants/mentor-basic-info';
-import { getBasicInfo, patchBasicInfo } from '@/lib/api';
+import { getMentorBasicInfo, patchMentorBasicInfo } from '@/lib/api';
 
 const YEAR = '2026학년도';
 
@@ -21,22 +21,22 @@ export default function MentorBasicInfoPage() {
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState('');
 
-  // 멘티 시절 작성한 기본정보를 멘티 API에서 그대로 로드
   useEffect(() => {
-    getBasicInfo(YEAR)
+    getMentorBasicInfo(YEAR)
       .then((data) => {
         setPersonalInfo({
           ...emptyMentorPersonalInfo,
           name: data.personal.name,
-          affiliation: data.personal.affiliation,
+          affiliation: data.personal.currentLawschool,  // "소속 로스쿨" ← currentLawschool
           birthDate: data.personal.birthDate,
           gender: data.personal.gender,
+          lawSchoolGrade: data.personal.lawschoolGrade ? `${data.personal.lawschoolGrade}학년도` : '',
           academicStatus: data.personal.academicStatus,
+          militaryStatus: data.personal.militaryStatus,
           major1: data.personal.major1,
           major2: data.personal.major2,
           admissionYear: data.personal.admissionYear,
           graduationYear: data.personal.graduationYear,
-          // lawSchoolGrade, militaryStatus는 멘티 API 미지원 — 빈 값 유지
         });
       })
       .catch(() => setLoadError('기본정보를 불러오지 못했습니다.'))
@@ -51,16 +51,20 @@ export default function MentorBasicInfoPage() {
     setBirthDateError('');
     setSaving(true);
     try {
-      await patchBasicInfo(YEAR, {
+      // "2024학년도" → 2024 (Int) | "" → null
+      const gradeNum = draft.lawSchoolGrade ? parseInt(draft.lawSchoolGrade, 10) : null;
+      await patchMentorBasicInfo(YEAR, {
         personal: {
           birthDate: draft.birthDate,
           gender: draft.gender,
           academicStatus: draft.academicStatus,
+          militaryStatus: draft.militaryStatus,
           major1: draft.major1,
           major2: draft.major2,
           admissionYear: draft.admissionYear,
           graduationYear: draft.graduationYear,
-          // lawSchoolGrade, militaryStatus는 멘티 API 미지원 — 저장 안 함
+          currentLawschool: draft.affiliation,  // FE affiliation ("소속 로스쿨") → BE currentLawschool
+          lawschoolGrade: Number.isFinite(gradeNum) ? gradeNum : null,
         },
       });
       setPersonalInfo(draft);

--- a/apps/web/src/constants/basic-info.ts
+++ b/apps/web/src/constants/basic-info.ts
@@ -6,15 +6,15 @@ export type PersonalInfo = {
   major1: string;
   major2: string;
   admissionYear: string;
-  militaryStatus: string;   // DB 미지원 — 로컬 상태로만 유지
+  militaryStatus: string;
   academicStatus: string;
   graduationYear: string;
 };
 
 export type AdmissionEntry = { school: string; type: string };
 export type AdmissionInfo = {
-  가: { first: AdmissionEntry; second: AdmissionEntry };  // second는 DB 미지원
-  나: { first: AdmissionEntry; second: AdmissionEntry };  // second는 DB 미지원
+  가: { first: AdmissionEntry; second: AdmissionEntry };
+  나: { first: AdmissionEntry; second: AdmissionEntry };
 };
 
 export const emptyPersonalInfo: PersonalInfo = {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -167,9 +167,8 @@ export async function patchBasicInfo(
 // ----------------------------------------------------------------
 
 export type MentorBasicInfoPersonal = BasicInfoPersonal & {
-  currentLawschool: string;
-  graduatedLawschool: string;
-  lawschoolGrade: number | null;
+  lawschool: string;             // 소속 로스쿨 (MentorRecord)
+  lawschoolGrade: number | null; // 기수 (MentorRecord)
 };
 
 export type MentorBasicInfoData = {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -121,11 +121,11 @@ export type BasicInfoPersonal = {
   militaryStatus: string;
 };
 
+// 가/나 × 1·2지망 4슬롯, 슬롯별 학교 + 특별전형 boolean
+export type AdmissionSlot = { school: string; isSpecial: boolean };
 export type BasicInfoAdmission = {
-  // DB에 저장되는 필드: 가/나군 제1지망 학교, 특별전형 여부
-  가: { first: string };
-  나: { first: string };
-  isSpecialAdmission: boolean;
+  가: { first: AdmissionSlot; second: AdmissionSlot };
+  나: { first: AdmissionSlot; second: AdmissionSlot };
 };
 
 export type BasicInfoData = {
@@ -142,14 +142,16 @@ export async function getBasicInfo(year: string): Promise<BasicInfoData> {
   return res.json();
 }
 
+type AdmissionSlotPatch = { school?: string; isSpecial?: boolean };
+type AdmissionGroupPatch = { first?: AdmissionSlotPatch; second?: AdmissionSlotPatch };
+
 export async function patchBasicInfo(
   year: string,
   body: {
     personal?: Partial<Omit<BasicInfoPersonal, "name" | "affiliation">>;
     admission?: {
-      가?: { first?: string };
-      나?: { first?: string };
-      isSpecialAdmission?: boolean;
+      가?: AdmissionGroupPatch;
+      나?: AdmissionGroupPatch;
     };
   }
 ): Promise<void> {
@@ -158,6 +160,42 @@ export async function patchBasicInfo(
     { method: "PATCH", headers: headers(), credentials: "include", body: JSON.stringify(body) }
   );
   if (!res.ok) throw new Error("기본정보 저장 실패");
+}
+
+// ----------------------------------------------------------------
+// Mentor Basic Info
+// ----------------------------------------------------------------
+
+export type MentorBasicInfoPersonal = BasicInfoPersonal & {
+  currentLawschool: string;
+  graduatedLawschool: string;
+  lawschoolGrade: number | null;
+};
+
+export type MentorBasicInfoData = {
+  personal: MentorBasicInfoPersonal;
+};
+
+export async function getMentorBasicInfo(year: string): Promise<MentorBasicInfoData> {
+  const res = await fetch(
+    `${API_BASE}/api/mentor/basic-info?year=${encodeURIComponent(year)}`,
+    { headers: headers(), credentials: "include" }
+  );
+  if (!res.ok) throw new Error("멘토 기본정보 조회 실패");
+  return res.json();
+}
+
+export async function patchMentorBasicInfo(
+  year: string,
+  body: {
+    personal?: Partial<Omit<MentorBasicInfoPersonal, "name">>;
+  }
+): Promise<void> {
+  const res = await fetch(
+    `${API_BASE}/api/mentor/basic-info?year=${encodeURIComponent(year)}`,
+    { method: "PATCH", headers: headers(), credentials: "include", body: JSON.stringify(body) }
+  );
+  if (!res.ok) throw new Error("멘토 기본정보 저장 실패");
 }
 
 // ----------------------------------------------------------------

--- a/docs/api/api-spec.md
+++ b/docs/api/api-spec.md
@@ -128,7 +128,7 @@
 
 ## `/api/mentor/basic-info` — GET / PATCH
 
-멘토 기본정보. `User`(신상 + 로스쿨) + `MentorRecord`(학적 스냅샷) 합성.
+멘토 기본정보. `User`(신상) + `MentorRecord`(학적 스냅샷 + 소속 로스쿨·기수) 합성.
 
 **Query:** `?year=2026`
 
@@ -146,20 +146,20 @@
     "admissionYear": "2019",
     "graduationYear": "2024",
     "academicStatus": "재학",
-    "currentLawschool": "string",
-    "graduatedLawschool": "",
-    "lawschoolGrade": 17
+    "lawschool": "string",
+    "lawschoolGrade": 2024
   }
 }
 ```
+
+`lawschool` (소속 로스쿨) 와 `lawschoolGrade` (기수, 입학년도 정수)는 cycle별 `MentorRecord`에 저장됨.
 
 **PATCH Body** (모든 필드 선택적):
 ```json
 {
   "personal": {
-    "currentLawschool": "string",
-    "graduatedLawschool": "string",
-    "lawschoolGrade": 17,
+    "lawschool": "string",
+    "lawschoolGrade": 2024,
     "academicStatus": "재학"
   }
 }

--- a/docs/api/api-spec.md
+++ b/docs/api/api-spec.md
@@ -80,9 +80,14 @@
     "academicStatus": "재학"
   },
   "admission": {
-    "가": { "first": "string" },
-    "나": { "first": "string" },
-    "isSpecialAdmission": false
+    "가": {
+      "first":  { "school": "string", "isSpecial": false },
+      "second": { "school": "string", "isSpecial": false }
+    },
+    "나": {
+      "first":  { "school": "string", "isSpecial": false },
+      "second": { "school": "string", "isSpecial": false }
+    }
   }
 }
 ```
@@ -101,12 +106,19 @@
     "academicStatus": "재학"
   },
   "admission": {
-    "가": { "first": "string" },
-    "나": { "first": "string" },
-    "isSpecialAdmission": false
+    "가": {
+      "first":  { "school": "string", "isSpecial": false },
+      "second": { "school": "string", "isSpecial": false }
+    },
+    "나": {
+      "first":  { "school": "string", "isSpecial": false },
+      "second": { "school": "string", "isSpecial": false }
+    }
   }
 }
 ```
+
+`admission.{가|나}.{first|second}.school` 빈 문자열은 DB 컬럼이 NULL로 저장된다. `isSpecial` 미지정 시 기본값 `false` 유지.
 
 **PATCH Response 200:** `{ "success": true }`
 

--- a/packages/database/prisma/migrations/20260507000000_mentee_admission_4slots/migration.sql
+++ b/packages/database/prisma/migrations/20260507000000_mentee_admission_4slots/migration.sql
@@ -1,0 +1,15 @@
+-- AlterTable: mentee_records — #137 희망 로스쿨 4슬롯 + 슬롯별 특별전형 boolean
+-- 기존 target_school_ga/na/is_special_admission 단일 슬롯 → 가/나 × 1·2지망 4슬롯 + 슬롯별 is_special
+
+ALTER TABLE "mentee_records"
+    DROP COLUMN "target_school_ga",
+    DROP COLUMN "target_school_na",
+    DROP COLUMN "is_special_admission",
+    ADD COLUMN "target_school_ga_first" VARCHAR(100),
+    ADD COLUMN "is_special_ga_first" BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN "target_school_ga_second" VARCHAR(100),
+    ADD COLUMN "is_special_ga_second" BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN "target_school_na_first" VARCHAR(100),
+    ADD COLUMN "is_special_na_first" BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN "target_school_na_second" VARCHAR(100),
+    ADD COLUMN "is_special_na_second" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/database/prisma/migrations/20260507010000_lawschool_to_mentor_record/migration.sql
+++ b/packages/database/prisma/migrations/20260507010000_lawschool_to_mentor_record/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable: users — #137 로스쿨 정보 User → MentorRecord 로 이동 (졸업/현재 구분 폐기)
+ALTER TABLE "users"
+    DROP COLUMN "current_lawschool",
+    DROP COLUMN "graduated_lawschool",
+    DROP COLUMN "lawschool_grade";
+
+-- AlterTable: mentor_records — #137 멘토 본인 로스쿨 단일 슬롯
+ALTER TABLE "mentor_records"
+    ADD COLUMN "lawschool_name" VARCHAR(100),
+    ADD COLUMN "lawschool_grade" INTEGER;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -112,11 +112,6 @@ model User {
   undergrad_entry_year       Int?
   undergrad_graduation_year  Int?
 
-  // 로스쿨 (시간 불변)
-  current_lawschool   String? @db.VarChar(100)
-  graduated_lawschool String? @db.VarChar(100)
-  lawschool_grade     Int?
-
   // 계정
   account_status  AccountStatus   @default(active)
   current_role    CurrentRole     @default(none)
@@ -241,6 +236,10 @@ model MentorRecord {
   strengths_weaknesses       String?           @db.Text
   career_goal                String?           @db.Text
   is_special_admission       Boolean           @default(false)
+
+  // 멘토 본인 로스쿨 정보 (cycle 시점 기준)
+  lawschool_name             String?           @db.VarChar(100)  // 소속 로스쿨
+  lawschool_grade            Int?                                 // 기수 (입학년도)
 
   // 신청 시점 학적 스냅샷 (멘토 본인의 로스쿨 학적)
   academic_status            AcademicStatus?

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -174,9 +174,15 @@ model MenteeRecord {
   toefl_score               Int?
   teps_score                Int?
 
-  target_school_ga      String?           @db.VarChar(100)  // 가군 희망 학교
-  target_school_na      String?           @db.VarChar(100)  // 나군 희망 학교
-  is_special_admission  Boolean           @default(false)
+  // 희망 로스쿨 — 가/나 군 × 1·2지망 4슬롯, 슬롯별 학교 + 특별전형 여부
+  target_school_ga_first    String?       @db.VarChar(100)  // 가군 1지망
+  is_special_ga_first       Boolean       @default(false)
+  target_school_ga_second   String?       @db.VarChar(100)  // 가군 2지망
+  is_special_ga_second      Boolean       @default(false)
+  target_school_na_first    String?       @db.VarChar(100)  // 나군 1지망
+  is_special_na_first       Boolean       @default(false)
+  target_school_na_second   String?       @db.VarChar(100)  // 나군 2지망
+  is_special_na_second      Boolean       @default(false)
 
   // 3단계: 자소서·정성 (사용자 직접 입력)
   qualitative_activities Json?    // { volunteer, conference, thesis, club, external }


### PR DESCRIPTION
  ## 버그                                                                     

  새로고침하면 입력값이 사라지던 두 가지 문제 해결.

  1. **멘티** — 희망 학교 가/나군 **제 2지망**이 저장되지 않음. 또한 일반/특별
   전형이 전체에 1개만 저장됨.
  2. **멘토** — 소속 로스쿨 / 로스쿨 기수 / 병역여부가 저장되지 않음.

  ## 근본 원인

  1. **멘티**: `MenteeRecord` 스키마에 1지망 컬럼만 있었고
  `is_special_admission`도 단일 boolean. 2지망과 슬롯별 전형 정보를 저장할    
  곳이 없었음.
  2. **멘토**: FE 멘토 페이지가 stale — `/api/mentor/basic-info` (#118에서    
  추가) 대신 멘티 API를 호출했고, 4개 필드를 GET 매핑·PATCH body 양쪽에서     
  명시적으로 제외 (주석 "멘티 API 미지원"이 #131 이후 stale).

  ## 변경 사항

  ### BE (`packages/database`, `apps/api`)

  - `MenteeRecord` 스키마: 단일
  `target_school_ga`/`target_school_na`/`is_special_admission` → 가/나 ×      
  1·2지망 4슬롯 + 슬롯별 `is_special_*` boolean (8개 컬럼)
  - 마이그레이션 `20260507000000_mentee_admission_4slots` (destructive — dev  
  DB)
  - `payload-split.ts` `MENTEE_RECORD_FIELDS` 갱신 (old 3개 제거, new 8개     
  추가)
  - `/api/mentee/basic-info` GET·PATCH가 중첩 구조 지원:
    admission: { 가: { first/second: { school, isSpecial } }, 나: ... }       

  ### FE (`apps/web`)

  - `lib/api.ts`:
  - `BasicInfoAdmission` 4슬롯·슬롯별 isSpecial 로 변경
  - 멘토 전용 `getMentorBasicInfo`/`patchMentorBasicInfo` + 타입 추가
  - 멘티 basic-info 페이지: GET·PATCH 4슬롯 모두 송수신 (isSpecial ↔
  '특별전형/일반전형')
  - 멘토 basic-info 페이지:
  - 멘티 API → 멘토 API로 전환
  - "소속 로스쿨"(affiliation) ↔ BE `currentLawschool`
  - "로스쿨 기수"(lawSchoolGrade) ↔ BE `lawschoolGrade` (Int ↔ "X학년도" 변환)
  - "병역여부"(militaryStatus) GET·PATCH 연결
  - stale 주석 제거

  ### 문서

  - `docs/api/api-spec.md` 멘티 basic-info 스펙 4슬롯 구조 반영

  ## 검증

  curl round-trip:

  - 멘티 PATCH `가1: 고려대 일반`, `가2: 서울대 특별`, `나1: 연세대 일반`,    
  `나2: 성균관대 특별` → GET 동일 4슬롯 그대로 반환 ✓
  - 멘토 PATCH `currentLawschool: "고려대학교 로스쿨"`, `lawschoolGrade:      
  2024`, `militaryStatus: "군필"` → GET 동일 값 그대로 반환 ✓
  - 한국어 인코딩: `--data-binary @file` 패턴으로 cp949 변환 회피 (기존 #131  
  패턴 동일)

  ## 마이그레이션 영향

  destructive — `mentee_records` 의 기존 `target_school_ga`,
  `target_school_na`, `is_special_admission` 데이터는 삭제. dev DB만 영향.    
  운영 배포 시 별도 백필 검토 필요.

  ## 관련

  - Spec: `docs/api/api-spec.md` 갱신
  - 커밋 6개: schema → migration → BE API → FE lib → FE 멘티 페이지 → FE 멘토 
  페이지 → 스펙 문서


### 추가 — 로스쿨 정보 위치 정리 (BE 스키마 정돈)                                                                                           

  `User` 테이블의 `current_lawschool` / `graduated_lawschool` / `lawschool_grade` 3개 필드 사용처 부재로 제거. 
  `MentorRecord` 에 다음 2개 필드 신설:

  - `lawschool_name` (소속 로스쿨, String?)
  - `lawschool_grade` (기수, Int?, 입학년도)

  영향받은 라우트:
  - `GET·PATCH /api/mentor/basic-info`: 응답·body의 `currentLawschool` / `graduatedLawschool` → 단일 `lawschool`
  - `GET /api/auth/me`: 3개 로스쿨 필드 제거
  - `payload-split.ts`: USER_FIELDS / MENTOR_RECORD_FIELDS 재배치

  **미연동 admin 화면**: `/admin/users/[userId]`, `/admin/mentors/create` 는 mock 데이터를 쓰는 미구현 화면이므로 본 PR 범위 외. 실제 BE 연동 
  작업 시 별도 처리.

  마이그레이션 추가: `20260507010000_lawschool_to_mentor_record` (destructive — User 측 기존 데이터 유실).
