### PR TITLE
83 feat 회원가입 시 이메일 인증 추가

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -2,3 +2,7 @@ DATABASE_URL=""
 DIRECT_URL=""
 JWT_SECRET=""
 GEMINI_API_KEY=""
+
+# 이메일 인증 (#83)
+RESEND_API_KEY=""                              # 미설정 시 콘솔 fallback
+MAIL_FROM="pLAWcess <onboarding@resend.dev>"   # 도메인 인증 후 noreply@<도메인>

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,7 +19,8 @@
     "next": "16.2.2",
     "pg": "^8.20.0",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "resend": "^6.12.3"
   },
   "devDependencies": {
     "@types/bcryptjs": "^3.0.0",

--- a/apps/api/src/app/api/auth/email/send-verification/route.ts
+++ b/apps/api/src/app/api/auth/email/send-verification/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@plawcess/database";
+import {
+  generateSixDigitCode, hashCode, assertSendRateLimit, RateLimitError,
+  CODE_EXPIRES_MINUTES, getClientIp,
+} from "@/lib/email/code";
+import { getEmailSender, EmailDeliveryError } from "@/lib/email/sender";
+import { signupCodeMail } from "@/lib/email/templates";
+
+type Body = { purpose: "signup"; email: string };
+
+export async function POST(req: NextRequest) {
+  let body: Body;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "요청 형식이 올바르지 않습니다." }, { status: 400 });
+  }
+
+  if (!body || typeof body !== "object" || body.purpose !== "signup") {
+    return NextResponse.json({ error: "지원하지 않는 purpose 입니다." }, { status: 400 });
+  }
+
+  const email = body.email;
+  if (!email || typeof email !== "string") {
+    return NextResponse.json({ error: "email 이 필요합니다." }, { status: 400 });
+  }
+
+  const ip = getClientIp(req.headers);
+
+  // 가입 시점 enumeration 허용 — 이미 가입된 이메일이면 명시적 409
+  const dup = await prisma.user.findUnique({ where: { email }, select: { user_id: true } });
+  if (dup) {
+    return NextResponse.json({ error: "이미 사용 중인 이메일입니다." }, { status: 409 });
+  }
+
+  // rate limit
+  try {
+    await assertSendRateLimit(email, "signup");
+  } catch (e) {
+    if (e instanceof RateLimitError) {
+      return NextResponse.json({ error: e.message }, { status: 429 });
+    }
+    throw e;
+  }
+
+  // 코드 생성 + Resend 발송
+  const code = generateSixDigitCode();
+  const mail = signupCodeMail(code);
+  try {
+    await getEmailSender().send({ to: email, ...mail });
+  } catch (e) {
+    if (e instanceof EmailDeliveryError) {
+      return NextResponse.json({ error: "메일 발송에 실패했습니다." }, { status: 502 });
+    }
+    throw e;
+  }
+
+  // 성공 시에만 DB INSERT
+  const expiresAt = new Date(Date.now() + CODE_EXPIRES_MINUTES * 60 * 1000);
+  await prisma.emailVerification.create({
+    data: {
+      email,
+      purpose: "signup",
+      code_hash: await hashCode(code),
+      expires_at: expiresAt,
+      ip_address: ip,
+    },
+  });
+
+  return NextResponse.json({ sent: true, expiresAt: expiresAt.toISOString() });
+}

--- a/apps/api/src/app/api/auth/email/verify-code/route.ts
+++ b/apps/api/src/app/api/auth/email/verify-code/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@plawcess/database";
+import {
+  compareCode, findLatestActiveVerification,
+  VERIFY_MAX_ATTEMPTS, SIGNUP_TOKEN_EXPIRES_MINUTES,
+} from "@/lib/email/code";
+import { signSignupVerificationToken } from "@/lib/auth-tokens";
+
+type Body = {
+  email: string;
+  purpose: "signup";
+  code: string;
+};
+
+export async function POST(req: NextRequest) {
+  let body: Body;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "요청 형식이 올바르지 않습니다." }, { status: 400 });
+  }
+
+  const { email, purpose, code } = body;
+  if (!email || !purpose || !code) {
+    return NextResponse.json({ error: "email·purpose·code 가 모두 필요합니다." }, { status: 400 });
+  }
+  if (purpose !== "signup") {
+    return NextResponse.json({ error: "지원하지 않는 purpose 입니다." }, { status: 400 });
+  }
+
+  const row = await findLatestActiveVerification(email, "signup");
+  if (!row) {
+    return NextResponse.json({ error: "코드가 만료되었거나 발송된 적 없습니다." }, { status: 400 });
+  }
+
+  const newAttempts = row.attempts + 1;
+  if (newAttempts > VERIFY_MAX_ATTEMPTS) {
+    await prisma.emailVerification.update({
+      where: { verification_id: row.verification_id },
+      data: { attempts: newAttempts, consumed_at: new Date() },
+    });
+    return NextResponse.json({ error: "시도 횟수가 초과되었습니다. 새 코드를 발송해주세요." }, { status: 400 });
+  }
+
+  const ok = await compareCode(code, row.code_hash);
+  if (!ok) {
+    await prisma.emailVerification.update({
+      where: { verification_id: row.verification_id },
+      data: { attempts: newAttempts },
+    });
+    return NextResponse.json({ error: "코드가 일치하지 않습니다." }, { status: 400 });
+  }
+
+  // 성공 — consumed_at 세팅
+  await prisma.emailVerification.update({
+    where: { verification_id: row.verification_id },
+    data: { attempts: newAttempts, consumed_at: new Date() },
+  });
+
+  const token = signSignupVerificationToken(email);
+  return NextResponse.json({
+    ok: true,
+    signupVerificationToken: token,
+    expiresAt: new Date(Date.now() + SIGNUP_TOKEN_EXPIRES_MINUTES * 60 * 1000).toISOString(),
+  });
+}

--- a/apps/api/src/app/api/auth/find-id/route.ts
+++ b/apps/api/src/app/api/auth/find-id/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@plawcess/database";
+import { getEmailSender, EmailDeliveryError } from "@/lib/email/sender";
+import { findIdMail } from "@/lib/email/templates";
+
+export async function POST(req: NextRequest) {
+  let body: { email?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "요청 형식이 올바르지 않습니다." }, { status: 400 });
+  }
+
+  const { email } = body;
+  if (!email) {
+    return NextResponse.json({ error: "이메일을 입력해주세요." }, { status: 400 });
+  }
+
+  const user = await prisma.user.findFirst({
+    where: { email, is_deleted: false },
+    select: { login_id: true },
+  });
+
+  // 계정 존재 여부 노출 방지 — 항상 동일한 응답
+  if (user?.login_id) {
+    try {
+      await getEmailSender().send({ to: email, ...findIdMail(user.login_id) });
+    } catch (e) {
+      if (e instanceof EmailDeliveryError) {
+        return NextResponse.json({ error: "메일 발송에 실패했습니다." }, { status: 502 });
+      }
+      throw e;
+    }
+  }
+
+  return NextResponse.json({ message: "입력하신 이메일로 아이디를 발송했습니다." });
+}

--- a/apps/api/src/app/api/auth/signup/route.ts
+++ b/apps/api/src/app/api/auth/signup/route.ts
@@ -2,28 +2,50 @@ import { NextRequest, NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
 import { prisma } from "@plawcess/database";
 import { signToken, makeAuthCookie } from "@/lib/auth";
+import { verifySignupVerificationToken } from "@/lib/auth-tokens";
 
 const LOGIN_ID_REGEX = /^[a-zA-Z0-9_]{4,30}$/;
+const STUDENT_ID_REGEX = /^[a-zA-Z0-9]{4,20}$/;
 
 export async function POST(req: NextRequest) {
-  let body: { name?: string; loginId?: string; email?: string; password?: string };
+  let body: {
+    name?: string;
+    loginId?: string;
+    email?: string;
+    password?: string;
+    studentId?: string;
+    signupVerificationToken?: string;
+  };
   try {
     body = await req.json();
   } catch {
     return NextResponse.json({ error: "요청 형식이 올바르지 않습니다." }, { status: 400 });
   }
 
-  const { name, loginId, email, password } = body;
-  if (!name || !loginId || !email || !password) {
-    return NextResponse.json({ error: "이름, 아이디, 이메일, 비밀번호는 필수입니다." }, { status: 400 });
+  const { name, loginId, email, password, studentId, signupVerificationToken } = body;
+  if (!name || !loginId || !email || !password || !studentId || !signupVerificationToken) {
+    return NextResponse.json(
+      { error: "이름·아이디·이메일·비밀번호·학번·이메일 인증 토큰은 필수입니다." },
+      { status: 400 },
+    );
   }
   if (!LOGIN_ID_REGEX.test(loginId)) {
     return NextResponse.json({ error: "아이디는 영문/숫자/언더스코어 4~30자여야 합니다." }, { status: 400 });
+  }
+  if (!STUDENT_ID_REGEX.test(studentId)) {
+    return NextResponse.json({ error: "학번은 영문/숫자 4~20자여야 합니다." }, { status: 400 });
   }
   if (password.length < 8) {
     return NextResponse.json({ error: "비밀번호는 8자 이상이어야 합니다." }, { status: 400 });
   }
 
+  // 이메일 인증 토큰 검증
+  const payload = verifySignupVerificationToken(signupVerificationToken);
+  if (!payload || payload.email !== email) {
+    return NextResponse.json({ error: "이메일 인증이 만료되었거나 유효하지 않습니다." }, { status: 401 });
+  }
+
+  // 중복 재검 (race 방어)
   const [emailDup, loginIdDup] = await Promise.all([
     prisma.user.findUnique({ where: { email } }),
     prisma.user.findUnique({ where: { login_id: loginId } }),
@@ -38,14 +60,30 @@ export async function POST(req: NextRequest) {
   const password_hash = await bcrypt.hash(password, 12);
 
   const user = await prisma.user.create({
-    data: { name, login_id: loginId, email, password_hash, current_role: "mentee", military_status: "not_applicable" },
-    select: { user_id: true, name: true, login_id: true, email: true, current_role: true, military_status: true },
+    data: {
+      name,
+      login_id: loginId,
+      email,
+      password_hash,
+      student_id: studentId,
+      current_role: "mentee",
+      military_status: "not_applicable",
+    },
+    select: {
+      user_id: true,
+      name: true,
+      login_id: true,
+      email: true,
+      student_id: true,
+      current_role: true,
+      military_status: true,
+    },
   });
 
   const token = signToken({ user_id: user.user_id, current_role: user.current_role });
 
   return NextResponse.json(
     { user },
-    { status: 201, headers: { "Set-Cookie": makeAuthCookie(token) } }
+    { status: 201, headers: { "Set-Cookie": makeAuthCookie(token) } },
   );
 }

--- a/apps/api/src/lib/auth-tokens.ts
+++ b/apps/api/src/lib/auth-tokens.ts
@@ -1,0 +1,29 @@
+import jwt from "jsonwebtoken";
+
+const JWT_SECRET = process.env.JWT_SECRET!;
+const ISSUER = "pLAWcess";
+
+const SIGNUP_VERIFICATION_AUDIENCE = "email-verification:signup";
+
+export type SignupVerificationPayload = {
+  email: string;
+};
+
+export function signSignupVerificationToken(email: string): string {
+  return jwt.sign({ email } satisfies SignupVerificationPayload, JWT_SECRET, {
+    expiresIn: "10m",
+    issuer: ISSUER,
+    audience: SIGNUP_VERIFICATION_AUDIENCE,
+  });
+}
+
+export function verifySignupVerificationToken(token: string): SignupVerificationPayload | null {
+  try {
+    return jwt.verify(token, JWT_SECRET, {
+      issuer: ISSUER,
+      audience: SIGNUP_VERIFICATION_AUDIENCE,
+    }) as SignupVerificationPayload;
+  } catch {
+    return null;
+  }
+}

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -4,6 +4,8 @@ import { NextRequest } from "next/server";
 const JWT_SECRET = process.env.JWT_SECRET!;
 const COOKIE_NAME = "plawcess_token";
 const EXPIRES_IN = "7d";
+const ISSUER = "pLAWcess";
+const SESSION_AUDIENCE = "session";
 
 export type TokenPayload = {
   user_id: string;
@@ -11,11 +13,17 @@ export type TokenPayload = {
 };
 
 export function signToken(payload: TokenPayload): string {
-  return jwt.sign(payload, JWT_SECRET, { expiresIn: EXPIRES_IN });
+  return jwt.sign(payload, JWT_SECRET, {
+    expiresIn: EXPIRES_IN,
+    issuer: ISSUER,
+    audience: SESSION_AUDIENCE,
+  });
 }
 
 export function verifyToken(token: string): TokenPayload | null {
   try {
+    // audience 미강제: 기존 세션 토큰(audience 없음) 호환을 위해.
+    // 토큰 종류 변환 공격은 verification·reset 토큰의 verify 함수가 자체 audience 강제로 차단.
     return jwt.verify(token, JWT_SECRET) as TokenPayload;
   } catch {
     return null;

--- a/apps/api/src/lib/email/code.ts
+++ b/apps/api/src/lib/email/code.ts
@@ -1,0 +1,70 @@
+import { randomInt } from "crypto";
+import bcrypt from "bcryptjs";
+import { prisma } from "@plawcess/database";
+
+export const CODE_EXPIRES_MINUTES = 5;
+export const RESET_TOKEN_EXPIRES_MINUTES = 10;
+export const SIGNUP_TOKEN_EXPIRES_MINUTES = 10;
+export const SEND_COOLDOWN_SECONDS = 60;
+export const SEND_HOURLY_LIMIT = 5;
+export const VERIFY_MAX_ATTEMPTS = 5;
+
+type Purpose = "signup" | "reset_password";
+
+export function generateSixDigitCode(): string {
+  return randomInt(0, 1_000_000).toString().padStart(6, "0");
+}
+
+export async function hashCode(code: string): Promise<string> {
+  return bcrypt.hash(code, 10);
+}
+
+export async function compareCode(code: string, hash: string): Promise<boolean> {
+  return bcrypt.compare(code, hash);
+}
+
+export class RateLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RateLimitError";
+  }
+}
+
+/**
+ * 발송 rate limit 검사. 위반 시 RateLimitError throw.
+ * - 60초 쿨다운: 직전 created_at 이 60초 이내
+ * - 시간당 5회: 직전 1시간 내 created_at 카운트 ≥ 5
+ */
+export async function assertSendRateLimit(email: string, purpose: Purpose): Promise<void> {
+  const now = new Date();
+  const cooldownThreshold = new Date(now.getTime() - SEND_COOLDOWN_SECONDS * 1000);
+  const hourThreshold = new Date(now.getTime() - 60 * 60 * 1000);
+
+  const recent = await prisma.emailVerification.findFirst({
+    where: { email, purpose, created_at: { gte: cooldownThreshold } },
+    orderBy: { created_at: "desc" },
+  });
+  if (recent) {
+    throw new RateLimitError("잠시 후 다시 시도해주세요.");
+  }
+  const hourCount = await prisma.emailVerification.count({
+    where: { email, purpose, created_at: { gte: hourThreshold } },
+  });
+  if (hourCount >= SEND_HOURLY_LIMIT) {
+    throw new RateLimitError("발송 한도를 초과했습니다.");
+  }
+}
+
+/**
+ * 가장 최근 미consumed·미만료 EmailVerification 행 조회.
+ */
+export async function findLatestActiveVerification(email: string, purpose: Purpose) {
+  return prisma.emailVerification.findFirst({
+    where: { email, purpose, consumed_at: null, expires_at: { gt: new Date() } },
+    orderBy: { created_at: "desc" },
+  });
+}
+
+export function getClientIp(headers: Headers): string {
+  return headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? headers.get("x-real-ip") ?? "unknown";
+}

--- a/apps/api/src/lib/email/console.ts
+++ b/apps/api/src/lib/email/console.ts
@@ -1,0 +1,11 @@
+import { EmailSender } from "./sender";
+
+export class ConsoleEmailSender implements EmailSender {
+  async send(input: { to: string; subject: string; text: string; html: string }): Promise<void> {
+    if (process.env.NODE_ENV === "production") {
+      throw new Error("ConsoleEmailSender 는 운영 환경에서 사용 금지 — RESEND_API_KEY 미설정");
+    }
+    // eslint-disable-next-line no-console
+    console.log("[EMAIL]", { to: input.to, subject: input.subject, text: input.text });
+  }
+}

--- a/apps/api/src/lib/email/resend.ts
+++ b/apps/api/src/lib/email/resend.ts
@@ -1,0 +1,21 @@
+import { Resend } from "resend";
+import { EmailSender, EmailDeliveryError } from "./sender";
+
+export class ResendEmailSender implements EmailSender {
+  private client: Resend;
+  constructor(apiKey: string, private from: string) {
+    this.client = new Resend(apiKey);
+  }
+  async send(input: { to: string; subject: string; text: string; html: string }): Promise<void> {
+    const { error } = await this.client.emails.send({
+      from: this.from,
+      to: input.to,
+      subject: input.subject,
+      text: input.text,
+      html: input.html,
+    });
+    if (error) {
+      throw new EmailDeliveryError(`Resend 발송 실패: ${error.message ?? "unknown"}`, error);
+    }
+  }
+}

--- a/apps/api/src/lib/email/sender.ts
+++ b/apps/api/src/lib/email/sender.ts
@@ -1,0 +1,28 @@
+import { ResendEmailSender } from "./resend";
+import { ConsoleEmailSender } from "./console";
+
+export interface EmailSender {
+  send(input: { to: string; subject: string; text: string; html: string }): Promise<void>;
+}
+
+export class EmailDeliveryError extends Error {
+  constructor(message: string, public cause?: unknown) {
+    super(message);
+    this.name = "EmailDeliveryError";
+  }
+}
+
+let cached: EmailSender | null = null;
+
+export function getEmailSender(): EmailSender {
+  if (cached) return cached;
+  if (process.env.RESEND_API_KEY) {
+    cached = new ResendEmailSender(
+      process.env.RESEND_API_KEY,
+      process.env.MAIL_FROM ?? "pLAWcess <onboarding@resend.dev>",
+    );
+  } else {
+    cached = new ConsoleEmailSender();
+  }
+  return cached;
+}

--- a/apps/api/src/lib/email/templates.ts
+++ b/apps/api/src/lib/email/templates.ts
@@ -1,0 +1,12 @@
+type MailContent = { subject: string; text: string; html: string };
+
+const FOOTER_TEXT = "\n\n요청하지 않으셨다면 이 메일을 무시해주세요.\n— pLAWcess";
+const FOOTER_HTML = `<p style="color:#888;font-size:12px;margin-top:24px;">요청하지 않으셨다면 이 메일을 무시해주세요.<br/>— pLAWcess</p>`;
+
+export function signupCodeMail(code: string): MailContent {
+  return {
+    subject: "[pLAWcess] 회원가입 인증 코드",
+    text: `인증 코드는 ${code} 입니다. 5분 안에 입력해주세요.${FOOTER_TEXT}`,
+    html: `<div style="font-family:sans-serif;font-size:15px;">인증 코드는 <strong style="font-size:20px;">${code}</strong> 입니다.<br/>5분 안에 입력해주세요.${FOOTER_HTML}</div>`,
+  };
+}

--- a/apps/api/src/lib/email/templates.ts
+++ b/apps/api/src/lib/email/templates.ts
@@ -3,6 +3,14 @@ type MailContent = { subject: string; text: string; html: string };
 const FOOTER_TEXT = "\n\n요청하지 않으셨다면 이 메일을 무시해주세요.\n— pLAWcess";
 const FOOTER_HTML = `<p style="color:#888;font-size:12px;margin-top:24px;">요청하지 않으셨다면 이 메일을 무시해주세요.<br/>— pLAWcess</p>`;
 
+export function findIdMail(loginId: string): MailContent {
+  return {
+    subject: "[pLAWcess] 아이디 찾기 안내",
+    text: `회원님의 아이디는 "${loginId}" 입니다.${FOOTER_TEXT}`,
+    html: `<div style="font-family:sans-serif;font-size:15px;">회원님의 아이디는 <strong style="font-size:18px;">${loginId}</strong> 입니다.${FOOTER_HTML}</div>`,
+  };
+}
+
 export function signupCodeMail(code: string): MailContent {
   return {
     subject: "[pLAWcess] 회원가입 인증 코드",

--- a/apps/web/src/app/find-id/page.tsx
+++ b/apps/web/src/app/find-id/page.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import Footer from '@/components/layout/Footer';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? '';
+
+export default function FindIdPage() {
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+
+    let res: Response;
+    try {
+      res = await fetch(`${API_BASE}/api/auth/find-id`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+    } catch {
+      setError('서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.');
+      setLoading(false);
+      return;
+    }
+
+    setLoading(false);
+
+    if (!res.ok) {
+      const data = await res.json();
+      setError(data.error ?? '오류가 발생했습니다.');
+      return;
+    }
+
+    setSubmitted(true);
+  }
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <header className="sticky top-0 z-50 h-16 bg-white border-b border-border flex items-center px-6 shrink-0">
+        <Link href="/" className="text-brand font-bold text-lg tracking-tight">
+          pLAWcess
+        </Link>
+      </header>
+      <main className="flex-1 bg-page-bg flex justify-center items-start px-4 pt-20">
+        <div className="w-full max-w-sm py-16">
+          <div className="text-center mb-8">
+            <h1 className="text-2xl font-bold text-text-primary">아이디 찾기</h1>
+            <p className="mt-2 text-sm text-text-secondary">
+              가입 시 사용한 이메일을 입력하시면 아이디를 보내드립니다.
+            </p>
+          </div>
+
+          <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-8">
+            {submitted ? (
+              <div className="text-center flex flex-col gap-4">
+                <p className="text-sm text-text-primary">
+                  입력하신 이메일로 아이디를 발송했습니다.<br />
+                  메일함을 확인해주세요.
+                </p>
+                <Link href="/login" className="text-sm text-brand hover:underline font-medium">
+                  로그인으로 돌아가기
+                </Link>
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+                <div className="flex flex-col gap-1.5">
+                  <label htmlFor="email" className="text-sm font-medium text-text-primary">
+                    이메일
+                  </label>
+                  <input
+                    id="email"
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    placeholder="가입 시 사용한 이메일"
+                    required
+                    className="w-full px-3 py-2.5 text-sm border border-border-input rounded-md bg-white text-text-primary placeholder:text-text-placeholder focus:outline-none focus:border-brand transition-colors"
+                  />
+                </div>
+
+                {error && <p className="text-sm text-red-500">{error}</p>}
+
+                <button
+                  type="submit"
+                  disabled={loading}
+                  className="w-full py-2.5 text-sm font-semibold text-white bg-brand rounded-md hover:bg-brand-dark transition-colors mt-1 disabled:opacity-50"
+                >
+                  {loading ? '발송 중...' : '아이디 찾기'}
+                </button>
+
+                <p className="text-center text-sm text-text-secondary">
+                  <Link href="/login" className="text-brand hover:underline font-medium">
+                    로그인으로 돌아가기
+                  </Link>
+                </p>
+              </form>
+            )}
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -154,6 +154,15 @@ export default function LoginPage() {
                 </button>
               )}
 
+              <p className="text-center text-sm text-text-secondary flex justify-center gap-4">
+                <Link href="/find-id" className="text-brand hover:underline font-medium">
+                  아이디 찾기
+                </Link>
+                <Link href="/forgot-password" className="text-brand hover:underline font-medium">
+                  비밀번호 찾기
+                </Link>
+              </p>
+
               <p className="text-center text-sm text-text-secondary">
                 계정이 없으신가요?{' '}
                 <Link href="/signup" className="text-brand hover:underline font-medium">

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -1,14 +1,15 @@
 'use client';
 
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import Footer from '@/components/layout/Footer';
 
 const API_BASE = '';
+const COOLDOWN_SEC = 60;
 
 type Role = 'mentee' | 'mentor';
-type Gender = 'male' | 'female';
+type EmailVerifyState = 'idle' | 'sent' | 'verified';
 
 type FormState = {
   role: Role;
@@ -17,8 +18,7 @@ type FormState = {
   email: string;
   password: string;
   passwordConfirm: string;
-  birthDate: string;       // YYYY.MM.DD.
-  gender: Gender | '';
+  birthDate: string;
   phone: string;
   studentId: string;
   enrollmentFile: File | null;
@@ -37,7 +37,6 @@ const EMPTY_FORM: FormState = {
   password: '',
   passwordConfirm: '',
   birthDate: '',
-  gender: '',
   phone: '',
   studentId: '',
   enrollmentFile: null,
@@ -60,24 +59,38 @@ export default function SignupPage() {
   const [checkLoading, setCheckLoading] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  // 이메일 인증
+  const [emailVerifyState, setEmailVerifyState] = useState<EmailVerifyState>('idle');
+  const [emailVerifyError, setEmailVerifyError] = useState('');
+  const [code, setCode] = useState('');
+  const [sendLoading, setSendLoading] = useState(false);
+  const [verifyLoading, setVerifyLoading] = useState(false);
+  const [signupVerificationToken, setSignupVerificationToken] = useState('');
+  const [cooldown, setCooldown] = useState(0);
+
+  useEffect(() => {
+    if (cooldown <= 0) return;
+    const id = setInterval(() => setCooldown((c) => Math.max(0, c - 1)), 1000);
+    return () => clearInterval(id);
+  }, [cooldown]);
+
   function update<K extends keyof FormState>(key: K, value: FormState[K]) {
     setForm((prev) => ({ ...prev, [key]: value }));
-    // loginId 변경 시 체크 결과 초기화
-    if (key === 'loginId') {
-      setCheckResult(null);
+    if (key === 'loginId') setCheckResult(null);
+    if (key === 'email') {
+      setEmailVerifyState('idle');
+      setEmailVerifyError('');
+      setCode('');
+      setSignupVerificationToken('');
+      setCooldown(0);
     }
   }
 
   async function handleCheckLoginId() {
     const { loginId } = form;
-    if (!loginId) {
-      setError('아이디를 입력해주세요.');
-      return;
-    }
-
+    if (!loginId) { setError('아이디를 입력해주세요.'); return; }
     setCheckLoading(true);
     setError('');
-
     try {
       const res = await fetch(`${API_BASE}/api/auth/check-login-id`, {
         method: 'POST',
@@ -85,35 +98,67 @@ export default function SignupPage() {
         credentials: 'include',
         body: JSON.stringify({ loginId }),
       });
-
       const data = await res.json();
-
       if (!res.ok) {
-        setCheckResult({
-          ok: false,
-          message: '아이디 형식이 올바르지 않습니다. (영문/숫자/언더스코어 4~30자)',
-        });
+        setCheckResult({ ok: false, message: '아이디 형식이 올바르지 않습니다. (영문/숫자/언더스코어 4~30자)' });
         return;
       }
-
-      if (data.available) {
-        setCheckResult({
-          ok: true,
-          message: '사용 가능한 아이디입니다.',
-        });
-      } else {
-        setCheckResult({
-          ok: false,
-          message: '이미 사용 중인 아이디입니다.',
-        });
-      }
-    } catch (err) {
       setCheckResult({
-        ok: false,
-        message: '중복 확인에 실패했습니다. 다시 시도해주세요.',
+        ok: data.available,
+        message: data.available ? '사용 가능한 아이디입니다.' : '이미 사용 중인 아이디입니다.',
       });
+    } catch {
+      setCheckResult({ ok: false, message: '중복 확인에 실패했습니다. 다시 시도해주세요.' });
     } finally {
       setCheckLoading(false);
+    }
+  }
+
+  async function handleSendCode() {
+    if (!form.email) { setEmailVerifyError('이메일을 입력해주세요.'); return; }
+    setEmailVerifyError('');
+    setSendLoading(true);
+    try {
+      const res = await fetch(`${API_BASE}/api/auth/email/send-verification`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ purpose: 'signup', email: form.email }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setEmailVerifyError(data.error ?? '코드 발송에 실패했습니다.');
+        return;
+      }
+      setEmailVerifyState('sent');
+      setCooldown(COOLDOWN_SEC);
+    } catch {
+      setEmailVerifyError('서버에 연결할 수 없습니다.');
+    } finally {
+      setSendLoading(false);
+    }
+  }
+
+  async function handleVerifyCode() {
+    if (!code) { setEmailVerifyError('인증 코드를 입력해주세요.'); return; }
+    setEmailVerifyError('');
+    setVerifyLoading(true);
+    try {
+      const res = await fetch(`${API_BASE}/api/auth/email/verify-code`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: form.email, purpose: 'signup', code }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setEmailVerifyError(data.error ?? '인증에 실패했습니다.');
+        return;
+      }
+      setSignupVerificationToken(data.signupVerificationToken);
+      setEmailVerifyState('verified');
+    } catch {
+      setEmailVerifyError('서버에 연결할 수 없습니다.');
+    } finally {
+      setVerifyLoading(false);
     }
   }
 
@@ -130,28 +175,16 @@ export default function SignupPage() {
     e.preventDefault();
     setError('');
 
-    if (!checkResult?.ok) {
-      setError('아이디 중복확인을 해주세요.');
-      return;
-    }
-
-    if (form.password !== form.passwordConfirm) {
-      setError('비밀번호가 일치하지 않습니다.');
-      return;
-    }
+    if (!checkResult?.ok) { setError('아이디 중복확인을 해주세요.'); return; }
+    if (emailVerifyState !== 'verified') { setError('이메일 인증을 완료해주세요.'); return; }
+    if (form.password !== form.passwordConfirm) { setError('비밀번호가 일치하지 않습니다.'); return; }
     if (!/^\d{4}\.\d{2}\.\d{2}\.$/.test(form.birthDate)) {
       setError('생년월일은 YYYY.MM.DD. 형식으로 입력해주세요.');
-      return;
-    }
-    if (!form.gender) {
-      setError('성별을 선택해주세요.');
       return;
     }
 
     setLoading(true);
 
-    // #120: loginId까지 BE 지원. birthDate/gender/phone/studentId/enrollmentFile/role은
-    //       추후 BE 확장 시 추가 (#83 이메일 인증, 학번/재학증명서 처리 등 별도 이슈)
     const res = await fetch(`${API_BASE}/api/auth/signup`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -161,6 +194,8 @@ export default function SignupPage() {
         loginId: form.loginId,
         email: form.email,
         password: form.password,
+        studentId: form.studentId,
+        signupVerificationToken,
       }),
     });
 
@@ -199,9 +234,7 @@ export default function SignupPage() {
                     type="button"
                     onClick={() => update('role', r)}
                     className={`py-2.5 text-sm font-medium rounded-md transition-colors ${
-                      form.role === r
-                        ? 'bg-brand text-white'
-                        : 'text-text-secondary hover:text-text-primary'
+                      form.role === r ? 'bg-brand text-white' : 'text-text-secondary hover:text-text-primary'
                     }`}
                   >
                     {r === 'mentee' ? '멘티' : '멘토'}
@@ -220,10 +253,10 @@ export default function SignupPage() {
                   required
                   className={inputClass}
                 />
-              
               </Field>
-              {/* 학부생 학번 */}
-              <Field label="학부생 학번" htmlFor="studentId">
+
+              {/* 학부 학번 */}
+              <Field label="학부 학번" htmlFor="studentId">
                 <input
                   id="studentId"
                   type="text"
@@ -263,7 +296,7 @@ export default function SignupPage() {
                 )}
               </Field>
 
-              {/* 이메일 + 인증하기 */}
+              {/* 이메일 + 인증 */}
               <Field label="이메일" htmlFor="email">
                 <div className="flex gap-2">
                   <input
@@ -273,16 +306,53 @@ export default function SignupPage() {
                     onChange={(e) => update('email', e.target.value)}
                     placeholder="your.email@example.com"
                     required
-                    className={`${inputClass} flex-1`}
+                    disabled={emailVerifyState === 'verified'}
+                    className={`${inputClass} flex-1 disabled:opacity-60`}
                   />
                   <button
                     type="button"
-                    onClick={() => alert('이메일 인증 기능은 곧 추가됩니다.')}
-                    className="px-4 py-2.5 text-sm font-medium text-white bg-brand rounded-md hover:bg-brand-dark transition-colors whitespace-nowrap"
+                    onClick={handleSendCode}
+                    disabled={!form.email || sendLoading || cooldown > 0 || emailVerifyState === 'verified'}
+                    className="px-4 py-2.5 text-sm font-medium text-white bg-brand rounded-md hover:bg-brand-dark transition-colors whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed"
                   >
-                    인증하기
+                    {sendLoading
+                      ? '발송 중...'
+                      : cooldown > 0
+                      ? `${cooldown}초 후 재발송`
+                      : emailVerifyState === 'sent'
+                      ? '재발송'
+                      : '인증 코드 발송'}
                   </button>
                 </div>
+
+                {emailVerifyState === 'sent' && (
+                  <div className="flex gap-2 mt-1">
+                    <input
+                      type="text"
+                      inputMode="numeric"
+                      value={code}
+                      onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+                      placeholder="6자리 코드 입력"
+                      maxLength={6}
+                      className={`${inputClass} flex-1 tracking-widest`}
+                    />
+                    <button
+                      type="button"
+                      onClick={handleVerifyCode}
+                      disabled={code.length !== 6 || verifyLoading}
+                      className="px-4 py-2.5 text-sm font-medium text-white bg-brand rounded-md hover:bg-brand-dark transition-colors whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {verifyLoading ? '확인 중...' : '확인'}
+                    </button>
+                  </div>
+                )}
+
+                {emailVerifyState === 'verified' && (
+                  <p className="text-xs text-green-600">이메일 인증이 완료되었습니다.</p>
+                )}
+                {emailVerifyError && (
+                  <p className="text-xs text-red-500">{emailVerifyError}</p>
+                )}
               </Field>
 
               {/* 비밀번호 */}
@@ -325,46 +395,16 @@ export default function SignupPage() {
                 />
               </Field>
 
-              {/* 성별 */}
-              <Field label="성별">
-                <div className="grid grid-cols-2 gap-1 p-1 bg-page-bg rounded-md">
-                  {(['male', 'female'] as const).map((g) => (
-                    <button
-                      key={g}
-                      type="button"
-                      onClick={() => update('gender', g)}
-                      className={`py-2.5 text-sm font-medium rounded-md transition-colors ${
-                        form.gender === g
-                          ? 'bg-brand text-white'
-                          : 'text-text-secondary hover:text-text-primary'
-                      }`}
-                    >
-                      {g === 'male' ? '남성' : '여성'}
-                    </button>
-                  ))}
-                </div>
-              </Field>
-
-              {/* 전화번호 + SMS 인증 */}
+              {/* 전화번호 */}
               <Field label="전화번호" htmlFor="phone">
-                <div className="flex gap-2">
-                  <input
-                    id="phone"
-                    type="tel"
-                    value={form.phone}
-                    onChange={(e) => update('phone', e.target.value)}
-                    placeholder="010-0000-0000"
-                    required
-                    className={`${inputClass} flex-1`}
-                  />
-                  <button
-                    type="button"
-                    onClick={() => alert('SMS 인증 기능은 곧 추가됩니다.')}
-                    className="px-4 py-2.5 text-sm font-medium text-white bg-brand rounded-md hover:bg-brand-dark transition-colors whitespace-nowrap"
-                  >
-                    SMS 인증
-                  </button>
-                </div>
+                <input
+                  id="phone"
+                  type="tel"
+                  value={form.phone}
+                  onChange={(e) => update('phone', e.target.value)}
+                  placeholder="010-0000-0000"
+                  className={inputClass}
+                />
               </Field>
 
               {/* 학부 재학증명서 업로드 */}

--- a/docs/api/api-spec.md
+++ b/docs/api/api-spec.md
@@ -58,6 +58,66 @@
 
 ---
 
+## `/api/auth/email/send-verification` — POST (#83)
+
+회원가입용 6자리 코드 메일 발송. (비밀번호 재설정 분기는 #84 에서 추가)
+
+**Body:** `{ purpose: "signup", email: string }`
+
+**처리:**
+- `User.email` 중복 시 409 (가입 시점 enumeration 허용)
+- Rate limit: 동일 (email, purpose) 60초 쿨다운, 시간당 5회 → 위반 시 429
+- Resend 발송 후 `EmailVerification` INSERT (`expires_at = now+5분`)
+
+**Response 200:** `{ sent: true, expiresAt: ISO_string }`
+
+**Errors:**
+- 400: 요청 형식 오류 / purpose 미지원
+- 409: 이미 사용 중인 이메일
+- 429: 쿨다운/한도 초과
+- 502: 메일 발송 실패
+
+---
+
+## `/api/auth/email/verify-code` — POST (#83)
+
+회원가입 코드 검증 + 가입 단계용 짧은 JWT 발급. (비밀번호 재설정 분기는 #84 에서 추가)
+
+**Body:** `{ email, purpose: "signup", code }`
+
+**처리:**
+- (email, purpose) 가장 최근 미consumed·미만료 행 조회
+- `attempts++` → 5회 초과 시 잠금
+- `bcrypt.compare` 실패 시 400
+- 성공 시 `consumed_at = now`
+
+**Response 200:** `{ ok: true, signupVerificationToken: <JWT>, expiresAt }`
+- JWT payload: `{ email }`, audience `email-verification:signup`, 10분
+
+**Errors:**
+- 400: 코드 만료 / 시도 초과 / 코드 불일치 / purpose 미지원
+
+---
+
+## `/api/auth/signup` — POST (수정, #83)
+
+기존 가입 라우트에 학번·이메일 인증 토큰 수용 추가.
+
+**Body:** `{ name, loginId, email, password, studentId, signupVerificationToken }`
+
+- `signupVerificationToken` JWT 검증: audience `email-verification:signup`, `payload.email === body.email` 일치, 만료 미경과
+- `studentId` 검증: 영문/숫자 4~20자
+- 기존 검증(loginId 형식, password 길이, email/loginId 중복)은 그대로
+
+**Response 201:** `{ user: { user_id, name, login_id, email, student_id, current_role, military_status } }` + 세션 쿠키.
+
+**Errors:**
+- 400: 형식 오류 / 학번 형식
+- 401: 이메일 인증 토큰 만료/위조
+- 409: email/loginId 중복
+
+---
+
 ## `/api/mentee/basic-info` — GET / PATCH
 
 멘티 기본정보. `User`(신상) + `MenteeRecord`(사이클 학적·희망학교) 합성.

--- a/docs/superpowers/plans/2026-05-10-email-verification.md
+++ b/docs/superpowers/plans/2026-05-10-email-verification.md
@@ -1,0 +1,1414 @@
+# 이메일 인증 (회원가입 / 아이디·비밀번호 찾기) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 이슈 #83 — Resend 기반 6자리 코드 이메일 인증을 회원가입에 도입하고, 아이디 찾기·비밀번호 재설정 BE 라우트를 신규 추가한다. 학번을 signup 라우트에서 수용한다.
+
+**Architecture:** EmailVerification·PasswordResetToken 두 신규 테이블 + EmailSender 어댑터(Resend / Console) 추상화. 5개 BE 라우트(send-verification·verify-code·signup 확장·find-id·reset-password). JWT audience claim 으로 토큰 종류 분리.
+
+**Tech Stack:** Next.js 16 Route Handlers, Prisma 7, jsonwebtoken, bcryptjs (이미 사용 중), resend (신규), pnpm workspace.
+
+**Spec:** `docs/superpowers/specs/2026-05-10-email-verification-design.md`
+
+**Branch:** `83-feat-회원가입-시-이메일-인증-추가` (이미 들어와 있음)
+
+---
+
+## Pre-flight
+
+- 마이그레이션은 본 PR 머지 후 `prisma migrate deploy` 로 공유 dev DB 에 별도 적용 (memory `feedback_db_migration_discipline`).
+- 본 PR 검증 범위: `prisma generate`, `pnpm --filter api build`, 타입체크, 라우트 등록 확인.
+- E2E curl 검증은 머지·deploy 후 별도 단계.
+- 빌드 시점에 신규 모델(EmailVerification, PasswordResetToken)이 Prisma Client 에 포함돼야 하므로 Task 1 완료 후 `prisma generate` 한 번 실행.
+
+---
+
+## Task 1: Prisma schema + 마이그레이션 SQL
+
+**Files:**
+- Modify: `packages/database/prisma/schema.prisma`
+- Create: `packages/database/prisma/migrations/20260510120000_email_verification/migration.sql`
+
+- [ ] **Step 1: schema.prisma — User 모델에 relation 추가**
+
+기존 User 모델의 relations 블록(`mentee_records`, `mentor_records`, ...)을 찾아 마지막 줄에 추가:
+
+```prisma
+  // relations
+  mentee_records        MenteeRecord[]
+  mentor_records        MentorRecord[]
+  applications          Application[]
+  created_match_results MatchResult[] @relation("MatchCreatedBy")
+  admin_memos           AdminMemo[]
+  password_reset_tokens PasswordResetToken[]
+```
+
+- [ ] **Step 2: schema.prisma — EmailVerificationPurpose enum + EmailVerification 모델 추가**
+
+파일 맨 아래(다른 enum 정의들과 같은 영역, 또는 파일 끝)에 추가:
+
+```prisma
+// ----------------------------------------------------------------
+// 이메일 인증 (#83) — 회원가입·비밀번호 재설정 공통
+// 6자리 코드 발송→검증, bcrypt 해시로 저장, 1회용
+// ----------------------------------------------------------------
+enum EmailVerificationPurpose {
+  signup
+  reset_password
+}
+
+model EmailVerification {
+  verification_id String                    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  email           String                    @db.VarChar(100)
+  purpose         EmailVerificationPurpose
+  code_hash       String                    @db.VarChar(100)
+  expires_at      DateTime
+  attempts        Int                       @default(0)
+  consumed_at     DateTime?
+  created_at      DateTime                  @default(now())
+  ip_address      String?                   @db.VarChar(45)
+
+  @@index([email, purpose, created_at])
+  @@map("email_verifications")
+}
+```
+
+- [ ] **Step 3: schema.prisma — PasswordResetToken 모델 추가**
+
+같은 영역에 이어서:
+
+```prisma
+// ----------------------------------------------------------------
+// 비밀번호 재설정 토큰 (#83)
+// verify-code 통과 → 새 비밀번호 입력 사이를 잇는 1회용 토큰
+// ----------------------------------------------------------------
+model PasswordResetToken {
+  token_id    String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  user_id     String    @db.Uuid
+  token_hash  String    @db.VarChar(100)
+  expires_at  DateTime
+  consumed_at DateTime?
+  created_at  DateTime  @default(now())
+
+  user User @relation(fields: [user_id], references: [user_id], onDelete: Cascade)
+
+  @@index([user_id])
+  @@map("password_reset_tokens")
+}
+```
+
+- [ ] **Step 4: 마이그레이션 디렉터리 생성 + SQL 파일 작성**
+
+`packages/database/prisma/migrations/20260510120000_email_verification/migration.sql` 생성:
+
+```sql
+-- CreateEnum
+CREATE TYPE "EmailVerificationPurpose" AS ENUM ('signup', 'reset_password');
+
+-- CreateTable
+CREATE TABLE "email_verifications" (
+    "verification_id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "email" VARCHAR(100) NOT NULL,
+    "purpose" "EmailVerificationPurpose" NOT NULL,
+    "code_hash" VARCHAR(100) NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "consumed_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "ip_address" VARCHAR(45),
+
+    CONSTRAINT "email_verifications_pkey" PRIMARY KEY ("verification_id")
+);
+
+-- CreateTable
+CREATE TABLE "password_reset_tokens" (
+    "token_id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "user_id" UUID NOT NULL,
+    "token_hash" VARCHAR(100) NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "consumed_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "password_reset_tokens_pkey" PRIMARY KEY ("token_id")
+);
+
+-- CreateIndex
+CREATE INDEX "email_verifications_email_purpose_created_at_idx" ON "email_verifications"("email", "purpose", "created_at");
+
+-- CreateIndex
+CREATE INDEX "password_reset_tokens_user_id_idx" ON "password_reset_tokens"("user_id");
+
+-- AddForeignKey
+ALTER TABLE "password_reset_tokens" ADD CONSTRAINT "password_reset_tokens_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("user_id") ON DELETE CASCADE ON UPDATE CASCADE;
+```
+
+- [ ] **Step 5: prisma generate 실행 (Client 갱신)**
+
+```powershell
+pnpm --filter @plawcess/database exec prisma generate
+```
+Expected: `✔ Generated Prisma Client`
+
+- [ ] **Step 6: 커밋**
+
+```powershell
+git add packages/database/prisma/schema.prisma packages/database/prisma/migrations/20260510120000_email_verification
+git commit -m "feat(#83): EmailVerification·PasswordResetToken 모델 + 마이그레이션 SQL"
+```
+
+---
+
+## Task 2: 환경변수 + resend 패키지 설치
+
+**Files:**
+- Modify: `apps/api/.env.example`
+- Modify: `apps/api/package.json`
+
+- [ ] **Step 1: .env.example 갱신**
+
+`apps/api/.env.example` 전체:
+
+```bash
+DATABASE_URL=""
+DIRECT_URL=""
+JWT_SECRET=""
+GEMINI_API_KEY=""
+
+# 이메일 인증 (#83)
+RESEND_API_KEY=""                              # 미설정 시 콘솔 fallback
+MAIL_FROM="pLAWcess <onboarding@resend.dev>"   # 도메인 인증 후 noreply@<도메인>
+```
+
+- [ ] **Step 2: resend 패키지 설치**
+
+```powershell
+pnpm --filter api add resend
+```
+Expected: `apps/api/package.json` 의 dependencies 에 `"resend": "^x.x.x"` 추가, `pnpm-lock.yaml` 갱신.
+
+- [ ] **Step 3: 커밋**
+
+```powershell
+git add apps/api/.env.example apps/api/package.json pnpm-lock.yaml
+git commit -m "chore(#83): resend 의존성 추가 + .env.example 갱신"
+```
+
+---
+
+## Task 3: lib/email 모듈 (sender·templates·mask·code)
+
+**Files:**
+- Create: `apps/api/src/lib/email/sender.ts`
+- Create: `apps/api/src/lib/email/resend.ts`
+- Create: `apps/api/src/lib/email/console.ts`
+- Create: `apps/api/src/lib/email/templates.ts`
+- Create: `apps/api/src/lib/email/mask.ts`
+- Create: `apps/api/src/lib/email/code.ts`
+
+- [ ] **Step 1: sender.ts — 인터페이스 + 팩토리 + 에러 클래스**
+
+`apps/api/src/lib/email/sender.ts`:
+
+```ts
+import { ResendEmailSender } from "./resend";
+import { ConsoleEmailSender } from "./console";
+
+export interface EmailSender {
+  send(input: { to: string; subject: string; text: string; html: string }): Promise<void>;
+}
+
+export class EmailDeliveryError extends Error {
+  constructor(message: string, public cause?: unknown) {
+    super(message);
+    this.name = "EmailDeliveryError";
+  }
+}
+
+let cached: EmailSender | null = null;
+
+export function getEmailSender(): EmailSender {
+  if (cached) return cached;
+  if (process.env.RESEND_API_KEY) {
+    cached = new ResendEmailSender(process.env.RESEND_API_KEY, process.env.MAIL_FROM ?? "pLAWcess <onboarding@resend.dev>");
+  } else {
+    cached = new ConsoleEmailSender();
+  }
+  return cached;
+}
+```
+
+- [ ] **Step 2: resend.ts — Resend 구현**
+
+`apps/api/src/lib/email/resend.ts`:
+
+```ts
+import { Resend } from "resend";
+import { EmailSender, EmailDeliveryError } from "./sender";
+
+export class ResendEmailSender implements EmailSender {
+  private client: Resend;
+  constructor(apiKey: string, private from: string) {
+    this.client = new Resend(apiKey);
+  }
+  async send(input: { to: string; subject: string; text: string; html: string }): Promise<void> {
+    const { error } = await this.client.emails.send({
+      from: this.from,
+      to: input.to,
+      subject: input.subject,
+      text: input.text,
+      html: input.html,
+    });
+    if (error) {
+      throw new EmailDeliveryError(`Resend 발송 실패: ${error.message ?? "unknown"}`, error);
+    }
+  }
+}
+```
+
+- [ ] **Step 3: console.ts — 개발 fallback**
+
+`apps/api/src/lib/email/console.ts`:
+
+```ts
+import { EmailSender } from "./sender";
+
+export class ConsoleEmailSender implements EmailSender {
+  async send(input: { to: string; subject: string; text: string; html: string }): Promise<void> {
+    if (process.env.NODE_ENV === "production") {
+      throw new Error("ConsoleEmailSender 는 운영 환경에서 사용 금지 — RESEND_API_KEY 미설정");
+    }
+    // eslint-disable-next-line no-console
+    console.log("[EMAIL]", { to: input.to, subject: input.subject, text: input.text });
+  }
+}
+```
+
+- [ ] **Step 4: templates.ts — 3종 메일 본문**
+
+`apps/api/src/lib/email/templates.ts`:
+
+```ts
+type MailContent = { subject: string; text: string; html: string };
+
+const FOOTER_TEXT = "\n\n요청하지 않으셨다면 이 메일을 무시해주세요.\n— pLAWcess";
+const FOOTER_HTML = `<p style="color:#888;font-size:12px;margin-top:24px;">요청하지 않으셨다면 이 메일을 무시해주세요.<br/>— pLAWcess</p>`;
+
+export function signupCodeMail(code: string): MailContent {
+  return {
+    subject: "[pLAWcess] 회원가입 인증 코드",
+    text: `인증 코드는 ${code} 입니다. 5분 안에 입력해주세요.${FOOTER_TEXT}`,
+    html: `<div style="font-family:sans-serif;font-size:15px;">인증 코드는 <strong style="font-size:20px;">${code}</strong> 입니다.<br/>5분 안에 입력해주세요.${FOOTER_HTML}</div>`,
+  };
+}
+
+export function resetPasswordCodeMail(code: string): MailContent {
+  return {
+    subject: "[pLAWcess] 비밀번호 재설정 인증 코드",
+    text: `인증 코드는 ${code} 입니다. 5분 안에 입력해주세요.${FOOTER_TEXT}`,
+    html: `<div style="font-family:sans-serif;font-size:15px;">인증 코드는 <strong style="font-size:20px;">${code}</strong> 입니다.<br/>5분 안에 입력해주세요.${FOOTER_HTML}</div>`,
+  };
+}
+
+export function findIdMail(loginId: string): MailContent {
+  return {
+    subject: "[pLAWcess] 아이디 안내",
+    text: `회원님의 아이디는 ${loginId} 입니다.${FOOTER_TEXT}`,
+    html: `<div style="font-family:sans-serif;font-size:15px;">회원님의 아이디는 <strong>${loginId}</strong> 입니다.${FOOTER_HTML}</div>`,
+  };
+}
+```
+
+- [ ] **Step 5: mask.ts — 이메일 마스킹**
+
+`apps/api/src/lib/email/mask.ts`:
+
+```ts
+/**
+ * 이메일 마스킹: 로컬파트 1~2자는 첫 1자 + ***, 3자 이상은 첫 2자 + ***
+ * 예: a@x.com → a***@x.com, ab@x.com → a***@x.com, hong@gmail.com → ho***@gmail.com
+ */
+export function maskEmail(email: string): string {
+  const at = email.indexOf("@");
+  if (at < 0) return email;
+  const local = email.slice(0, at);
+  const domain = email.slice(at);
+  const visible = local.length >= 3 ? local.slice(0, 2) : local.slice(0, 1);
+  return `${visible}***${domain}`;
+}
+```
+
+- [ ] **Step 6: code.ts — 코드 생성·해시·rate limit 헬퍼**
+
+`apps/api/src/lib/email/code.ts`:
+
+```ts
+import { randomInt } from "crypto";
+import bcrypt from "bcryptjs";
+import { prisma, Prisma } from "@plawcess/database";
+
+export const CODE_EXPIRES_MINUTES = 5;
+export const RESET_TOKEN_EXPIRES_MINUTES = 10;
+export const SIGNUP_TOKEN_EXPIRES_MINUTES = 10;
+export const SEND_COOLDOWN_SECONDS = 60;
+export const SEND_HOURLY_LIMIT = 5;
+export const VERIFY_MAX_ATTEMPTS = 5;
+
+type Purpose = "signup" | "reset_password";
+
+export function generateSixDigitCode(): string {
+  return randomInt(0, 1_000_000).toString().padStart(6, "0");
+}
+
+export async function hashCode(code: string): Promise<string> {
+  return bcrypt.hash(code, 10);
+}
+
+export async function compareCode(code: string, hash: string): Promise<boolean> {
+  return bcrypt.compare(code, hash);
+}
+
+/**
+ * 발송 rate limit 검사. 위반 시 throw.
+ * - 60초 쿨다운: 직전 created_at 이 60초 이내
+ * - 시간당 5회: 직전 1시간 내 created_at 카운트 ≥ 5
+ */
+export async function assertSendRateLimit(email: string, purpose: Purpose): Promise<void> {
+  const now = new Date();
+  const cooldownThreshold = new Date(now.getTime() - SEND_COOLDOWN_SECONDS * 1000);
+  const hourThreshold = new Date(now.getTime() - 60 * 60 * 1000);
+
+  const recent = await prisma.emailVerification.findFirst({
+    where: { email, purpose, created_at: { gte: cooldownThreshold } },
+    orderBy: { created_at: "desc" },
+  });
+  if (recent) {
+    throw new RateLimitError("잠시 후 다시 시도해주세요.");
+  }
+  const hourCount = await prisma.emailVerification.count({
+    where: { email, purpose, created_at: { gte: hourThreshold } },
+  });
+  if (hourCount >= SEND_HOURLY_LIMIT) {
+    throw new RateLimitError("발송 한도를 초과했습니다.");
+  }
+}
+
+export class RateLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RateLimitError";
+  }
+}
+
+/**
+ * 가장 최근 미consumed·미만료 EmailVerification 행 조회.
+ */
+export async function findLatestActiveVerification(email: string, purpose: Purpose) {
+  return prisma.emailVerification.findFirst({
+    where: { email, purpose, consumed_at: null, expires_at: { gt: new Date() } },
+    orderBy: { created_at: "desc" },
+  });
+}
+
+/**
+ * IP 기반 rate limit (find-id 등) — in-process 카운터.
+ * 멀티 인스턴스 환경에서는 인스턴스당 한도가 됨 (spec 위험 항목).
+ */
+const ipCounter = new Map<string, { count: number; resetAt: number }>();
+
+export function assertIpRateLimit(ip: string, key: string, hourlyLimit: number): void {
+  const now = Date.now();
+  const k = `${key}:${ip}`;
+  const entry = ipCounter.get(k);
+  if (!entry || entry.resetAt < now) {
+    ipCounter.set(k, { count: 1, resetAt: now + 60 * 60 * 1000 });
+    return;
+  }
+  if (entry.count >= hourlyLimit) {
+    throw new RateLimitError("시간당 시도 한도를 초과했습니다.");
+  }
+  entry.count += 1;
+}
+
+export function getClientIp(headers: Headers): string {
+  return headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? headers.get("x-real-ip") ?? "unknown";
+}
+
+// 사용 안 함을 막기 위한 type re-export 트릭 — Prisma 타입 의존 외부 노출
+export type { Prisma };
+```
+
+- [ ] **Step 7: 타입체크**
+
+```powershell
+pnpm --filter api exec tsc --noEmit
+```
+Expected: 에러 없음 (라우트 미구현 상태에서도 lib 모듈만으론 컴파일 통과해야 함).
+
+- [ ] **Step 8: 커밋**
+
+```powershell
+git add apps/api/src/lib/email
+git commit -m "feat(#83): lib/email 모듈 — sender 어댑터·템플릿·마스킹·rate limit"
+```
+
+---
+
+## Task 4: lib/auth-tokens.ts (verification·reset 토큰) + auth.ts audience claim
+
+**Files:**
+- Create: `apps/api/src/lib/auth-tokens.ts`
+- Modify: `apps/api/src/lib/auth.ts`
+
+- [ ] **Step 1: auth.ts — signToken 에 audience claim 추가**
+
+`apps/api/src/lib/auth.ts` 의 `signToken` 만 수정 (verifyToken 은 legacy 토큰 호환 위해 audience 검증 추가하지 않음 — 신규 verification·reset 토큰은 별도 함수에서 audience 강제):
+
+```ts
+import jwt from "jsonwebtoken";
+import { NextRequest } from "next/server";
+
+const JWT_SECRET = process.env.JWT_SECRET!;
+const COOKIE_NAME = "plawcess_token";
+const EXPIRES_IN = "7d";
+const ISSUER = "pLAWcess";
+const SESSION_AUDIENCE = "session";
+
+export type TokenPayload = {
+  user_id: string;
+  current_role: string;
+};
+
+export function signToken(payload: TokenPayload): string {
+  return jwt.sign(payload, JWT_SECRET, {
+    expiresIn: EXPIRES_IN,
+    issuer: ISSUER,
+    audience: SESSION_AUDIENCE,
+  });
+}
+
+export function verifyToken(token: string): TokenPayload | null {
+  try {
+    // audience 검증 강제: session 토큰만 통과. legacy(audience 없는) 토큰은 통과시키지 않음.
+    // → 머지 시점 모든 사용자 재로그인 강제. 운영 영향 작음(대시보드 사용자 한정).
+    const decoded = jwt.verify(token, JWT_SECRET, {
+      issuer: ISSUER,
+      audience: SESSION_AUDIENCE,
+    }) as TokenPayload;
+    return decoded;
+  } catch {
+    return null;
+  }
+}
+
+export function getTokenFromCookie(req: NextRequest): TokenPayload | null {
+  const token = req.cookies.get(COOKIE_NAME)?.value;
+  if (!token) return null;
+  return verifyToken(token);
+}
+
+export function makeAuthCookie(token: string): string {
+  const maxAge = 60 * 60 * 24 * 7; // 7일
+  return `${COOKIE_NAME}=${token}; HttpOnly; Path=/; Max-Age=${maxAge}; SameSite=Lax`;
+}
+
+export function makeClearCookie(): string {
+  return `${COOKIE_NAME}=; HttpOnly; Path=/; Max-Age=0; SameSite=Lax`;
+}
+```
+
+> ⚠ 주의: 이 변경은 머지 시점의 모든 기존 세션 토큰을 무효화한다(audience claim 미보유). 사용자는 재로그인 필요. 본 PR description 에 명시.
+
+- [ ] **Step 2: auth-tokens.ts — verification·reset 토큰 헬퍼**
+
+`apps/api/src/lib/auth-tokens.ts`:
+
+```ts
+import jwt from "jsonwebtoken";
+
+const JWT_SECRET = process.env.JWT_SECRET!;
+const ISSUER = "pLAWcess";
+
+const SIGNUP_VERIFICATION_AUDIENCE = "email-verification:signup";
+const PASSWORD_RESET_AUDIENCE = "password-reset";
+
+export type SignupVerificationPayload = {
+  email: string;
+};
+
+export type ResetTokenPayload = {
+  token_id: string;
+  raw: string;
+};
+
+export function signSignupVerificationToken(email: string): string {
+  return jwt.sign({ email } satisfies SignupVerificationPayload, JWT_SECRET, {
+    expiresIn: "10m",
+    issuer: ISSUER,
+    audience: SIGNUP_VERIFICATION_AUDIENCE,
+  });
+}
+
+export function verifySignupVerificationToken(token: string): SignupVerificationPayload | null {
+  try {
+    return jwt.verify(token, JWT_SECRET, {
+      issuer: ISSUER,
+      audience: SIGNUP_VERIFICATION_AUDIENCE,
+    }) as SignupVerificationPayload;
+  } catch {
+    return null;
+  }
+}
+
+export function signResetToken(token_id: string, raw: string): string {
+  return jwt.sign({ token_id, raw } satisfies ResetTokenPayload, JWT_SECRET, {
+    expiresIn: "10m",
+    issuer: ISSUER,
+    audience: PASSWORD_RESET_AUDIENCE,
+  });
+}
+
+export function verifyResetToken(token: string): ResetTokenPayload | null {
+  try {
+    return jwt.verify(token, JWT_SECRET, {
+      issuer: ISSUER,
+      audience: PASSWORD_RESET_AUDIENCE,
+    }) as ResetTokenPayload;
+  } catch {
+    return null;
+  }
+}
+```
+
+- [ ] **Step 3: 타입체크**
+
+```powershell
+pnpm --filter api exec tsc --noEmit
+```
+Expected: 에러 없음.
+
+- [ ] **Step 4: 커밋**
+
+```powershell
+git add apps/api/src/lib/auth.ts apps/api/src/lib/auth-tokens.ts
+git commit -m "feat(#83): JWT audience claim 분리 + verification·reset 토큰 헬퍼"
+```
+
+---
+
+## Task 5: POST /api/auth/email/send-verification
+
+**Files:**
+- Create: `apps/api/src/app/api/auth/email/send-verification/route.ts`
+
+- [ ] **Step 1: 라우트 작성**
+
+`apps/api/src/app/api/auth/email/send-verification/route.ts`:
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@plawcess/database";
+import {
+  generateSixDigitCode, hashCode, assertSendRateLimit, RateLimitError,
+  CODE_EXPIRES_MINUTES, getClientIp,
+} from "@/lib/email/code";
+import { getEmailSender, EmailDeliveryError } from "@/lib/email/sender";
+import { signupCodeMail, resetPasswordCodeMail } from "@/lib/email/templates";
+
+type Body =
+  | { purpose: "signup"; email: string }
+  | { purpose: "reset_password"; name: string; loginId: string; email: string };
+
+export async function POST(req: NextRequest) {
+  let body: Body;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "요청 형식이 올바르지 않습니다." }, { status: 400 });
+  }
+
+  if (!body || typeof body !== "object" || !("purpose" in body)) {
+    return NextResponse.json({ error: "purpose 가 필요합니다." }, { status: 400 });
+  }
+
+  const email = (body as { email?: string }).email;
+  if (!email || typeof email !== "string") {
+    return NextResponse.json({ error: "email 이 필요합니다." }, { status: 400 });
+  }
+
+  const ip = getClientIp(req.headers);
+
+  // purpose 별 사전 검증
+  if (body.purpose === "signup") {
+    const dup = await prisma.user.findUnique({ where: { email }, select: { user_id: true } });
+    if (dup) {
+      return NextResponse.json({ error: "이미 사용 중인 이메일입니다." }, { status: 409 });
+    }
+  } else if (body.purpose === "reset_password") {
+    const { name, loginId } = body;
+    if (!name || !loginId) {
+      return NextResponse.json({ error: "이름·아이디·이메일이 모두 필요합니다." }, { status: 400 });
+    }
+    const user = await prisma.user.findFirst({
+      where: { name, login_id: loginId, email, is_deleted: false },
+      select: { user_id: true },
+    });
+    if (!user) {
+      // enumeration 방어: 200 동일 응답, 메일 미발송
+      return NextResponse.json({
+        sent: true,
+        expiresAt: new Date(Date.now() + CODE_EXPIRES_MINUTES * 60 * 1000).toISOString(),
+      });
+    }
+  } else {
+    return NextResponse.json({ error: "지원하지 않는 purpose 입니다." }, { status: 400 });
+  }
+
+  // rate limit
+  try {
+    await assertSendRateLimit(email, body.purpose);
+  } catch (e) {
+    if (e instanceof RateLimitError) {
+      return NextResponse.json({ error: e.message }, { status: 429 });
+    }
+    throw e;
+  }
+
+  // 코드 생성 + Resend 발송
+  const code = generateSixDigitCode();
+  const mail = body.purpose === "signup" ? signupCodeMail(code) : resetPasswordCodeMail(code);
+  try {
+    await getEmailSender().send({ to: email, ...mail });
+  } catch (e) {
+    if (e instanceof EmailDeliveryError) {
+      return NextResponse.json({ error: "메일 발송에 실패했습니다." }, { status: 502 });
+    }
+    throw e;
+  }
+
+  // 성공 시에만 DB INSERT
+  const expiresAt = new Date(Date.now() + CODE_EXPIRES_MINUTES * 60 * 1000);
+  await prisma.emailVerification.create({
+    data: {
+      email,
+      purpose: body.purpose,
+      code_hash: await hashCode(code),
+      expires_at: expiresAt,
+      ip_address: ip,
+    },
+  });
+
+  return NextResponse.json({ sent: true, expiresAt: expiresAt.toISOString() });
+}
+```
+
+- [ ] **Step 2: 타입체크**
+
+```powershell
+pnpm --filter api exec tsc --noEmit
+```
+Expected: 에러 없음.
+
+- [ ] **Step 3: 커밋**
+
+```powershell
+git add apps/api/src/app/api/auth/email/send-verification
+git commit -m "feat(#83): POST /api/auth/email/send-verification — 가입·재설정 코드 발송"
+```
+
+---
+
+## Task 6: POST /api/auth/email/verify-code
+
+**Files:**
+- Create: `apps/api/src/app/api/auth/email/verify-code/route.ts`
+
+- [ ] **Step 1: 라우트 작성**
+
+`apps/api/src/app/api/auth/email/verify-code/route.ts`:
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import bcrypt from "bcryptjs";
+import { randomBytes } from "crypto";
+import { prisma } from "@plawcess/database";
+import {
+  compareCode, findLatestActiveVerification,
+  VERIFY_MAX_ATTEMPTS, RESET_TOKEN_EXPIRES_MINUTES, SIGNUP_TOKEN_EXPIRES_MINUTES,
+} from "@/lib/email/code";
+import { signSignupVerificationToken, signResetToken } from "@/lib/auth-tokens";
+
+type Body = {
+  email: string;
+  purpose: "signup" | "reset_password";
+  code: string;
+};
+
+export async function POST(req: NextRequest) {
+  let body: Body;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "요청 형식이 올바르지 않습니다." }, { status: 400 });
+  }
+
+  const { email, purpose, code } = body;
+  if (!email || !purpose || !code) {
+    return NextResponse.json({ error: "email·purpose·code 가 모두 필요합니다." }, { status: 400 });
+  }
+  if (purpose !== "signup" && purpose !== "reset_password") {
+    return NextResponse.json({ error: "지원하지 않는 purpose 입니다." }, { status: 400 });
+  }
+
+  const row = await findLatestActiveVerification(email, purpose);
+  if (!row) {
+    return NextResponse.json({ error: "코드가 만료되었거나 발송된 적 없습니다." }, { status: 400 });
+  }
+
+  const newAttempts = row.attempts + 1;
+  if (newAttempts > VERIFY_MAX_ATTEMPTS) {
+    await prisma.emailVerification.update({
+      where: { verification_id: row.verification_id },
+      data: { attempts: newAttempts, consumed_at: new Date() },
+    });
+    return NextResponse.json({ error: "시도 횟수가 초과되었습니다. 새 코드를 발송해주세요." }, { status: 400 });
+  }
+
+  const ok = await compareCode(code, row.code_hash);
+  if (!ok) {
+    await prisma.emailVerification.update({
+      where: { verification_id: row.verification_id },
+      data: { attempts: newAttempts },
+    });
+    return NextResponse.json({ error: "코드가 일치하지 않습니다." }, { status: 400 });
+  }
+
+  // 성공 — consumed_at 세팅
+  await prisma.emailVerification.update({
+    where: { verification_id: row.verification_id },
+    data: { attempts: newAttempts, consumed_at: new Date() },
+  });
+
+  if (purpose === "signup") {
+    const token = signSignupVerificationToken(email);
+    return NextResponse.json({
+      ok: true,
+      signupVerificationToken: token,
+      expiresAt: new Date(Date.now() + SIGNUP_TOKEN_EXPIRES_MINUTES * 60 * 1000).toISOString(),
+    });
+  }
+
+  // reset_password — user 조회 후 reset token 발급
+  const user = await prisma.user.findUnique({ where: { email }, select: { user_id: true } });
+  if (!user) {
+    // 비정상 — verify 통과했는데 user 없음 (사이에 삭제된 경우 등). 실패 처리.
+    return NextResponse.json({ error: "사용자를 찾을 수 없습니다." }, { status: 404 });
+  }
+
+  const raw = randomBytes(32).toString("base64url");
+  const token_hash = await bcrypt.hash(raw, 10);
+  const expiresAt = new Date(Date.now() + RESET_TOKEN_EXPIRES_MINUTES * 60 * 1000);
+  const created = await prisma.passwordResetToken.create({
+    data: { user_id: user.user_id, token_hash, expires_at: expiresAt },
+    select: { token_id: true },
+  });
+
+  const resetToken = signResetToken(created.token_id, raw);
+  return NextResponse.json({
+    ok: true,
+    resetToken,
+    expiresAt: expiresAt.toISOString(),
+  });
+}
+```
+
+- [ ] **Step 2: 타입체크**
+
+```powershell
+pnpm --filter api exec tsc --noEmit
+```
+Expected: 에러 없음.
+
+- [ ] **Step 3: 커밋**
+
+```powershell
+git add apps/api/src/app/api/auth/email/verify-code
+git commit -m "feat(#83): POST /api/auth/email/verify-code — 코드 검증 + 후속 토큰 발급"
+```
+
+---
+
+## Task 7: POST /api/auth/signup 확장 (studentId + signupVerificationToken)
+
+**Files:**
+- Modify: `apps/api/src/app/api/auth/signup/route.ts`
+
+- [ ] **Step 1: 라우트 전체 교체**
+
+`apps/api/src/app/api/auth/signup/route.ts`:
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import bcrypt from "bcryptjs";
+import { prisma } from "@plawcess/database";
+import { signToken, makeAuthCookie } from "@/lib/auth";
+import { verifySignupVerificationToken } from "@/lib/auth-tokens";
+
+const LOGIN_ID_REGEX = /^[a-zA-Z0-9_]{4,30}$/;
+const STUDENT_ID_REGEX = /^[a-zA-Z0-9]{4,20}$/;
+
+export async function POST(req: NextRequest) {
+  let body: {
+    name?: string;
+    loginId?: string;
+    email?: string;
+    password?: string;
+    studentId?: string;
+    signupVerificationToken?: string;
+  };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "요청 형식이 올바르지 않습니다." }, { status: 400 });
+  }
+
+  const { name, loginId, email, password, studentId, signupVerificationToken } = body;
+  if (!name || !loginId || !email || !password || !studentId || !signupVerificationToken) {
+    return NextResponse.json(
+      { error: "이름·아이디·이메일·비밀번호·학번·이메일 인증 토큰은 필수입니다." },
+      { status: 400 },
+    );
+  }
+  if (!LOGIN_ID_REGEX.test(loginId)) {
+    return NextResponse.json({ error: "아이디는 영문/숫자/언더스코어 4~30자여야 합니다." }, { status: 400 });
+  }
+  if (!STUDENT_ID_REGEX.test(studentId)) {
+    return NextResponse.json({ error: "학번은 영문/숫자 4~20자여야 합니다." }, { status: 400 });
+  }
+  if (password.length < 8) {
+    return NextResponse.json({ error: "비밀번호는 8자 이상이어야 합니다." }, { status: 400 });
+  }
+
+  // 이메일 인증 토큰 검증
+  const payload = verifySignupVerificationToken(signupVerificationToken);
+  if (!payload || payload.email !== email) {
+    return NextResponse.json({ error: "이메일 인증이 만료되었거나 유효하지 않습니다." }, { status: 401 });
+  }
+
+  // 중복 재검 (race 방어)
+  const [emailDup, loginIdDup] = await Promise.all([
+    prisma.user.findUnique({ where: { email } }),
+    prisma.user.findUnique({ where: { login_id: loginId } }),
+  ]);
+  if (emailDup) {
+    return NextResponse.json({ error: "이미 사용 중인 이메일입니다." }, { status: 409 });
+  }
+  if (loginIdDup) {
+    return NextResponse.json({ error: "이미 사용 중인 아이디입니다." }, { status: 409 });
+  }
+
+  const password_hash = await bcrypt.hash(password, 12);
+
+  const user = await prisma.user.create({
+    data: {
+      name,
+      login_id: loginId,
+      email,
+      password_hash,
+      student_id: studentId,
+      current_role: "mentee",
+      military_status: "not_applicable",
+    },
+    select: {
+      user_id: true,
+      name: true,
+      login_id: true,
+      email: true,
+      student_id: true,
+      current_role: true,
+      military_status: true,
+    },
+  });
+
+  const token = signToken({ user_id: user.user_id, current_role: user.current_role });
+
+  return NextResponse.json(
+    { user },
+    { status: 201, headers: { "Set-Cookie": makeAuthCookie(token) } },
+  );
+}
+```
+
+- [ ] **Step 2: 타입체크**
+
+```powershell
+pnpm --filter api exec tsc --noEmit
+```
+Expected: 에러 없음.
+
+- [ ] **Step 3: 커밋**
+
+```powershell
+git add apps/api/src/app/api/auth/signup/route.ts
+git commit -m "feat(#83): /api/auth/signup — studentId 수용 + 이메일 인증 토큰 검증"
+```
+
+---
+
+## Task 8: POST /api/auth/find-id
+
+**Files:**
+- Create: `apps/api/src/app/api/auth/find-id/route.ts`
+
+- [ ] **Step 1: 라우트 작성**
+
+`apps/api/src/app/api/auth/find-id/route.ts`:
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@plawcess/database";
+import { assertIpRateLimit, RateLimitError, getClientIp } from "@/lib/email/code";
+import { getEmailSender, EmailDeliveryError } from "@/lib/email/sender";
+import { findIdMail } from "@/lib/email/templates";
+import { maskEmail } from "@/lib/email/mask";
+
+const FIND_ID_HOURLY_LIMIT = 10;
+
+export async function POST(req: NextRequest) {
+  let body: { name?: string; studentId?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "요청 형식이 올바르지 않습니다." }, { status: 400 });
+  }
+
+  const { name, studentId } = body;
+  if (!name || !studentId) {
+    return NextResponse.json({ error: "이름과 학번이 필요합니다." }, { status: 400 });
+  }
+
+  const ip = getClientIp(req.headers);
+  try {
+    assertIpRateLimit(ip, "find-id", FIND_ID_HOURLY_LIMIT);
+  } catch (e) {
+    if (e instanceof RateLimitError) {
+      return NextResponse.json({ error: e.message }, { status: 429 });
+    }
+    throw e;
+  }
+
+  const user = await prisma.user.findFirst({
+    where: { name, student_id: studentId, is_deleted: false },
+    select: { login_id: true, email: true },
+  });
+
+  if (!user || !user.login_id) {
+    return NextResponse.json({ error: "일치하는 회원이 없습니다." }, { status: 404 });
+  }
+
+  // 메일 발송 (실패해도 클라이언트엔 502)
+  try {
+    await getEmailSender().send({ to: user.email, ...findIdMail(user.login_id) });
+  } catch (e) {
+    if (e instanceof EmailDeliveryError) {
+      return NextResponse.json({ error: "메일 발송에 실패했습니다." }, { status: 502 });
+    }
+    throw e;
+  }
+
+  return NextResponse.json({ maskedEmail: maskEmail(user.email) });
+}
+```
+
+- [ ] **Step 2: 타입체크**
+
+```powershell
+pnpm --filter api exec tsc --noEmit
+```
+Expected: 에러 없음.
+
+- [ ] **Step 3: 커밋**
+
+```powershell
+git add apps/api/src/app/api/auth/find-id
+git commit -m "feat(#83): POST /api/auth/find-id — 이름·학번 일치 시 마스킹 이메일 + 아이디 메일"
+```
+
+---
+
+## Task 9: POST /api/auth/reset-password
+
+**Files:**
+- Create: `apps/api/src/app/api/auth/reset-password/route.ts`
+
+- [ ] **Step 1: 라우트 작성**
+
+`apps/api/src/app/api/auth/reset-password/route.ts`:
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import bcrypt from "bcryptjs";
+import { prisma } from "@plawcess/database";
+import { verifyResetToken } from "@/lib/auth-tokens";
+
+export async function POST(req: NextRequest) {
+  let body: { resetToken?: string; newPassword?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "요청 형식이 올바르지 않습니다." }, { status: 400 });
+  }
+
+  const { resetToken, newPassword } = body;
+  if (!resetToken || !newPassword) {
+    return NextResponse.json({ error: "resetToken·newPassword 가 필요합니다." }, { status: 400 });
+  }
+  if (newPassword.length < 8) {
+    return NextResponse.json({ error: "비밀번호는 8자 이상이어야 합니다." }, { status: 400 });
+  }
+
+  const payload = verifyResetToken(resetToken);
+  if (!payload) {
+    return NextResponse.json({ error: "재설정 링크가 만료되었거나 유효하지 않습니다." }, { status: 401 });
+  }
+
+  const row = await prisma.passwordResetToken.findUnique({
+    where: { token_id: payload.token_id },
+    select: { token_id: true, user_id: true, token_hash: true, expires_at: true, consumed_at: true },
+  });
+  if (!row || row.consumed_at !== null || row.expires_at < new Date()) {
+    return NextResponse.json({ error: "재설정 링크가 만료되었거나 사용되었습니다." }, { status: 401 });
+  }
+
+  const ok = await bcrypt.compare(payload.raw, row.token_hash);
+  if (!ok) {
+    return NextResponse.json({ error: "재설정 링크가 만료되었거나 유효하지 않습니다." }, { status: 401 });
+  }
+
+  const password_hash = await bcrypt.hash(newPassword, 12);
+  const now = new Date();
+
+  await prisma.$transaction([
+    prisma.user.update({
+      where: { user_id: row.user_id },
+      data: { password_hash },
+    }),
+    prisma.passwordResetToken.update({
+      where: { token_id: row.token_id },
+      data: { consumed_at: now },
+    }),
+    // 같은 user 의 다른 미사용 reset token 일괄 무효화
+    prisma.passwordResetToken.updateMany({
+      where: { user_id: row.user_id, consumed_at: null, token_id: { not: row.token_id } },
+      data: { consumed_at: now },
+    }),
+  ]);
+
+  return NextResponse.json({ success: true });
+}
+```
+
+- [ ] **Step 2: 타입체크**
+
+```powershell
+pnpm --filter api exec tsc --noEmit
+```
+Expected: 에러 없음.
+
+- [ ] **Step 3: 커밋**
+
+```powershell
+git add apps/api/src/app/api/auth/reset-password
+git commit -m "feat(#83): POST /api/auth/reset-password — reset token 검증 + 비밀번호 변경 + 다른 토큰 무효화"
+```
+
+---
+
+## Task 10: docs/api/api-spec.md 갱신
+
+**Files:**
+- Modify: `docs/api/api-spec.md`
+
+- [ ] **Step 1: api-spec.md 에 5 라우트 섹션 추가**
+
+기존 `## /api/auth/me — GET` 섹션 바로 다음에 다음 5개 섹션을 삽입:
+
+````markdown
+---
+
+## `/api/auth/email/send-verification` — POST (#83)
+
+가입·비밀번호재설정용 6자리 코드 메일 발송.
+
+**Body (purpose 별 분기):**
+```ts
+| { purpose: "signup"; email: string }
+| { purpose: "reset_password"; name: string; loginId: string; email: string }
+```
+
+**처리:**
+- `signup`: User.email 중복 시 409
+- `reset_password`: 이름·아이디·이메일 셋 다 일치 시 발송. 불일치도 200 동일 응답(enumeration 방어), 메일 미발송
+- Rate limit: 동일 (email, purpose) 60초 쿨다운, 시간당 5회 → 위반 시 429
+- Resend 발송 후 `EmailVerification` INSERT (`expires_at = now+5분`)
+
+**Response 200:** `{ sent: true, expiresAt: ISO_string }`
+
+**Errors:**
+- 400: 요청 형식 오류 / purpose 누락
+- 409: 이미 사용 중인 이메일 (signup 만)
+- 429: 쿨다운/한도 초과
+- 502: 메일 발송 실패
+
+---
+
+## `/api/auth/email/verify-code` — POST (#83)
+
+코드 검증 + 후속 토큰 발급.
+
+**Body:** `{ email, purpose: "signup" | "reset_password", code }`
+
+**처리:**
+- (email, purpose) 가장 최근 미consumed·미만료 행 조회
+- attempts++ → 5회 초과 시 잠금
+- bcrypt.compare 실패 시 400
+- 성공 시 consumed_at=now
+
+**Response 200:**
+- `signup`: `{ ok: true, signupVerificationToken: <JWT>, expiresAt }` — payload `{ email }`, audience `email-verification:signup`, 10분
+- `reset_password`: `{ ok: true, resetToken: <JWT>, expiresAt }` + `password_reset_tokens` INSERT(user_id 매핑). JWT payload `{ token_id, raw }`, audience `password-reset`, 10분
+
+**Errors:**
+- 400: 코드 만료 / 시도 초과 / 코드 불일치
+- 404: 사용자 부재 (reset_password 도중 user 삭제 등)
+
+---
+
+## `/api/auth/signup` — POST (수정, #83)
+
+기존 가입 라우트에 학번·이메일 인증 토큰 수용 추가.
+
+**Body:** `{ name, loginId, email, password, studentId, signupVerificationToken }`
+
+- `signupVerificationToken` JWT 검증: audience `email-verification:signup`, payload.email === body.email 일치, 만료 미경과
+- `studentId` 검증: 영문/숫자 4~20자
+- 기존 검증(loginId 형식, password 길이, email/loginId 중복)은 그대로
+
+**Response 201:** `{ user: { user_id, name, login_id, email, student_id, current_role, military_status } }` + 세션 쿠키.
+
+**Errors:**
+- 400: 형식 오류 / 학번 형식
+- 401: 이메일 인증 토큰 만료/위조
+- 409: email/loginId 중복
+
+---
+
+## `/api/auth/find-id` — POST (#83)
+
+이름+학번 일치 시 마스킹된 이메일 응답 + 메일로 아이디 발송.
+
+**Body:** `{ name, studentId }`
+
+**처리:**
+- IP rate limit: 시간당 10회
+- User where { name, student_id, is_deleted: false } 일치 단일 행
+
+**이메일 마스킹 규칙:**
+- 로컬파트 1~2자: 첫 1자 + `***`
+- 로컬파트 3자 이상: 첫 2자 + `***`
+
+**Response 200:** `{ maskedEmail: "ho***@gmail.com" }`
+
+**Errors:**
+- 400: 요청 형식
+- 404: 일치하는 회원 없음
+- 429: IP 한도 초과
+- 502: 메일 발송 실패
+
+---
+
+## `/api/auth/reset-password` — POST (#83)
+
+`reset_token` 검증 후 비밀번호 변경.
+
+**Body:** `{ resetToken, newPassword }`
+
+**처리:**
+- JWT 검증 → token_id 추출
+- `password_reset_tokens` 조회: 미consumed, 미만료
+- bcrypt.compare(raw, token_hash)
+- newPassword.length ≥ 8
+- 트랜잭션: User.password_hash 갱신 + 이 token consumed + 같은 user 의 다른 미사용 reset token 일괄 무효화
+
+**Response 200:** `{ success: true }`
+
+**Errors:**
+- 400: 형식/비밀번호 길이
+- 401: 토큰 만료/사용됨/위조
+````
+
+- [ ] **Step 2: 커밋**
+
+```powershell
+git add docs/api/api-spec.md
+git commit -m "docs(#83): api-spec.md — 이메일 인증·아이디·비번 찾기 5 라우트 추가"
+```
+
+---
+
+## Task 11: 빌드·타입체크 검증
+
+**Files:**
+- Reference only
+
+- [ ] **Step 1: prisma generate (혹시 모를 schema 변경 반영)**
+
+```powershell
+pnpm --filter @plawcess/database exec prisma generate
+```
+Expected: `✔ Generated Prisma Client`
+
+- [ ] **Step 2: api 타입체크**
+
+```powershell
+pnpm --filter api exec tsc --noEmit
+```
+Expected: 에러 없음.
+
+- [ ] **Step 3: api 빌드**
+
+```powershell
+pnpm --filter api build
+```
+Expected: `✓ Compiled successfully`. 출력 라우트 목록에 다음이 보여야 함:
+- `POST /api/auth/email/send-verification`
+- `POST /api/auth/email/verify-code`
+- `POST /api/auth/signup` (기존)
+- `POST /api/auth/find-id`
+- `POST /api/auth/reset-password`
+
+- [ ] **Step 4: 라우트 등록 확인 (grep)**
+
+```powershell
+pnpm --filter api build 2>&1 | Select-String "/api/auth/(email|find-id|reset-password|signup)"
+```
+Expected: 위 5개 경로 모두 출력.
+
+- [ ] **Step 5: 메모리에 검증 결과 기록 — 별도 커밋 없음 (코드 변경 없음)**
+
+E2E curl 검증은 머지·deploy 후 별도 단계. 본 PR 에서는 빌드·타입체크 통과 까지가 검증 범위.
+
+---
+
+## Task 12: push + PR Title/Body 초안 사용자 전달
+
+**Files:**
+- Reference only
+
+> Memory `feedback_pr_body_self_authored`: push 후 URL + Title + Body 초안을 한 메시지로 사용자에게 전달.
+
+- [ ] **Step 1: 변경 요약 확인**
+
+```powershell
+git log --oneline main..HEAD
+```
+Expected: Task 1~10 의 커밋 10개 (5 feat + 1 chore + 1 feat env + 3 라우트 추가 commit, 정확 개수는 task 진행 그대로).
+
+- [ ] **Step 2: push**
+
+```powershell
+git push -u origin 83-feat-회원가입-시-이메일-인증-추가
+```
+Expected: `branch '83-...' set up to track 'origin/83-...'`. push 출력의 Compare URL 후보 캡처.
+
+- [ ] **Step 3: PR Title/Body 초안 작성 (사용자 전달용)**
+
+**Title:**
+```
+feat(#83): 회원가입 이메일 인증 + 아이디·비번 찾기 BE (Resend, JWT audience 분리)
+```
+
+**Body:**
+```markdown
+## 변경 요약
+- 회원가입에 6자리 코드 이메일 인증 도입 (Resend 발송, 코드는 bcrypt 해시 저장)
+- 아이디 찾기·비밀번호 재설정 BE 라우트 신규 (총 5개 라우트)
+- `signup` 라우트가 `studentId` 와 `signupVerificationToken` 수용 (FE 입력칸 → BE 저장 연결)
+- JWT audience claim 분리 (session / email-verification:signup / password-reset)
+- 이메일 마스킹 규칙: 로컬파트 1~2자는 1자, 3자 이상은 2자만 노출
+
+## DB 변경
+- 신규 테이블 2개: `email_verifications`, `password_reset_tokens`
+- 마이그레이션: `20260510120000_email_verification`
+- 기존 데이터 영향 없음 (User 변경 없음, student_id 기존 nullable 그대로)
+- 공유 dev DB 적용은 머지 후 `prisma migrate deploy`
+
+## 보안
+- 코드·reset token 모두 bcrypt 해시로 저장 (평문 저장 ✕)
+- Enumeration 방어: 비밀번호 재설정 send 시 불일치도 200 동일 응답
+- Rate limit: 발송 60초 쿨다운, 시간당 5회. 코드 5분 만료, 검증 5회 후 잠금
+- 비밀번호 변경 트랜잭션: 해당 토큰 consumed + 같은 user 의 다른 미사용 reset token 일괄 무효화
+
+## ⚠ 호환성 주의
+- 본 PR 의 `verifyToken` 변경은 audience claim 검증을 강제하므로 **머지 시점 모든 기존 세션 토큰 무효화** — 사용자는 재로그인 필요
+- 운영 도메인 SPF/DKIM 설정 + `MAIL_FROM` 자체 도메인 변경은 별도 단계 (현재 `onboarding@resend.dev` 기본)
+
+## FE 핸드오프
+spec 문서 참조: `docs/superpowers/specs/2026-05-10-email-verification-design.md` 의 §9 핸드오프 섹션. 핵심:
+- `apps/web/src/app/signup/page.tsx`: 인증 코드 발송·입력 단계, sessionStorage 토큰 보관, body 에 `studentId` + `signupVerificationToken` 포함
+- `apps/web/src/app/find-id/page.tsx` (신규)
+- `apps/web/src/app/find-password/page.tsx` (신규, 3단계 위저드)
+- `apps/web/src/lib/api.ts`: 5개 신규/확장 API 함수
+
+## 검증
+- 타입체크 통과 (`tsc --noEmit`)
+- api 워크스페이스 빌드 성공
+- 5 라우트 모두 빌드 출력에 등록 확인
+- E2E curl 검증은 마이그레이션 deploy 후 별도
+
+## 범위 외 (별도 이슈)
+- 재학증명서 파일 업로드
+- 만료 행 정리 cron
+- 운영 도메인 SPF/DKIM
+- 테스트 프레임워크 도입
+- 기존 사용자(student_id NULL) 의 학번 보강 UI/배치
+```
+
+- [ ] **Step 4: 사용자에게 한 메시지로 전달**
+
+push 출력의 PR URL 후보(또는 `https://github.com/pLAWcess/pLAWcess/compare/main...83-feat-...` 형식 URL) + 위 Title + Body 초안을 한 텍스트 메시지로 사용자에게 전달. PR 생성은 사용자가 직접 (memory `reference_pr_workflow` 에 따라 gh CLI 미설치 환경).
+
+---
+
+## Self-Review (작성 후 점검)
+
+**Spec coverage check** — spec 의 모든 섹션이 task 로 매핑됐는지:
+
+| Spec 섹션 | 매핑 task |
+|---|---|
+| §3.1 EmailVerification 모델 | Task 1 |
+| §3.2 PasswordResetToken 모델 | Task 1 |
+| §3.3 User student_id (nullable 유지) | Task 1·7 |
+| §3.4 마이그레이션 SQL | Task 1 |
+| §4.1 send-verification | Task 5 |
+| §4.2 verify-code | Task 6 |
+| §4.3 signup 확장 | Task 7 |
+| §4.4 find-id + 마스킹 | Task 8 (mask 헬퍼는 Task 3) |
+| §4.5 reset-password | Task 9 |
+| §5 플로우 시퀀스 | Task 5~9 (각 라우트가 단계 구현) |
+| §6 메일 어댑터 모듈 | Task 3 |
+| §6.6 환경변수 | Task 2 |
+| §6.7 JWT audience 분리 | Task 4 |
+| §7 보안 정책 | Task 3·5·6·9 (코드 해시·rate limit·enumeration·트랜잭션 무효화) |
+| §8 테스트 케이스 | E2E 머지 후 별도 (본 PR §11) |
+| §9 FE 핸드오프 | Task 12 PR Body 에 명시 |
+| §10 범위 외 | Task 12 PR Body 에 명시 |
+| §11 위험 요소 | Task 12 PR Body 에 호환성·도메인 명시 |
+
+**Type consistency check**:
+- `EmailSender` 인터페이스 (Task 3 sender.ts) ↔ `ResendEmailSender`/`ConsoleEmailSender` 구현 (Task 3) — 일치
+- `RateLimitError` (code.ts) ↔ Task 5·8 catch — 일치
+- `signSignupVerificationToken` (Task 4) ↔ Task 7 `verifySignupVerificationToken` — 일치
+- `signResetToken(token_id, raw)` (Task 4) ↔ Task 6 발급 / Task 9 검증 — 일치
+- Prisma 모델명: `prisma.emailVerification`, `prisma.passwordResetToken` — schema 의 PascalCase → camelCase Prisma Client 표준 — 일치
+
+**Placeholder scan**: 없음. 모든 step 에 실제 코드/명령 포함.

--- a/docs/superpowers/specs/2026-05-10-email-verification-design.md
+++ b/docs/superpowers/specs/2026-05-10-email-verification-design.md
@@ -1,0 +1,459 @@
+# 이메일 인증 (회원가입 / 아이디·비밀번호 찾기) — Design Spec
+
+- **Date**: 2026-05-10
+- **Issue**: #83 (회원가입 이메일 인증) + #84 (아이디·비번 찾기) — 두 PR 로 분리, 본 spec 은 통합 설계
+- **Owner**: BE (FE 핸드오프 별도)
+- **Status**: Approved (브레인스토밍 완료)
+- **PR 분리:** §3.1·§4.1(signup 분기)·§4.2(signup 분기)·§4.3·§6 의 공통 인프라 = #83 / §3.2·§4.1(reset 분기)·§4.2(reset 분기)·§4.4·§4.5 = #84. #84 는 #83 머지 후 적용.
+
+## 1. 배경 / 문제
+
+현재 시스템:
+
+- `POST /api/auth/signup` 은 이메일을 단순 unique 제약으로만 받고, 실제 수신 여부를 검증하지 않는다 (`apps/api/src/app/api/auth/signup/route.ts`).
+- 아이디 찾기 / 비밀번호 재설정 라우트가 없다 — 사용자가 자신의 아이디·비밀번호를 잊으면 복구 경로 없음.
+- FE 회원가입 페이지(`apps/web/src/app/signup/page.tsx`)에는 `studentId` 입력칸이 이미 존재하나 BE 가 수용하지 않아 무시되고 있다 (코드 주석에 `#83 이메일 인증, 학번/재학증명서 처리 등 별도 이슈`로 명시됨).
+
+목표: 회원가입과 아이디·비밀번호 복구 시 이메일 본인확인을 도입하고, 학번을 BE 가 수용하도록 한다.
+
+## 2. 결정사항 (브레인스토밍 합의)
+
+| 주제 | 결정 |
+|---|---|
+| 인증 방식 | 6자리 숫자 코드 (메일로 발송 → 폼에 입력) |
+| 메일 발송 인프라 | Resend (free 3000/월, 100/일). 미설정 시 Console fallback |
+| 회원가입 인증 시점 | 가입 폼 안에서 인증 통과 필수. 미인증 계정 DB 미생성 |
+| 아이디 찾기 식별자 | 이름 + 학번. 일치 시 마스킹된 이메일 표시 + 메일로 아이디 직접 발송 (코드 인증 X) |
+| 비밀번호 찾기 식별자 | 이름 + 아이디 + 이메일 (셋 다 일치) → 코드 인증 → 임시 reset_token → 새 비밀번호 |
+| Reset 단계 신원확인 | 임시 reset_token (10분) 발급 패턴 |
+| Rate limit 정책 | 발송 60초 쿨다운, 시간당 5회. 코드 만료 5분, 시도 5회 후 잠금 |
+| Enumeration 방어 | 비밀번호 찾기 send 시 불일치도 200 동일 응답. 회원가입 send 는 명시적 (가입은 의도적 명확성) |
+| #83 PR 범위 | 이메일 인증 + 학번 BE 수용. 재학증명서 / 만료 cron / 테스트 인프라 / 도메인 SPF·DKIM 은 범위 외 |
+
+## 3. 데이터 모델
+
+신규 Prisma 모델 2개, 기존 User 변경 없음 (`packages/database/prisma/schema.prisma`).
+
+### 3.1 `EmailVerification`
+
+이메일 인증 코드의 발급·검증 추적. signup·reset_password 공통.
+
+```prisma
+model EmailVerification {
+  verification_id  String                    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  email            String                    @db.VarChar(100)
+  purpose          EmailVerificationPurpose
+  code_hash        String                    @db.VarChar(100) // bcrypt(6자리 코드)
+  expires_at       DateTime                                   // 발급 후 5분
+  attempts         Int                       @default(0)      // 검증 시도 횟수, 5회 초과 시 잠금
+  consumed_at      DateTime?                                  // 검증 성공 또는 잠금 시각 (1회용)
+  created_at       DateTime                  @default(now())
+  ip_address       String?                   @db.VarChar(45)  // rate limit 추적
+
+  @@index([email, purpose, created_at])
+  @@map("email_verifications")
+}
+
+enum EmailVerificationPurpose {
+  signup
+  reset_password
+}
+```
+
+**왜 단일 테이블 + purpose 컬럼:** signup·reset_password 의 발송·검증 로직이 거의 동일. purpose 만 다름. 아이디 찾기는 코드 인증 없으므로 이 테이블 미사용.
+
+### 3.2 `PasswordResetToken`
+
+비밀번호 코드 검증 통과 → 새 비밀번호 입력 단계를 잇는 1회용 토큰. user_id 와 매핑.
+
+```prisma
+model PasswordResetToken {
+  token_id     String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  user_id      String    @db.Uuid
+  token_hash   String    @db.VarChar(100)  // bcrypt(랜덤 32바이트 base64url)
+  expires_at   DateTime                     // 발급 후 10분
+  consumed_at  DateTime?
+  created_at   DateTime  @default(now())
+
+  user User @relation(fields: [user_id], references: [user_id], onDelete: Cascade)
+
+  @@index([user_id])
+  @@map("password_reset_tokens")
+}
+```
+
+**왜 별도 테이블:** EmailVerification 은 (email, purpose) 만으로 의미가 완결되지만, reset_token 은 user_id 와 연결돼야 새 비밀번호를 그 사용자에게 적용 가능. 책임 분리.
+
+`User` 모델에 `password_reset_tokens PasswordResetToken[]` relation 추가.
+
+### 3.3 User 변경
+
+- `student_id` — 그대로 nullable 유지 (기존 데이터 보호). 신규 가입자는 signup 라우트에서 필수 수신.
+- 다른 컬럼 변경 없음.
+- **기존 사용자(student_id NULL)의 아이디 찾기:** 학번 일치 검색에 걸리지 않으므로 404 응답이 됨. 1차 릴리스에서는 별도 보강 없음 — 마이페이지에서 학번 입력 유도하는 UI 또는 운영자 일괄 데이터 보강은 별도 이슈로 분리.
+
+### 3.4 마이그레이션
+
+```sql
+CREATE TYPE "EmailVerificationPurpose" AS ENUM ('signup', 'reset_password');
+
+CREATE TABLE "email_verifications" (
+  "verification_id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "email"           VARCHAR(100) NOT NULL,
+  "purpose"         "EmailVerificationPurpose" NOT NULL,
+  "code_hash"       VARCHAR(100) NOT NULL,
+  "expires_at"      TIMESTAMP(3) NOT NULL,
+  "attempts"        INTEGER NOT NULL DEFAULT 0,
+  "consumed_at"     TIMESTAMP(3),
+  "created_at"      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "ip_address"      VARCHAR(45)
+);
+CREATE INDEX "email_verifications_email_purpose_created_at_idx"
+  ON "email_verifications" ("email", "purpose", "created_at");
+
+CREATE TABLE "password_reset_tokens" (
+  "token_id"     UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "user_id"      UUID NOT NULL REFERENCES "users"("user_id") ON DELETE CASCADE,
+  "token_hash"   VARCHAR(100) NOT NULL,
+  "expires_at"   TIMESTAMP(3) NOT NULL,
+  "consumed_at"  TIMESTAMP(3),
+  "created_at"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX "password_reset_tokens_user_id_idx"
+  ON "password_reset_tokens" ("user_id");
+```
+
+기존 데이터 영향 없음. 멤버 정책 `feedback_db_migration_discipline` 에 따라 공유 dev DB 적용은 PR 머지 후 별도 단계.
+
+## 4. API 엔드포인트
+
+5개 라우트. 기존 signup 만 수정, 나머지 4개 신규.
+
+### 4.1 `POST /api/auth/email/send-verification` (신규)
+
+가입·비밀번호재설정용 6자리 코드 메일 발송.
+
+**Body (purpose 별 분기):**
+```ts
+type Body =
+  | { purpose: "signup"; email: string }
+  | { purpose: "reset_password"; name: string; loginId: string; email: string };
+```
+
+**처리:**
+1. **rate limit 체크** — 동일 (email, purpose) 가장 최근 created_at 60초 이내 → 429. 직전 1시간 내 5회 초과 → 429.
+2. **purpose별 사전 검증:**
+   - `signup`: User.email 중복 시 409 (회원가입은 명시적 enumeration 허용 — 이미 가입자에게 동의된 행동)
+   - `reset_password`: User where { name, login_id, email, is_deleted: false } 일치 안 함 → **200 동일 응답** (enumeration 방어). 메일 발송은 안 함
+3. 6자리 코드 생성: `crypto.randomInt(0, 1_000_000).toString().padStart(6, "0")`
+4. **Resend 발송 시도** (실패 시 502 — INSERT 미실행, 다음 시도 카운트 가능)
+5. 발송 성공 시 `EmailVerification` INSERT (`code_hash = bcrypt(code, 10)`, `expires_at = now+5분`)
+
+**응답:**
+- 200: `{ sent: true, expiresAt: ISO_string }`
+- 429: `{ error: "잠시 후 다시 시도해주세요." }` 또는 `{ error: "발송 한도를 초과했습니다." }`
+- 502: `{ error: "메일 발송에 실패했습니다." }`
+
+### 4.2 `POST /api/auth/email/verify-code` (신규)
+
+코드 검증 + 이후 단계 토큰 발급.
+
+**Body:** `{ email: string, purpose: "signup" | "reset_password", code: string }`
+
+**처리:**
+1. (email, purpose) 가장 최근 미consumed·미만료 행 조회 → 없으면 400 `"코드가 만료되었거나 발송된 적 없습니다."`
+2. `attempts++` UPDATE. 6회째(즉 attempts=6 직전 5번째 실패까지)면 잠금: `consumed_at = now` 설정 후 400 `"시도 횟수가 초과되었습니다. 새 코드를 발송해주세요."`
+3. `bcrypt.compare(code, code_hash)` 실패 → 400 `"코드가 일치하지 않습니다."` (attempts 는 이미 ++)
+4. 성공 시 `consumed_at = now`
+
+**응답 (성공):**
+- `signup` →
+  ```json
+  {
+    "ok": true,
+    "signupVerificationToken": "<JWT>",
+    "expiresAt": "ISO"
+  }
+  ```
+  JWT payload: `{ email, purpose: "signup", iss: "pLAWcess", aud: "email-verification:signup", exp: now+10m }`. 시크릿: `JWT_SECRET`.
+- `reset_password` → 같은 트랜잭션 안에서:
+  - 32바이트 랜덤 토큰 생성 (`crypto.randomBytes(32).toString("base64url")`)
+  - `password_reset_tokens` INSERT (`user_id`, `token_hash = bcrypt(rawToken, 10)`, `expires_at = now+10m`)
+  - 응답:
+    ```json
+    {
+      "ok": true,
+      "resetToken": "<JWT>",
+      "expiresAt": "ISO"
+    }
+    ```
+    JWT payload: `{ token_id, raw: rawToken, iss: "pLAWcess", aud: "password-reset", exp: now+10m }` — JWT 는 위변조 방지용 wrapper, 실제 검증은 DB 의 token_hash 와 raw 비교.
+
+### 4.3 `POST /api/auth/signup` (수정)
+
+**기존 Body:** `{ name, loginId, email, password }`
+**확장 Body:** `{ name, loginId, email, password, studentId, signupVerificationToken }`
+
+**처리 (추가/변경):**
+1. **JWT 검증** (앞단에서) — `signupVerificationToken` 디코드, audience `"email-verification:signup"` 확인, 만료 확인, `payload.email === body.email` 확인. 실패 시 401 `"이메일 인증이 만료되었거나 유효하지 않습니다."`
+2. **studentId 검증** — 영문/숫자 4~20자 (정확한 형식은 운영 데이터 기준으로 추후 협의 가능). 미충족 시 400 `"학번 형식이 올바르지 않습니다."`
+3. 기존: email/loginId 중복 검사 (409), bcrypt 해시
+4. User INSERT 시 `student_id: studentId` 추가
+5. JWT 세션 쿠키 발급 (기존 그대로)
+
+**응답 201:** 기존과 동일 + `student_id` 가 응답 user 에 포함.
+
+### 4.4 `POST /api/auth/find-id` (신규)
+
+**Body:** `{ name: string, studentId: string }`
+
+**처리:**
+1. **IP rate limit** — 같은 IP 시간당 10회 (이름+학번 무차별 시도 방어). 메모리 기반 또는 별도 테이블 — 1차 구현은 in-process 카운터(서버 1대 가정).
+2. User 조회: `where { name, student_id: studentId, is_deleted: false }`. 둘 다 일치하는 단일 user 가 있어야 함.
+3. 일치하면:
+   - Resend 발송: 제목 `"[pLAWcess] 아이디 안내"`, 본문 `"회원님의 아이디는 ${loginId} 입니다."`
+   - 응답 200: `{ maskedEmail: "ho***@gmail.com" }`
+4. 일치 안 함 → 404 `"일치하는 회원이 없습니다."`
+
+**이메일 마스킹 규칙:**
+- 로컬파트 길이 1~2자: 첫 1자 + `***` (예: `a@x.com` → `a***@x.com`, `ab@x.com` → `a***@x.com`)
+- 로컬파트 길이 3자 이상: 첫 2자 + `***` (예: `hong@gmail.com` → `ho***@gmail.com`)
+
+### 4.5 `POST /api/auth/reset-password` (신규)
+
+**Body:** `{ resetToken: string, newPassword: string }`
+
+**처리:**
+1. JWT 검증: 디코드, audience `"password-reset"`, 만료 확인 → 실패 시 401
+2. payload 에서 `token_id`, `raw` 추출. `password_reset_tokens` 행 조회 (token_id 단위).
+3. 행 없음 / `consumed_at` not null / `expires_at` 경과 → 401 `"재설정 링크가 만료되었거나 사용되었습니다."`
+4. `bcrypt.compare(raw, token_hash)` 실패 → 401 (위조 방어)
+5. `newPassword.length < 8` → 400
+6. 트랜잭션:
+   - User.password_hash = `bcrypt(newPassword, 12)`
+   - 이 token: `consumed_at = now`
+   - 같은 user 의 다른 미사용 reset_token 일괄 `consumed_at = now` (보안: 동시에 발급된 다른 토큰 무효화)
+
+**응답 200:** `{ success: true }`
+
+## 5. 플로우 시퀀스
+
+### 5.1 회원가입
+
+```
+사용자 → FE: 이메일 입력, "인증 코드 발송"
+FE   → BE: POST /api/auth/email/send-verification {purpose:"signup", email}
+BE   → Resend → User 메일함, EmailVerification INSERT
+FE   ← BE: 200 {sent, expiresAt}
+
+사용자 → FE: 코드 입력, "확인"
+FE   → BE: POST .../verify-code {purpose:"signup", email, code}
+BE: attempts++, bcrypt.compare, consumed_at=now
+FE   ← BE: 200 {ok, signupVerificationToken}
+FE: sessionStorage 에 토큰 보관, 나머지 필드 활성화
+
+사용자 → FE: 이름·아이디·비밀번호·학번 입력, "가입"
+FE   → BE: POST /api/auth/signup {name, loginId, email, password, studentId, signupVerificationToken}
+BE: JWT 검증 → email/loginId 중복 재검 → User INSERT → 세션 쿠키 발급
+FE   ← BE: 201 {user}
+```
+
+### 5.2 아이디 찾기
+
+```
+사용자 → FE: 이름·학번 입력
+FE   → BE: POST /api/auth/find-id {name, studentId}
+BE: User 조회. 일치 안 함 → 404. 일치 시 메일 발송.
+FE   ← BE: 200 {maskedEmail} 또는 404
+사용자 ← Resend: "회원님의 아이디는 ${loginId} 입니다." 메일 수신
+```
+
+### 5.3 비밀번호 재설정
+
+```
+사용자 → FE: 이름·아이디·이메일 입력, "인증 코드 발송"
+FE   → BE: POST /api/auth/email/send-verification {purpose:"reset_password", name, loginId, email}
+BE: 셋 다 일치 user 조회. 불일치도 200 동일 응답. 일치 시 코드 발송 + INSERT.
+FE   ← BE: 200 {sent, expiresAt}
+
+사용자 → FE: 코드 입력
+FE   → BE: POST .../verify-code {purpose:"reset_password", email, code}
+BE: 코드 검증 → password_reset_tokens INSERT (user_id 매핑)
+FE   ← BE: 200 {ok, resetToken}
+
+사용자 → FE: 새 비밀번호 입력, "변경"
+FE   → BE: POST /api/auth/reset-password {resetToken, newPassword}
+BE: 트랜잭션 - password_hash 갱신 + token consumed + 다른 미사용 토큰 일괄 무효화
+FE   ← BE: 200 {success: true}
+```
+
+### 5.4 예외 케이스
+
+| 상황 | 응답 | 사용자 안내 |
+|---|---|---|
+| 코드 만료 (>5분) | 400 `"코드가 만료되었습니다."` | 재발송 유도 |
+| 코드 5회 오답 | 400 `"시도 횟수 초과, 새 코드를 발송해주세요."` | 새 코드로 리셋 |
+| 60초 쿨다운 위반 | 429 `"잠시 후 다시 시도해주세요."` | 카운트다운 표시 |
+| 시간당 5회 초과 | 429 `"발송 한도를 초과했습니다."` | 1시간 후 안내 |
+| signupVerificationToken 만료 | 401 `"이메일 인증을 다시 받아주세요."` | 1단계 복귀 |
+| reset_token 만료/사용됨 | 401 `"재설정 링크가 만료되었거나 사용되었습니다."` | 처음부터 다시 |
+| Resend 발송 실패 | 502 `"메일 발송에 실패했습니다."` | 재시도 |
+
+## 6. 메일 발송 어댑터
+
+### 6.1 모듈 구조 (`apps/api/src/lib/email/`)
+
+```
+email/
+├── sender.ts         — EmailSender 인터페이스 + 팩토리 (env 기반)
+├── resend.ts         — ResendEmailSender (운영)
+├── console.ts        — ConsoleEmailSender (개발/테스트 fallback)
+└── templates.ts      — 3종 메일 본문 빌더
+```
+
+### 6.2 `EmailSender` 인터페이스
+
+```ts
+export interface EmailSender {
+  send(input: { to: string; subject: string; text: string; html: string }): Promise<void>;
+}
+
+export function getEmailSender(): EmailSender {
+  if (!process.env.RESEND_API_KEY) return new ConsoleEmailSender();
+  return new ResendEmailSender(process.env.RESEND_API_KEY, process.env.MAIL_FROM!);
+}
+```
+
+### 6.3 ResendEmailSender
+
+- 패키지 `resend` 설치 (`pnpm --filter api add resend`)
+- 발송: `await resend.emails.send({ from, to, subject, text, html })`
+- 실패 시 `EmailDeliveryError` throw → 라우트에서 catch → 502
+- **rate limit 체크 → Resend send → 성공 시 EmailVerification INSERT** 순서
+
+### 6.4 ConsoleEmailSender
+
+- `RESEND_API_KEY` 미설정 시 자동 활성화
+- `console.log("[EMAIL]", { to, subject, text })` 로 전체 본문(코드 포함) 출력
+- **운영 환경에서는 사용 금지** — 키가 없는 환경 자체가 운영이 아니라는 정책으로 제어 (`NODE_ENV === "production"` 가드 추가 검토)
+
+### 6.5 메일 템플릿 (3종)
+
+| 용도 | 제목 | text 본문 (요약) |
+|---|---|---|
+| 가입 코드 | `[pLAWcess] 회원가입 인증 코드` | `인증 코드는 ${code} 입니다. 5분 안에 입력해주세요. 요청하지 않으셨다면 이 메일을 무시해주세요.` |
+| 재설정 코드 | `[pLAWcess] 비밀번호 재설정 인증 코드` | `인증 코드는 ${code} 입니다. 5분 안에 입력해주세요. 요청하지 않으셨다면 이 메일을 무시해주세요.` |
+| 아이디 안내 | `[pLAWcess] 아이디 안내` | `회원님의 아이디는 ${loginId} 입니다.` |
+
+HTML 도 동일 내용 + 인라인 스타일(`<div style="font-family:sans-serif">…<strong>${code}</strong>…</div>`). 스팸 점수 완화를 위해 text+html 둘 다 발송.
+
+### 6.6 환경변수 추가 (`apps/api/.env.example`)
+
+```bash
+DATABASE_URL=""
+DIRECT_URL=""
+JWT_SECRET=""
+GEMINI_API_KEY=""
+
+# 이메일 인증 (#83)
+RESEND_API_KEY=""                              # 미설정 시 콘솔 fallback
+MAIL_FROM="pLAWcess <onboarding@resend.dev>"   # 도메인 인증 후 noreply@<도메인> 으로 변경
+```
+
+### 6.7 JWT audience 분리
+
+`JWT_SECRET` 재사용. 단 audience claim 으로 토큰 종류 분리:
+
+| 종류 | aud | exp | 용도 |
+|---|---|---|---|
+| 일반 세션 | `session` | 7일 (기존) | 로그인 쿠키 |
+| signup verification | `email-verification:signup` | 10분 | signup 호출 시 인증 증명 |
+| password reset | `password-reset` | 10분 | reset-password 호출 시 신원 증명 |
+
+**기존 `signToken` 변경:** `aud: "session"` claim 추가. 기존 라우트(`/api/auth/me`, 보호 라우트의 `getTokenFromCookie` 검증) 가 audience 검증 하도록 보강. 현재 audience 검증 안 하면 — 토큰 종류 변환 가능성 있어 보안 hole. 본 PR 에서 같이 정리.
+
+### 6.8 운영 전환 체크리스트 (PR 머지 후 별도)
+
+- Resend 계정 생성 + API 키 발급 → 환경변수 등록
+- 도메인 SPF/DKIM 추가 → `MAIL_FROM` 자체 도메인으로 변경
+- (선택) Resend Dashboard 발송 통계 모니터링 셋업
+
+## 7. 보안 / 정책
+
+- **코드는 bcrypt 해시로 저장** — DB 덤프 유출되어도 평문 코드 노출 ✕
+- **reset_token 도 DB 에는 bcrypt 해시 저장**, 평문은 클라이언트에만 — JWT 는 위변조 방지 wrapper, 실제 검증은 DB hash 비교
+- **JWT audience 분리** — signup verification / reset / 일반 세션 셋이 서로 변환 불가
+- **Enumeration 방어** — `reset_password` send-verification 은 (이름+아이디+이메일) 불일치 시에도 200 동일 응답, 메일 미발송. signup 은 의도적 명확성으로 409 유지
+- **트랜잭션 무효화** — 비밀번호 변경 시 같은 user 의 다른 미사용 reset_token 일괄 consumed
+- **타이밍 공격 완화** — bcrypt.compare 가 일정 시간 보장. 일치 안 함 vs 행 없음 응답시간 편차 작음. 추가 sleep 불필요
+- **로그 마스킹** — 코드·토큰·비밀번호는 절대 로그에 남기지 않음 (Console fallback 제외, 운영 가드)
+- **Rate limit 정책** — 발송 60초 쿨다운, 시간당 5회. 코드 만료 5분, 검증 시도 5회 후 잠금
+
+## 8. 테스트 케이스 (수동 curl E2E 검증)
+
+테스트 프레임워크 미설치이므로 수동 curl 로 검증. 구현 단계 체크리스트:
+
+| # | 시나리오 | 기대 |
+|---|---|---|
+| 1 | 가입 정상 플로우 | send → verify → signup 순차 200/200/201, User INSERT 확인 |
+| 2 | 코드 만료 (>5분 wait) | verify → 400 |
+| 3 | 코드 5회 오답 | 6번째 verify → 400 + 잠금 (consumed_at 세팅 확인) |
+| 4 | 60초 쿨다운 | 두 번째 send 즉시 → 429 |
+| 5 | 시간당 5회 한도 | 6번째 send → 429 |
+| 6 | signup 토큰 위조 (서명 변경) | signup → 401 |
+| 7 | signup 토큰 email 불일치 | payload.email ≠ body.email → 401 |
+| 8 | reset 정상 플로우 | send → verify → reset 통과, User.password_hash 변경 확인 |
+| 9 | reset 토큰 재사용 | 동일 resetToken 으로 두 번째 reset → 401 |
+| 10 | reset 후 다른 미사용 토큰 무효화 | 한 user 에 두 토큰 발급 후 한 쪽 reset → 다른 토큰도 401 |
+| 11 | 아이디 찾기 정상 | 200 + 마스킹 이메일 + 메일 발송 확인 (Console 출력으로 검증) |
+| 12 | 아이디 찾기 불일치 | 404 |
+| 13 | 마스킹 경계 | 1자/2자/3자 로컬파트 각각 응답 형식 검증 |
+| 14 | reset_password Enumeration | user 없음 → 200, 메일 미발송 (Console 출력 X) |
+| 15 | 학번 형식 검증 | 너무 짧/긴/특수문자 → 400 |
+
+## 9. FE 핸드오프
+
+본 PR 의 BE 변경에 맞춰 별도 이슈로 진행.
+
+### 9.1 `apps/web/src/app/signup/page.tsx`
+- "인증 코드 발송" 버튼 + 60초 쿨다운 카운트다운 UI 추가
+- "코드 입력 + 확인" 단계 — 인증 통과 전엔 나머지 필드 잠금
+- 인증 통과 후 받은 `signupVerificationToken` 을 sessionStorage 에 저장 → 가입 제출 시 body 에 포함
+- 가입 body 에 `studentId` 포함 (현재 입력칸은 있으나 BE 미전송)
+- 가입 토큰이 만료되면 1단계로 복귀 안내
+
+### 9.2 `apps/web/src/app/find-id/page.tsx` (신규)
+- 이름 + 학번 입력 → POST `/api/auth/find-id`
+- 응답 `maskedEmail` 표시 + "회원님의 메일로 아이디가 발송되었습니다" 안내
+- 404 시 "일치하는 회원이 없습니다" 표시
+
+### 9.3 `apps/web/src/app/find-password/page.tsx` (신규)
+- 3단계 위저드: 이름·아이디·이메일 → 코드 입력 → 새 비밀번호
+- 단계 사이 상태(`signupVerificationToken` 또는 `resetToken`)는 useState 메모리. 페이지 새로고침 시 1단계 복귀 OK
+- 마지막 성공 시 로그인 페이지로 redirect
+
+### 9.4 `apps/web/src/lib/api.ts`
+신규 함수 5개 추가:
+- `sendEmailVerification(body): Promise<{ sent: true; expiresAt: string }>`
+- `verifyEmailCode(body): Promise<{ ok: true; signupVerificationToken?: string; resetToken?: string; expiresAt: string }>`
+- `signup` — 기존 시그니처 확장 (`studentId`, `signupVerificationToken` 추가)
+- `findId({ name, studentId }): Promise<{ maskedEmail: string }>`
+- `resetPassword({ resetToken, newPassword }): Promise<{ success: true }>`
+
+## 10. 범위 외 (별도 이슈)
+
+- 재학증명서 파일 업로드·검증 (Supabase Storage 또는 S3 + admin 검토 워크플로)
+- 이메일 템플릿 디자인(브랜딩, 로고)
+- 만료 행 정리 cron (`EmailVerification`, `password_reset_tokens`)
+- 운영 도메인 SPF/DKIM 설정 + `MAIL_FROM` 변경
+- 테스트 프레임워크 도입 (Vitest 등)
+- IP 기반 rate limit 의 분산 환경 대응 (현재는 in-process 카운터, 멀티 인스턴스 시 한도 초과 가능)
+
+## 11. 위험 요소
+
+- **Resend 한도** — free 100/일·3000/월. 일일 트래픽이 가입 + 비번재설정 + 아이디찾기 합산 100건 넘으면 유료 전환 필요. 머지 후 모니터링 권장.
+- **MAIL_FROM 미설정** — 도메인 미보유 시 `onboarding@resend.dev` 만 가능, 받는 사람도 본인 계정 메일만(Resend 무료계정 제한). **운영 도메인 셋업이 안 되면 일반 사용자에게 메일이 가지 않음** — 머지 전 도메인 결정 필요.
+- **JWT_SECRET 단일** — 1개 시크릿이 세션·verification·reset 모두 서명. 노출 시 전체 영향. audience claim 으로 분리하지만 시크릿 자체는 같음. 별도 시크릿 분리는 YAGNI(현재 운영 부담 우선).
+- **기존 audience 검증 미적용** — 본 PR 에서 일반 세션에 `aud: "session"` 추가 + 기존 라우트 검증 강화. 누락 시 토큰 변환 공격 가능.
+- **In-process IP rate limit** — 멀티 인스턴스 환경(향후 수평 확장)에서는 인스턴스당 한도가 됨. 별도 이슈로 Redis 등 외부 카운터 도입 검토.
+- **기존 사용자 학번 미보유** — 기존 가입자는 student_id NULL 이므로 본 PR 의 아이디 찾기를 사용할 수 없음. 운영 사용자에게 별도 안내 필요.

--- a/packages/database/prisma/migrations/20260510120000_email_verification/migration.sql
+++ b/packages/database/prisma/migrations/20260510120000_email_verification/migration.sql
@@ -1,0 +1,20 @@
+-- CreateEnum
+CREATE TYPE "EmailVerificationPurpose" AS ENUM ('signup', 'reset_password');
+
+-- CreateTable
+CREATE TABLE "email_verifications" (
+    "verification_id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "email" VARCHAR(100) NOT NULL,
+    "purpose" "EmailVerificationPurpose" NOT NULL,
+    "code_hash" VARCHAR(100) NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "consumed_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "ip_address" VARCHAR(45),
+
+    CONSTRAINT "email_verifications_pkey" PRIMARY KEY ("verification_id")
+);
+
+-- CreateIndex
+CREATE INDEX "email_verifications_email_purpose_created_at_idx" ON "email_verifications"("email", "purpose", "created_at");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -408,6 +408,33 @@ model CycleSchedule {
   @@map("cycle_schedules")
 }
 
+// ----------------------------------------------------------------
+// 8. email_verifications (#83)
+//    - 회원가입·비밀번호 재설정 6자리 코드 발송·검증
+//    - 코드는 bcrypt 해시로 저장, 1회용 (consumed_at 으로 종결)
+//    - 발송 rate limit 측정에 (email, purpose, created_at) 인덱스 사용
+//    - reset_password 분기는 #84 에서 추가 활성화 (enum 값은 미리 정의)
+// ----------------------------------------------------------------
+enum EmailVerificationPurpose {
+  signup
+  reset_password
+}
+
+model EmailVerification {
+  verification_id String                   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  email           String                   @db.VarChar(100)
+  purpose         EmailVerificationPurpose
+  code_hash       String                   @db.VarChar(100)
+  expires_at      DateTime
+  attempts        Int                      @default(0)
+  consumed_at     DateTime?
+  created_at      DateTime                 @default(now())
+  ip_address      String?                  @db.VarChar(45)
+
+  @@index([email, purpose, created_at])
+  @@map("email_verifications")
+}
+
 // ================================================================
 // migration.sql에 수동으로 추가해야 할 SQL
 // (Prisma가 자동 생성하지 않는 PostgreSQL 전용 기능)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      resend:
+        specifier: ^6.12.3
+        version: 6.12.3
     devDependencies:
       '@types/bcryptjs':
         specifier: ^3.0.0
@@ -726,6 +729,9 @@ packages:
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1519,6 +1525,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
@@ -2254,6 +2263,9 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2356,6 +2368,15 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  resend@6.12.3:
+    resolution: {integrity: sha512-FkEi6YPnVL96/LvH8+QP7NaeaBy5brYXwlRqUCqZZeNL0/iyKij18IPmyPXYauT/2ODn1JG04qKz+qlJfzqzTw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2479,6 +2500,9 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
@@ -2537,6 +2561,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svix@1.92.2:
+    resolution: {integrity: sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==}
 
   tailwindcss@4.2.2:
     resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
@@ -3242,6 +3269,8 @@ snapshots:
       '@types/react': 19.2.14
 
   '@rtsao/scc@1.1.0': {}
+
+  '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -4207,6 +4236,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.1.0: {}
 
   fastq@1.20.1:
@@ -4944,6 +4975,8 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postal-mime@2.7.4: {}
+
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.11
@@ -5061,6 +5094,11 @@ snapshots:
   remeda@2.33.4: {}
 
   require-from-string@2.0.2: {}
+
+  resend@6.12.3:
+    dependencies:
+      postal-mime: 2.7.4
+      svix: 1.92.2
 
   resolve-from@4.0.0: {}
 
@@ -5216,6 +5254,11 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   std-env@3.10.0: {}
 
   stop-iteration-iterator@1.1.0:
@@ -5289,6 +5332,10 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svix@1.92.2:
+    dependencies:
+      standardwebhooks: 1.0.0
 
   tailwindcss@4.2.2: {}
 


### PR DESCRIPTION
  ## Summary
  - 회원가입 시 이메일 OTP 인증 (6자리, 5분 유효) 도입 — `User` 가입 직전 이메일 검증 의무화
  - BE: 신규 라우트 3개 + JWT audience 분리 + Resend/Console 어댑터
  - FE: `/signup` 페이지에 인증 코드 발송·확인 플로우 + 60초 쿨다운 + 학번 필수화·성별 제거
  - DB: `EmailVerification` 모델 + `email_verifications` 테이블

  ## 신규 / 변경 라우트
  - `POST /api/auth/email/send-verification` — 6자리 OTP 발송 (이메일 중복 시 409, 발송 rate limit 60s/5h)
  - `POST /api/auth/email/verify-code` — 코드 검증 + `signupVerificationToken` 발급 (10분, audience `email-verification:signup`)
  - `POST /api/auth/signup` — `studentId` + `signupVerificationToken` 수용. 토큰 audience·email 일치 검증 후 가입

  ## DB 변경
  - `email_verifications` 테이블 신규: `verification_id`, `email`, `purpose`(enum), `code_hash`(bcrypt), `expires_at`, `attempts`,
  `consumed_at`, `ip_address`
  - 인덱스: `(email, purpose, created_at)`
  - 마이그레이션: `20260510120000_email_verification`
  - ✅ Supabase dev DB 이미 적용 완료 (`prisma migrate deploy`)

  ## 보안
  - 코드는 bcrypt 해시로 저장 (raw 코드는 메일에만 존재)
  - JWT audience 분리 — session 토큰 ↔ signup verification 토큰 교차 사용 불가
  - 발송 rate limit: 60초 쿨다운 + 시간당 5건 (이메일 단위)
  - 검증 attempt limit: 5회

  ## FE 변경 (`apps/web`)
  - `/signup` — 이메일 입력 → 인증 코드 발송 → 코드 검증 → 가입 폼 제출 (signupVerificationToken 동봉). 60초 재발송 쿨다운, 만료/오류 메시지. 
  - `/signup` — 성별 필드 제거, 학부 학번 라벨 갱신, `studentId` 필수화

  ## 검증
  - [x] 타입체크·빌드 통과
  - [x] dev 환경 Resend 발송 e2e 성공 (signup 완료 + `plawcess_token` 쿠키 발급)
  - [x] 이메일 중복 차단 동작 확인 (`/send-verification` 단계 + `/signup` race 방어 모두)
  - [x] 인증 토큰 만료/타 오디언스 차단 확인

  ## 동봉 안내
  - `da21177` 커밋에 #84 영역(login 링크, `/find-id` 페이지, `find-id` 라우트, `findIdMail` 템플릿) 일부가 함께 들어있음. #84 PR 과 일괄      
  동기화하려고 의도적으로 묶음. **#83 머지 후 #84 PR 머지 시** find-id 관련 파일은 동일 내용이므로 conflict-free 머지 예상.
  - 운영 배포 시 `RESEND_API_KEY`, `MAIL_FROM` 시크릿 설정 필요. 미설정 환경에서는 dev 한정 `ConsoleEmailSender` 가 코드를 stdout 로 출력     
  (운영 NODE_ENV 에서는 throw).

  ## 머지 순서
  `#83 → #84` (현재 #84 가 #83 위에 stack 되어 있어 #83 머지 후 #84 PR 자동 update)