### PR TITLE
feat(#149): 멘티/멘토 사이드바에 공지사항 페이지 추가

### DIFF
--- a/apps/web/src/app/mentee/announcements/[id]/page.tsx
+++ b/apps/web/src/app/mentee/announcements/[id]/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+import AnnouncementDetail from '@/components/announcements/AnnouncementDetail';
+
+export const metadata: Metadata = {
+  title: 'pLAWcess | 공지사항',
+};
+
+export default async function MenteeAnnouncementDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <AnnouncementDetail id={id} backPath="/mentee/announcements" />;
+}

--- a/apps/web/src/app/mentee/announcements/layout.tsx
+++ b/apps/web/src/app/mentee/announcements/layout.tsx
@@ -1,0 +1,27 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import jwt from 'jsonwebtoken';
+import DashboardShell from '@/components/layout/DashboardShell';
+
+const COOKIE_NAME = 'plawcess_token';
+
+export default async function MenteeAnnouncementsLayout({ children }: { children: React.ReactNode }) {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(COOKIE_NAME)?.value;
+
+  if (!token) {
+    redirect('/login');
+  }
+
+  try {
+    const secret = process.env.JWT_SECRET;
+    if (!secret) {
+      throw new Error('JWT_SECRET not set');
+    }
+    jwt.verify(token, secret);
+  } catch {
+    redirect('/login');
+  }
+
+  return <DashboardShell>{children}</DashboardShell>;
+}

--- a/apps/web/src/app/mentee/announcements/page.tsx
+++ b/apps/web/src/app/mentee/announcements/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import AnnouncementList from '@/components/announcements/AnnouncementList';
+
+export const metadata: Metadata = {
+  title: 'pLAWcess | 공지사항',
+};
+
+export default function MenteeAnnouncementsPage() {
+  return <AnnouncementList basePath="/mentee/announcements" />;
+}

--- a/apps/web/src/app/mentor/announcements/[id]/page.tsx
+++ b/apps/web/src/app/mentor/announcements/[id]/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+import AnnouncementDetail from '@/components/announcements/AnnouncementDetail';
+
+export const metadata: Metadata = {
+  title: 'pLAWcess | 공지사항',
+};
+
+export default async function MentorAnnouncementDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <AnnouncementDetail id={id} backPath="/mentor/announcements" />;
+}

--- a/apps/web/src/app/mentor/announcements/layout.tsx
+++ b/apps/web/src/app/mentor/announcements/layout.tsx
@@ -1,0 +1,27 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import jwt from 'jsonwebtoken';
+import DashboardShell from '@/components/layout/DashboardShell';
+
+const COOKIE_NAME = 'plawcess_token';
+
+export default async function MentorAnnouncementsLayout({ children }: { children: React.ReactNode }) {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(COOKIE_NAME)?.value;
+
+  if (!token) {
+    redirect('/login');
+  }
+
+  try {
+    const secret = process.env.JWT_SECRET;
+    if (!secret) {
+      throw new Error('JWT_SECRET not set');
+    }
+    jwt.verify(token, secret);
+  } catch {
+    redirect('/login');
+  }
+
+  return <DashboardShell>{children}</DashboardShell>;
+}

--- a/apps/web/src/app/mentor/announcements/page.tsx
+++ b/apps/web/src/app/mentor/announcements/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import AnnouncementList from '@/components/announcements/AnnouncementList';
+
+export const metadata: Metadata = {
+  title: 'pLAWcess | 공지사항',
+};
+
+export default function MentorAnnouncementsPage() {
+  return <AnnouncementList basePath="/mentor/announcements" />;
+}

--- a/apps/web/src/components/announcements/AnnouncementDetail.tsx
+++ b/apps/web/src/components/announcements/AnnouncementDetail.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link';
+import { MOCK_ANNOUNCEMENTS } from './data';
+
+export default function AnnouncementDetail({ id, backPath }: { id: string; backPath: string }) {
+  const announcement = MOCK_ANNOUNCEMENTS.find((a) => a.id === id);
+
+  if (!announcement) {
+    return (
+      <div className="max-w-3xl mx-auto w-full">
+        <p className="text-sm text-text-secondary">공지사항을 찾을 수 없습니다.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6 max-w-3xl mx-auto w-full">
+      <Link
+        href={backPath}
+        className="flex items-center gap-1.5 text-sm text-text-secondary hover:text-text-primary transition-colors w-fit"
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M15 18l-6-6 6-6" />
+        </svg>
+        목록으로
+      </Link>
+
+      <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-8">
+        <div className="border-b border-border pb-5 mb-6">
+          <h1 className="text-xl font-bold text-text-primary">{announcement.title}</h1>
+          <p className="mt-2 text-xs text-text-placeholder">
+            {announcement.author} · {new Date(announcement.created_at).toLocaleDateString('ko-KR')}
+          </p>
+        </div>
+        <p className="text-sm text-text-secondary leading-relaxed whitespace-pre-wrap">{announcement.body}</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/announcements/AnnouncementList.tsx
+++ b/apps/web/src/components/announcements/AnnouncementList.tsx
@@ -1,0 +1,46 @@
+import Link from 'next/link';
+import { MOCK_ANNOUNCEMENTS } from './data';
+
+export default function AnnouncementList({ basePath }: { basePath: string }) {
+  return (
+    <div className="flex flex-col gap-6 max-w-3xl mx-auto w-full">
+      <div>
+        <h1 className="text-2xl font-bold text-text-primary">공지사항</h1>
+        <p className="text-sm text-text-secondary mt-1">pLAWcess 운영팀의 공지사항을 확인하세요</p>
+      </div>
+
+      {MOCK_ANNOUNCEMENTS.length === 0 ? (
+        <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-10 text-center text-sm text-text-secondary">
+          등록된 공지사항이 없습니다.
+        </div>
+      ) : (
+        <div className="bg-white rounded-xl border border-border shadow-sm overflow-hidden">
+          <ul className="divide-y divide-border">
+            {MOCK_ANNOUNCEMENTS.map((a) => (
+              <li key={a.id}>
+                <Link
+                  href={`${basePath}/${a.id}`}
+                  className="w-full px-8 py-5 flex items-center justify-between hover:bg-gray-50 transition-colors"
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium text-text-primary">{a.title}</p>
+                    <p className="mt-1 text-xs text-text-placeholder">
+                      {a.author} · {new Date(a.created_at).toLocaleDateString('ko-KR')}
+                    </p>
+                  </div>
+                  <svg
+                    width="16" height="16" viewBox="0 0 24 24" fill="none"
+                    stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+                    className="shrink-0 ml-4 text-text-secondary"
+                  >
+                    <path d="M9 18l6-6-6-6" />
+                  </svg>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/announcements/data.ts
+++ b/apps/web/src/components/announcements/data.ts
@@ -1,0 +1,25 @@
+export type Announcement = {
+  id: string;
+  title: string;
+  body: string;
+  created_at: string;
+  author: string;
+};
+
+// TODO: API 연결 후 실제 데이터로 교체 — GET /api/announcements
+export const MOCK_ANNOUNCEMENTS: Announcement[] = [
+  {
+    id: '1',
+    title: '2026학년도 멘토 모집 안내',
+    body: '2026학년도 pLAWcess 멘토 모집을 시작합니다. 자유전공학부 출신 법학대학원 합격자라면 누구나 지원 가능합니다.',
+    created_at: '2026-04-10T00:00:00Z',
+    author: '관리자',
+  },
+  {
+    id: '2',
+    title: '멘티 신청 마감일 변경',
+    body: '멘티 신청 마감일이 2026년 4월 30일로 변경되었습니다. 기간 내 신청 부탁드립니다.',
+    created_at: '2026-04-05T00:00:00Z',
+    author: '관리자',
+  },
+];

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -9,7 +9,7 @@ const menteeNavItems = [
   { label: '정성 데이터', href: '/mentee/dashboard/qualitative' },
   { label: '프로세스 신청', href: '/mentee/applications' },
   { label: '합격 아카이브', href: '/mentee/archive' },
-  { label: '공지사항', href: '/announcements' },
+  { label: '공지사항', href: '/mentee/announcements' },
 ];
 
 type NavItem = { label: string; href: string; match?: string; exact?: boolean };
@@ -20,7 +20,7 @@ const mentorNavItems: NavItem[] = [
   { label: '정량 데이터', href: '/mentor/dashboard/quantitative' },
   { label: '정성 데이터', href: '/mentor/dashboard/qualitative' },
   { label: '합격 아카이브', href: '/mentor/archive' },
-  { label: '공지사항', href: '/announcements' },
+  { label: '공지사항', href: '/mentor/announcements' },
 ];
 
 const adminNavItems: NavItem[] = [


### PR DESCRIPTION
## Summary
- 멘티/멘토 사이드바에 공지사항 nav 항목 추가
- `/mentee/announcements`, `/mentor/announcements` 목록 페이지 생성 (DashboardShell 레이아웃)
- `/mentee/announcements/[id]`, `/mentor/announcements/[id]` 상세 페이지 생성
- 기존 `/announcements` (랜딩 페이지 레이아웃)로 이동하던 문제 해결

## Test plan
- [ ] 멘티 로그인 후 사이드바 "공지사항" 클릭 → `/mentee/announcements` 진입, 사이드바 유지 확인
- [ ] 멘토 로그인 후 사이드바 "공지사항" 클릭 → `/mentor/announcements` 진입, 사이드바 유지 확인
- [ ] 목록에서 공지사항 항목 클릭 → 상세 페이지 이동 확인
- [ ] 상세 페이지 "목록으로" 클릭 → 목록 복귀 확인
- [ ] 미로그인 상태에서 직접 URL 접근 시 `/login` 리다이렉트 확인

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)