### PR TITLE
176 be admin api 만들어죠

### DIFF
--- a/apps/api/src/app/api/admin/announcements/[id]/route.ts
+++ b/apps/api/src/app/api/admin/announcements/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma, Prisma } from "@plawcess/database";
+import { requireAdmin } from "@/lib/admin-guard";
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const guard = requireAdmin(req);
+  if (guard.error) return guard.error;
+
+  const { id } = await params;
+  if (!id) {
+    return NextResponse.json({ error: "id 가 필요합니다." }, { status: 400 });
+  }
+
+  try {
+    await prisma.announcement.delete({ where: { announcement_id: id } });
+  } catch (e) {
+    if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2025") {
+      return NextResponse.json({ error: "해당 공지사항이 없습니다." }, { status: 404 });
+    }
+    throw e;
+  }
+  return NextResponse.json({ success: true });
+}

--- a/apps/api/src/app/api/admin/announcements/route.ts
+++ b/apps/api/src/app/api/admin/announcements/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@plawcess/database";
+import { requireAdmin } from "@/lib/admin-guard";
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+const MAX_TITLE = 100;
+
+type AnnouncementRow = {
+  announcement_id: string;
+  title: string;
+  body: string;
+  created_at: Date;
+  created_by: { name: string };
+};
+
+function toResponse(row: AnnouncementRow) {
+  return {
+    announcementId: row.announcement_id,
+    title: row.title,
+    body: row.body,
+    createdAt: row.created_at.toISOString(),
+    author: row.created_by.name,
+  };
+}
+
+function parsePagination(req: NextRequest):
+  | { page: number; limit: number; error?: undefined }
+  | { error: NextResponse; page?: undefined; limit?: undefined } {
+  const pageRaw = req.nextUrl.searchParams.get("page");
+  const limitRaw = req.nextUrl.searchParams.get("limit");
+  const page = pageRaw ? parseInt(pageRaw, 10) : 1;
+  const limit = limitRaw ? parseInt(limitRaw, 10) : DEFAULT_LIMIT;
+  if (!Number.isInteger(page) || page < 1) {
+    return { error: NextResponse.json({ error: "page 가 올바르지 않습니다." }, { status: 400 }) };
+  }
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+    return { error: NextResponse.json({ error: `limit 은 1~${MAX_LIMIT} 사이여야 합니다.` }, { status: 400 }) };
+  }
+  return { page, limit };
+}
+
+export async function POST(req: NextRequest) {
+  const guard = requireAdmin(req);
+  if (guard.error) return guard.error;
+  const adminId = guard.payload.user_id;
+
+  let body: { title?: unknown; body?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "요청 형식이 올바르지 않습니다." }, { status: 400 });
+  }
+
+  const title = typeof body.title === "string" ? body.title.trim() : "";
+  const content = typeof body.body === "string" ? body.body.trim() : "";
+
+  if (title.length < 1 || title.length > MAX_TITLE) {
+    return NextResponse.json(
+      { error: `title 은 1~${MAX_TITLE}자여야 합니다.` },
+      { status: 400 },
+    );
+  }
+  if (content.length < 1) {
+    return NextResponse.json({ error: "body 는 1자 이상이어야 합니다." }, { status: 400 });
+  }
+
+  const created = await prisma.announcement.create({
+    data: { title, body: content, created_by_user_id: adminId },
+    include: { created_by: { select: { name: true } } },
+  });
+
+  return NextResponse.json(toResponse(created), { status: 201 });
+}
+
+export async function GET(req: NextRequest) {
+  const guard = requireAdmin(req);
+  if (guard.error) return guard.error;
+
+  const pg = parsePagination(req);
+  if (pg.error) return pg.error;
+  const { page, limit } = pg;
+
+  const [rows, totalCount] = await prisma.$transaction([
+    prisma.announcement.findMany({
+      orderBy: { created_at: "desc" },
+      skip: (page - 1) * limit,
+      take: limit,
+      include: { created_by: { select: { name: true } } },
+    }),
+    prisma.announcement.count(),
+  ]);
+
+  return NextResponse.json({
+    data: rows.map(toResponse),
+    totalCount,
+    page,
+    limit,
+  });
+}

--- a/apps/api/src/app/api/admin/applications/route.ts
+++ b/apps/api/src/app/api/admin/applications/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma, Prisma } from "@plawcess/database";
+import { requireAdmin } from "@/lib/admin-guard";
+import { resolveProcessYear } from "@/lib/active-cycle";
+import { applicationStatusToLabel } from "@/lib/labels";
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+function parsePagination(req: NextRequest):
+  | { page: number; limit: number; error?: undefined }
+  | { error: NextResponse; page?: undefined; limit?: undefined } {
+  const pageRaw = req.nextUrl.searchParams.get("page");
+  const limitRaw = req.nextUrl.searchParams.get("limit");
+  const page = pageRaw ? parseInt(pageRaw, 10) : 1;
+  const limit = limitRaw ? parseInt(limitRaw, 10) : DEFAULT_LIMIT;
+  if (!Number.isInteger(page) || page < 1) {
+    return { error: NextResponse.json({ error: "page 가 올바르지 않습니다." }, { status: 400 }) };
+  }
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+    return { error: NextResponse.json({ error: `limit 은 1~${MAX_LIMIT} 사이여야 합니다.` }, { status: 400 }) };
+  }
+  return { page, limit };
+}
+
+export async function GET(req: NextRequest) {
+  const guard = requireAdmin(req);
+  if (guard.error) return guard.error;
+
+  const role = req.nextUrl.searchParams.get("role");
+  if (role !== "mentee" && role !== "mentor") {
+    return NextResponse.json(
+      { error: "role 은 mentee 또는 mentor 여야 합니다." },
+      { status: 400 },
+    );
+  }
+
+  const yr = await resolveProcessYear(req);
+  if (yr.error) return yr.error;
+  const year = yr.year;
+
+  const pg = parsePagination(req);
+  if (pg.error) return pg.error;
+  const { page, limit } = pg;
+
+  const where: Prisma.ApplicationWhereInput = {
+    role,
+    process_year: year,
+    application_status: { in: ["submitted", "approved", "rejected", "revision_requested"] },
+  };
+
+  const [rows, totalCount] = await prisma.$transaction([
+    prisma.application.findMany({
+      where,
+      orderBy: { submitted_at: "desc" },
+      skip: (page - 1) * limit,
+      take: limit,
+      select: {
+        application_id: true,
+        application_status: true,
+        submitted_at: true,
+        user: {
+          select: {
+            user_id: true,
+            name: true,
+            student_id: true,
+            undergrad_first_major: true,
+          },
+        },
+        admin_memos: {
+          take: 1,
+          orderBy: { created_at: "desc" },
+          select: { memo_content: true },
+        },
+      },
+    }),
+    prisma.application.count({ where }),
+  ]);
+
+  // mentor 의 경우 페이지에 들어온 user_id 들로 latest mentor_record 조회
+  let lawschoolByUser: Map<string, string | null> | null = null;
+  if (role === "mentor") {
+    const userIds = rows.map((r) => r.user.user_id);
+    const records =
+      userIds.length === 0
+        ? []
+        : await prisma.mentorRecord.findMany({
+            where: { user_id: { in: userIds } },
+            orderBy: { process_year: "desc" },
+            select: { user_id: true, lawschool_name: true },
+          });
+    lawschoolByUser = new Map();
+    for (const r of records) {
+      if (!lawschoolByUser.has(r.user_id)) {
+        lawschoolByUser.set(r.user_id, r.lawschool_name);
+      }
+    }
+  }
+
+  const data = rows.map((row) => {
+    // Prisma include + take:1 결과는 객체가 아닌 길이 1 배열. [0]?. 로 추출.
+    const memo = row.admin_memos[0]?.memo_content ?? null;
+    const base = {
+      applicationId: row.application_id,
+      name: row.user.name,
+      studentId: row.user.student_id ?? "",
+      status: applicationStatusToLabel(row.application_status),
+      memo,
+      submittedAt: row.submitted_at?.toISOString() ?? null,
+    };
+    if (role === "mentee") {
+      return { ...base, major: row.user.undergrad_first_major ?? "" };
+    }
+    return { ...base, school: lawschoolByUser?.get(row.user.user_id) ?? null };
+  });
+
+  return NextResponse.json({ data, totalCount, page, limit });
+}

--- a/apps/api/src/app/api/admin/matchings/eligible/route.ts
+++ b/apps/api/src/app/api/admin/matchings/eligible/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@plawcess/database";
+import { requireAdmin } from "@/lib/admin-guard";
+import { resolveProcessYear } from "@/lib/active-cycle";
+
+export async function GET(req: NextRequest) {
+  const guard = requireAdmin(req);
+  if (guard.error) return guard.error;
+
+  const yr = await resolveProcessYear(req);
+  if (yr.error) return yr.error;
+  const year = yr.year;
+
+  const baseSelect = {
+    application_id: true,
+    user: {
+      select: {
+        user_id: true,
+        name: true,
+        student_id: true,
+        account_status: true,
+        undergrad_first_major: true,
+      },
+    },
+  } as const;
+
+  const [menteeRows, mentorRows] = await prisma.$transaction([
+    prisma.application.findMany({
+      where: { role: "mentee", process_year: year, application_status: "approved" },
+      orderBy: { user: { name: "asc" } },
+      select: baseSelect,
+    }),
+    prisma.application.findMany({
+      where: { role: "mentor", process_year: year, application_status: "approved" },
+      orderBy: { user: { name: "asc" } },
+      select: baseSelect,
+    }),
+  ]);
+
+  // 멘토 latest record 의 lawschool_name
+  const mentorUserIds = mentorRows.map((r) => r.user.user_id);
+  const records =
+    mentorUserIds.length === 0
+      ? []
+      : await prisma.mentorRecord.findMany({
+          where: { user_id: { in: mentorUserIds } },
+          orderBy: { process_year: "desc" },
+          select: { user_id: true, lawschool_name: true },
+        });
+  const lawschoolByUser = new Map<string, string | null>();
+  for (const r of records) {
+    if (!lawschoolByUser.has(r.user_id)) {
+      lawschoolByUser.set(r.user_id, r.lawschool_name);
+    }
+  }
+
+  return NextResponse.json({
+    year,
+    mentees: menteeRows.map((r) => ({
+      applicationId: r.application_id,
+      userId: r.user.user_id,
+      name: r.user.name,
+      studentId: r.user.student_id ?? "",
+      major: r.user.undergrad_first_major ?? "",
+      accountStatus: r.user.account_status,
+    })),
+    mentors: mentorRows.map((r) => ({
+      applicationId: r.application_id,
+      userId: r.user.user_id,
+      name: r.user.name,
+      studentId: r.user.student_id ?? "",
+      lawSchool: lawschoolByUser.get(r.user.user_id) ?? null,
+      accountStatus: r.user.account_status,
+    })),
+  });
+}

--- a/apps/api/src/app/api/admin/users/route.ts
+++ b/apps/api/src/app/api/admin/users/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@plawcess/database";
+import { requireAdmin } from "@/lib/admin-guard";
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+function parsePagination(req: NextRequest):
+  | { page: number; limit: number; error?: undefined }
+  | { error: NextResponse; page?: undefined; limit?: undefined } {
+  const pageRaw = req.nextUrl.searchParams.get("page");
+  const limitRaw = req.nextUrl.searchParams.get("limit");
+  const page = pageRaw ? parseInt(pageRaw, 10) : 1;
+  const limit = limitRaw ? parseInt(limitRaw, 10) : DEFAULT_LIMIT;
+  if (!Number.isInteger(page) || page < 1) {
+    return { error: NextResponse.json({ error: "page 가 올바르지 않습니다." }, { status: 400 }) };
+  }
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+    return { error: NextResponse.json({ error: `limit 은 1~${MAX_LIMIT} 사이여야 합니다.` }, { status: 400 }) };
+  }
+  return { page, limit };
+}
+
+export async function GET(req: NextRequest) {
+  const guard = requireAdmin(req);
+  if (guard.error) return guard.error;
+
+  const role = req.nextUrl.searchParams.get("role");
+  if (role !== "mentee" && role !== "mentor") {
+    return NextResponse.json(
+      { error: "role 은 mentee 또는 mentor 여야 합니다." },
+      { status: 400 },
+    );
+  }
+
+  const pg = parsePagination(req);
+  if (pg.error) return pg.error;
+  const { page, limit } = pg;
+
+  const where = { is_deleted: false, current_role: role } as const;
+  const [users, totalCount] = await prisma.$transaction([
+    prisma.user.findMany({
+      where,
+      orderBy: { name: "asc" },
+      skip: (page - 1) * limit,
+      take: limit,
+      select: {
+        user_id: true,
+        name: true,
+        student_id: true,
+        phone: true,
+        account_status: true,
+        undergrad_first_major: true,
+        undergrad_second_major: true,
+      },
+    }),
+    prisma.user.count({ where }),
+  ]);
+
+  if (role === "mentee") {
+    return NextResponse.json({
+      data: users.map((u) => ({
+        userId: u.user_id,
+        name: u.name,
+        studentId: u.student_id ?? "",
+        firstMajor: u.undergrad_first_major,
+        secondMajor: u.undergrad_second_major,
+        phone: u.phone ?? "",
+        accountStatus: u.account_status,
+      })),
+      totalCount,
+      page,
+      limit,
+    });
+  }
+
+  // role === "mentor": latest MentorRecord per user (페이지 사이즈만큼만)
+  const userIds = users.map((u) => u.user_id);
+  const records =
+    userIds.length === 0
+      ? []
+      : await prisma.mentorRecord.findMany({
+          where: { user_id: { in: userIds } },
+          orderBy: { process_year: "desc" },
+          select: { user_id: true, lawschool_name: true, lawschool_grade: true },
+        });
+  const latestByUser = new Map<string, { lawschool_name: string | null; lawschool_grade: number | null }>();
+  for (const r of records) {
+    if (!latestByUser.has(r.user_id)) {
+      latestByUser.set(r.user_id, { lawschool_name: r.lawschool_name, lawschool_grade: r.lawschool_grade });
+    }
+  }
+
+  return NextResponse.json({
+    data: users.map((u) => {
+      const r = latestByUser.get(u.user_id);
+      return {
+        userId: u.user_id,
+        name: u.name,
+        studentId: u.student_id ?? "",
+        lawSchool: r?.lawschool_name ?? null,
+        cohort: r?.lawschool_grade ?? null,
+        phone: u.phone ?? "",
+        accountStatus: u.account_status,
+      };
+    }),
+    totalCount,
+    page,
+    limit,
+  });
+}

--- a/apps/api/src/app/api/announcements/[id]/route.ts
+++ b/apps/api/src/app/api/announcements/[id]/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@plawcess/database";
+import { getTokenFromCookie } from "@/lib/auth";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const payload = getTokenFromCookie(req);
+  if (!payload) {
+    return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const row = await prisma.announcement.findUnique({
+    where: { announcement_id: id },
+    include: { created_by: { select: { name: true } } },
+  });
+  if (!row) {
+    return NextResponse.json({ error: "해당 공지사항이 없습니다." }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    announcementId: row.announcement_id,
+    title: row.title,
+    body: row.body,
+    createdAt: row.created_at.toISOString(),
+    author: row.created_by.name,
+  });
+}

--- a/apps/api/src/app/api/announcements/route.ts
+++ b/apps/api/src/app/api/announcements/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@plawcess/database";
+import { getTokenFromCookie } from "@/lib/auth";
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+function parsePagination(req: NextRequest):
+  | { page: number; limit: number; error?: undefined }
+  | { error: NextResponse; page?: undefined; limit?: undefined } {
+  const pageRaw = req.nextUrl.searchParams.get("page");
+  const limitRaw = req.nextUrl.searchParams.get("limit");
+  const page = pageRaw ? parseInt(pageRaw, 10) : 1;
+  const limit = limitRaw ? parseInt(limitRaw, 10) : DEFAULT_LIMIT;
+  if (!Number.isInteger(page) || page < 1) {
+    return { error: NextResponse.json({ error: "page 가 올바르지 않습니다." }, { status: 400 }) };
+  }
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+    return { error: NextResponse.json({ error: `limit 은 1~${MAX_LIMIT} 사이여야 합니다.` }, { status: 400 }) };
+  }
+  return { page, limit };
+}
+
+export async function GET(req: NextRequest) {
+  const payload = getTokenFromCookie(req);
+  if (!payload) {
+    return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
+  }
+
+  const pg = parsePagination(req);
+  if (pg.error) return pg.error;
+  const { page, limit } = pg;
+
+  const [rows, totalCount] = await prisma.$transaction([
+    prisma.announcement.findMany({
+      orderBy: { created_at: "desc" },
+      skip: (page - 1) * limit,
+      take: limit,
+      include: { created_by: { select: { name: true } } },
+    }),
+    prisma.announcement.count(),
+  ]);
+
+  return NextResponse.json({
+    data: rows.map((row) => ({
+      announcementId: row.announcement_id,
+      title: row.title,
+      body: row.body,
+      createdAt: row.created_at.toISOString(),
+      author: row.created_by.name,
+    })),
+    totalCount,
+    page,
+    limit,
+  });
+}

--- a/apps/api/src/lib/active-cycle.ts
+++ b/apps/api/src/lib/active-cycle.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@plawcess/database";
+
+/**
+ * 쿼리스트링 ?year=YYYY 를 파싱한다. 미지정 시 활성 CycleSchedule.process_year 로 fallback.
+ * 활성 cycle 도 없고 year 도 없으면 400.
+ *
+ * 사용:
+ *   const r = await resolveProcessYear(req);
+ *   if (r.error) return r.error;
+ *   const year = r.year;
+ */
+export async function resolveProcessYear(
+  req: NextRequest,
+): Promise<
+  | { year: number; error?: undefined }
+  | { error: NextResponse; year?: undefined }
+> {
+  const raw = req.nextUrl.searchParams.get("year");
+  if (raw !== null) {
+    const match = raw.match(/\d{4}/);
+    if (!match) {
+      return {
+        error: NextResponse.json({ error: "year 형식이 올바르지 않습니다." }, { status: 400 }),
+      };
+    }
+    return { year: parseInt(match[0], 10) };
+  }
+
+  const active = await prisma.cycleSchedule.findFirst({
+    where: { is_active: true },
+    select: { process_year: true },
+  });
+  if (!active) {
+    return {
+      error: NextResponse.json(
+        { error: "활성 사이클이 없습니다. year 를 명시해주세요." },
+        { status: 400 },
+      ),
+    };
+  }
+  return { year: active.process_year };
+}

--- a/apps/api/src/lib/admin-guard.ts
+++ b/apps/api/src/lib/admin-guard.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getTokenFromCookie, type TokenPayload } from "./auth";
+
+/**
+ * Admin 라우트 진입 시 호출. proxy 가드를 통과한 뒤에도 라우트 핸들러에서 한 번 더 검증한다(defense in depth).
+ *
+ * 사용:
+ *   const guard = requireAdmin(req);
+ *   if (guard.error) return guard.error;
+ *   const adminPayload = guard.payload;
+ */
+export function requireAdmin(
+  req: NextRequest,
+):
+  | { error: NextResponse; payload?: undefined }
+  | { error?: undefined; payload: TokenPayload } {
+  const payload = getTokenFromCookie(req);
+  if (!payload) {
+    return {
+      error: NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 }),
+    };
+  }
+  if (payload.current_role !== "admin") {
+    return {
+      error: NextResponse.json({ error: "관리자 권한이 필요합니다." }, { status: 403 }),
+    };
+  }
+  return { payload };
+}

--- a/apps/api/src/lib/labels.ts
+++ b/apps/api/src/lib/labels.ts
@@ -73,3 +73,14 @@ export function labelToDate(label: string): Date | null {
 export function yearToLabel(y: number | null | undefined): string {
   return y == null ? "" : y.toString();
 }
+
+// ---------- application_status (BE enum → FE label) ----------
+const APPLICATION_STATUS_TO_LABEL: Record<string, string> = {
+  submitted: "pending",
+  approved: "approved",
+  rejected: "rejected",
+  revision_requested: "revision",
+};
+export function applicationStatusToLabel(s: string | null | undefined): string {
+  return s ? (APPLICATION_STATUS_TO_LABEL[s] ?? "") : "";
+}

--- a/docs/api/api-spec.md
+++ b/docs/api/api-spec.md
@@ -380,3 +380,81 @@
   - 활성 cycle 있음: 단일 행 객체
   - 활성 cycle 없음: `null`
 - 401: 로그인 안 됨
+
+
+## #176 Admin 페이지 API
+
+### 공통 페이지네이션 래퍼
+
+배열형 응답은 모두 `{ data, totalCount, page, limit }` 형태. Query 파라미터 `?page=1&limit=50` (기본). `limit` 상한 200.
+
+### `GET /api/admin/users`
+
+회원관리 — 멘티/멘토 회원 목록.
+
+- 권한: admin
+- Query: `role=mentee|mentor` (필수), `page`, `limit`
+- Response 200: 페이지네이션 래퍼. `data` 항목은 멘티/멘토 역할에 따라 다름.
+  - 멘티: `{ userId, name, studentId, firstMajor, secondMajor, phone, accountStatus }`
+  - 멘토: `{ userId, name, studentId, lawSchool, cohort, phone, accountStatus }` — 가장 최근 MentorRecord 기준.
+- 400: role 누락/오류, page/limit 오류
+
+### `GET /api/admin/applications`
+
+신청관리 — 멘티/멘토 신청 목록.
+
+- 권한: admin
+- Query: `role=mentee|mentor` (필수), `year=YYYY` (옵션, 기본 활성 cycle), `page`, `limit`
+- Response 200: 페이지네이션 래퍼. `data` 항목:
+  - 공통: `{ applicationId, name, studentId, status, memo, submittedAt }`
+  - 멘티: `+ major`, 멘토: `+ school`
+- `status` 라벨 매핑: `submitted→pending` / `approved→approved` / `rejected→rejected` / `revision_requested→revision`
+- 400: role 누락/오류, year 형식, 활성 cycle 없음
+
+### `GET /api/admin/matchings/eligible`
+
+매칭관리 — `application_status='approved'` 멘티+멘토 풀.
+
+- 권한: admin
+- Query: `year=YYYY` (옵션, 기본 활성 cycle)
+- Response 200 (페이지네이션 미적용):
+  ```json
+  {
+    "year": 2026,
+    "mentees": [{ "applicationId", "userId", "name", "studentId", "major", "accountStatus" }],
+    "mentors": [{ "applicationId", "userId", "name", "studentId", "lawSchool", "accountStatus" }]
+  }
+  ```
+- 400: 활성 cycle 없고 year 미지정
+
+### `POST /api/admin/announcements`
+
+- 권한: admin
+- Body: `{ title: string (1~100자), body: string (1자 이상) }`
+- Response 201: `{ announcementId, title, body, createdAt, author }`
+- 400: 검증 실패
+
+### `GET /api/admin/announcements`
+
+- 권한: admin
+- Query: `page`, `limit`
+- Response 200: 페이지네이션 래퍼. `data` 항목 = POST 응답 형태.
+
+### `DELETE /api/admin/announcements/:id`
+
+- 권한: admin
+- Response 200: `{ "success": true }`
+- 404: 없는 id
+
+### `GET /api/announcements`
+
+- 권한: 로그인 필수 (멘티/멘토/admin)
+- Query: `page`, `limit`
+- Response 200: 페이지네이션 래퍼. `data` 항목 = POST 응답 형태.
+- 401: 비로그인
+
+### `GET /api/announcements/:id`
+
+- 권한: 로그인 필수
+- Response 200: `{ announcementId, title, body, createdAt, author }`
+- 401, 404

--- a/docs/superpowers/handoff/2026-05-11-fe-admin-api.md
+++ b/docs/superpowers/handoff/2026-05-11-fe-admin-api.md
@@ -1,0 +1,450 @@
+# [FE] Admin 페이지 API 적용 (#176)
+
+**Title 후보:** `feat(FE): admin 페이지 4종 — mock 제거, BE API 연결`
+**Labels:** `frontend`, `enhancement`
+**관련 BE PR:** (BE PR 머지 후 채울 것 — 브랜치 `176-be-admin-api-만들어죠`)
+**Spec:** `docs/superpowers/specs/2026-05-10-admin-api-design.md`
+**API 계약:** `docs/api/api-spec.md`
+
+## 요약
+
+Admin 4개 화면(회원관리·신청관리·매칭관리·공지사항)과 멘티/멘토 공지사항 화면의 mock 데이터를 BE 응답으로 교체. 새로 추가된 Announcement 테이블을 사용한 공지 CRUD 도 wiring 한다.
+
+## 공통 응답 규약
+
+### 1) 응답 케이스 — 모두 카멜케이스
+
+`user_id`/`student_id` 같은 snake_case 필드는 응답에 없다. 전부 `userId`, `studentId` 등 카멜케이스로 변환되어 옴. FE mock 의 `user_id` 필드명은 `userId` 로 일괄 교체 필요.
+
+### 2) 페이지네이션 래퍼 — 배열형 응답은 모두 래핑
+
+배열을 반환하는 API는 다음 형태로 응답:
+
+```json
+{
+  "data": [ ... ],
+  "totalCount": 137,
+  "page": 1,
+  "limit": 50
+}
+```
+
+- Query 파라미터: `?page=1&limit=50` (기본값). `limit` 상한 200, 1 미만/초과 시 400.
+- 적용 대상: `users`, `applications`, `admin announcements`, `public announcements`.
+- **미적용**: `eligible` (단일 객체 응답).
+
+기존 FE 의 클라이언트 페이지네이션(메모리에서 자르기)은 **서버 페이지네이션으로 교체**해야 한다. `totalCount` 로 `totalPages = Math.ceil(totalCount / limit)` 계산, `?page=` 로 이동.
+
+### 3) 인증
+
+- `/api/admin/*` — admin 만 접근. 비로그인 401, 비-admin 403.
+- `/api/announcements`, `/api/announcements/:id` — 로그인된 모든 유저(멘티/멘토/admin). 비로그인 401.
+
+---
+
+## 1. GET /api/admin/users (회원관리)
+
+  Query: `?role=mentee|mentor` (필수), `?page`, `?limit`
+
+  WHERE: `users.is_deleted = false AND current_role = $role`
+
+  SELECT:
+  - 공통: `userId, name, studentId, phone, accountStatus`
+  - 멘티: + `firstMajor, secondMajor` (학부 제1전공·제2전공)
+  - 멘토: + 가장 최근 MentorRecord 의 `lawSchool, cohort` (사용자별 `process_year DESC LIMIT 1`)
+
+  정렬: `name ASC`
+
+  응답 (멘티 예시):
+  ```json
+  {
+    "data": [
+      {
+        "userId": "uuid",
+        "name": "김민준",
+        "studentId": "2020123456",
+        "firstMajor": "법학과",
+        "secondMajor": null,
+        "phone": "010-1234-5678",
+        "accountStatus": "active"
+      }
+    ],
+    "totalCount": 12,
+    "page": 1,
+    "limit": 50
+  }
+  ```
+
+  응답 (멘토 예시):
+  ```json
+  {
+    "data": [
+      {
+        "userId": "uuid",
+        "name": "최수진",
+        "studentId": "2018456789",
+        "lawSchool": "서울대학교 로스쿨",
+        "cohort": 7,
+        "phone": "010-4567-8901",
+        "accountStatus": "active"
+      }
+    ],
+    "totalCount": 7,
+    "page": 1,
+    "limit": 50
+  }
+  ```
+
+  에러:
+  - 400 (role 누락/오류, page/limit 범위 위반)
+  - 401 (비로그인) / 403 (비-admin)
+
+---
+
+## 2. GET /api/admin/applications (신청관리)
+
+  Query: `?role=mentee|mentor` (필수), `?year=YYYY` (옵션, 기본 활성 cycle), `?page`, `?limit`
+
+  WHERE:
+  ```
+  applications.role = $role
+  AND applications.process_year = $year
+  AND applications.application_status IN
+      ('submitted','approved','rejected','revision_requested')
+  ```
+  (즉 `draft` 임시저장은 제외)
+
+  SELECT:
+  - 공통: `applicationId, name, studentId, status, memo, submittedAt`
+  - 멘티: + `major` (User.undergrad_first_major)
+  - 멘토: + `school` (가장 최근 MentorRecord.lawschool_name)
+
+  상태 라벨 매핑 (BE enum → FE 표시):
+  | DB enum | FE label |
+  |---|---|
+  | `submitted` | `pending` |
+  | `approved` | `approved` |
+  | `rejected` | `rejected` |
+  | `revision_requested` | `revision` |
+
+  관리자 메모는 같은 application 의 가장 최근 1건만 단일 string 으로 (`memo`). 없으면 `null`.
+
+  정렬: `submitted_at DESC`
+
+  응답 (멘티 예시):
+  ```json
+  {
+    "data": [
+      {
+        "applicationId": "uuid",
+        "name": "김민준",
+        "studentId": "2020123456",
+        "major": "법학과",
+        "status": "approved",
+        "memo": "서류 확인 완료",
+        "submittedAt": "2026-04-10T03:21:00.000Z"
+      }
+    ],
+    "totalCount": 24,
+    "page": 1,
+    "limit": 50
+  }
+  ```
+
+  응답 (멘토 예시): `major` 대신 `school: "서울대학교 로스쿨"`.
+
+  에러:
+  - 400 (role 누락/오류, year 형식, 활성 cycle 없고 year 미지정, page/limit 범위)
+  - 401 / 403
+
+---
+
+## 3. GET /api/admin/matchings/eligible (매칭 적격 풀)
+
+  Query: `?year=YYYY` (옵션, 기본 활성 cycle)
+
+  역할: AI 매칭 알고리즘의 **입력 후보군**. `application_status='approved'` 인 멘티+멘토 양쪽을 한 번에 반환. 이미 매칭됐는지 여부는 거르지 않음(재배정 시나리오 허용).
+
+  WHERE:
+  - mentees: `role='mentee' AND application_status='approved' AND process_year=$year`
+  - mentors: 위 + `role='mentor'`
+
+  정렬: 둘 다 `name ASC`
+
+  응답 (페이지네이션 미적용 — 단일 객체):
+  ```json
+  {
+    "year": 2026,
+    "mentees": [
+      {
+        "applicationId": "uuid",
+        "userId": "uuid",
+        "name": "김민준",
+        "studentId": "2020123456",
+        "major": "법학과",
+        "accountStatus": "active"
+      }
+    ],
+    "mentors": [
+      {
+        "applicationId": "uuid",
+        "userId": "uuid",
+        "name": "최수진",
+        "studentId": "2018456789",
+        "lawSchool": "서울대학교 로스쿨",
+        "accountStatus": "active"
+      }
+    ]
+  }
+  ```
+
+  에러:
+  - 400 (활성 cycle 없고 year 미지정)
+  - 401 / 403
+
+---
+
+## 4. POST /api/admin/announcements (공지 작성)
+
+  Body:
+  ```json
+  { "title": "string (1~100자)", "body": "string (1자 이상)" }
+  ```
+
+  처리:
+  - title/body 양쪽 trim 후 길이 검증
+  - `created_by_user_id` 는 admin 세션 payload 에서 자동 채움
+
+  응답 201:
+  ```json
+  {
+    "announcementId": "uuid",
+    "title": "...",
+    "body": "...",
+    "createdAt": "2026-05-11T01:23:45.000Z",
+    "author": "관리자 이름"
+  }
+  ```
+
+  에러:
+  - 400 (title 길이/누락, body 누락, JSON 파싱 실패)
+  - 401 / 403
+
+---
+
+## 5. GET /api/admin/announcements (관리자 공지 목록)
+
+  Query: `?page`, `?limit`
+
+  정렬: `created_at DESC`
+
+  응답:
+  ```json
+  {
+    "data": [
+      {
+        "announcementId": "uuid",
+        "title": "2026학년도 멘토 모집 안내",
+        "body": "본문 ...",
+        "createdAt": "2026-04-10T00:00:00.000Z",
+        "author": "관리자 이름"
+      }
+    ],
+    "totalCount": 8,
+    "page": 1,
+    "limit": 50
+  }
+  ```
+
+  에러:
+  - 400 (page/limit 범위)
+  - 401 / 403
+
+---
+
+## 6. DELETE /api/admin/announcements/:id (공지 삭제)
+
+  URL 파라미터: `:id` = `announcementId`(uuid)
+
+  처리: hard delete (복구 불가)
+
+  응답 200:
+  ```json
+  { "success": true }
+  ```
+
+  에러:
+  - 404 (없는 id)
+  - 401 / 403
+
+---
+
+## 7. GET /api/announcements (공개 목록)
+
+  대상: 로그인된 멘티/멘토/admin 모두.
+
+  Query: `?page`, `?limit`
+
+  정렬·응답 형태: 5번(관리자 목록)과 **동일**.
+
+  응답:
+  ```json
+  {
+    "data": [
+      {
+        "announcementId": "uuid",
+        "title": "...",
+        "body": "...",
+        "createdAt": "...",
+        "author": "관리자 이름"
+      }
+    ],
+    "totalCount": 8,
+    "page": 1,
+    "limit": 50
+  }
+  ```
+
+  에러:
+  - 401 (비로그인)
+  - 400 (page/limit 범위)
+
+---
+
+## 8. GET /api/announcements/:id (공개 상세)
+
+  URL 파라미터: `:id` = `announcementId`(uuid)
+
+  응답 200 (단일 객체):
+  ```json
+  {
+    "announcementId": "uuid",
+    "title": "...",
+    "body": "...",
+    "createdAt": "...",
+    "author": "관리자 이름"
+  }
+  ```
+
+  에러:
+  - 401 (비로그인)
+  - 404 (없는 id)
+
+---
+
+## FE 작업 체크리스트
+
+화면별 mock 제거 + 위 API 와 wiring:
+
+### `/admin/users` (회원관리)
+- [ ] mock `MENTEES`, `MENTORS` 배열 제거
+- [ ] `?role` 파라미터 + 페이지네이션 wiring (서버 페이지로 교체)
+- [ ] mock `user_id` 필드명을 `userId` 로 변경
+- [ ] 멘티 `college` 필드 → `firstMajor`, `major` → `secondMajor` 로 명확화
+- [ ] 멘토 `cohort` 표시 시 응답이 number → 한국어 `${cohort}기` 포맷팅
+
+### `/admin/applications` (신청관리)
+- [ ] mock `MENTEE_APPLICATIONS`, `MENTOR_APPLICATIONS` 제거
+- [ ] `?role` + `?year` + 페이지네이션 wiring
+- [ ] `submittedAt` 표시 추가(원하면)
+- [ ] 신청 상태 BE 라벨(`pending|approved|rejected|revision`) 그대로 사용
+
+### `/admin/matchings` (매칭관리)
+- [ ] mock `APPROVED_MENTEES`, `APPROVED_MENTORS` 제거
+- [ ] `GET /api/admin/matchings/eligible?year=` 한 번 호출 → `.mentees`, `.mentors` 두 테이블에 분배
+- [ ] 페이지네이션 없음(단일 풀)
+
+### `/admin/announcements/create` (공지 작성·삭제)
+- [ ] mock `MOCK_ANNOUNCEMENTS` 제거
+- [ ] 페이지 진입 시 `GET /api/admin/announcements` 로 리스트 로드
+- [ ] 폼 제출 → `POST /api/admin/announcements`, 응답을 리스트 prepend
+- [ ] 삭제 → `DELETE /api/admin/announcements/:id`, 200 OK 후 클라이언트에서 제거
+- [ ] 404 응답 발생 시 alert 후 리스트 새로고침
+
+### `/announcements`, `/mentee/announcements`, `/mentor/announcements` (공개 목록)
+- [ ] 공통 컴포넌트 `components/announcements/AnnouncementList.tsx` 의 `MOCK_ANNOUNCEMENTS` import 제거
+- [ ] `GET /api/announcements` 응답으로 교체 (3개 진입 경로 모두 같은 데이터)
+- [ ] basePath 별로 detail 링크 그대로 유지
+
+### `/{role}/announcements/[id]` (공개 상세)
+- [ ] mock 데이터 import 제거
+- [ ] `GET /api/announcements/:id` 호출, 404 처리
+- [ ] 본문 줄바꿈 보존 (`white-space: pre-wrap`)
+
+### lib/api.ts (또는 fetch 헬퍼)
+- [ ] 위 8개 엔드포인트 type 정의 + fetch 함수 추가
+- [ ] 페이지네이션 응답 공통 타입:
+  ```ts
+  type Paged<T> = { data: T[]; totalCount: number; page: number; limit: number };
+  ```
+
+## 참고 — 응답 type 초안 (TypeScript)
+
+```ts
+export type AccountStatus = 'active' | 'inactive' | 'blocked';
+export type ApplicationStatusLabel = 'pending' | 'approved' | 'rejected' | 'revision';
+
+export type MenteeRow = {
+  userId: string;
+  name: string;
+  studentId: string;
+  firstMajor: string | null;
+  secondMajor: string | null;
+  phone: string;
+  accountStatus: AccountStatus;
+};
+
+export type MentorRow = {
+  userId: string;
+  name: string;
+  studentId: string;
+  lawSchool: string | null;
+  cohort: number | null;
+  phone: string;
+  accountStatus: AccountStatus;
+};
+
+export type ApplicationRow = {
+  applicationId: string;
+  name: string;
+  studentId: string;
+  status: ApplicationStatusLabel;
+  memo: string | null;
+  submittedAt: string | null;
+} & ({ major: string } | { school: string | null });
+
+export type EligiblePool = {
+  year: number;
+  mentees: Array<{
+    applicationId: string;
+    userId: string;
+    name: string;
+    studentId: string;
+    major: string;
+    accountStatus: AccountStatus;
+  }>;
+  mentors: Array<{
+    applicationId: string;
+    userId: string;
+    name: string;
+    studentId: string;
+    lawSchool: string | null;
+    accountStatus: AccountStatus;
+  }>;
+};
+
+export type AnnouncementRow = {
+  announcementId: string;
+  title: string;
+  body: string;
+  createdAt: string;
+  author: string;
+};
+
+export type Paged<T> = {
+  data: T[];
+  totalCount: number;
+  page: number;
+  limit: number;
+};
+```

--- a/docs/superpowers/plans/2026-05-10-admin-api.md
+++ b/docs/superpowers/plans/2026-05-10-admin-api.md
@@ -1,0 +1,1175 @@
+# Admin 페이지 API 구현 플랜 (#176)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Admin 페이지 4개 화면(회원관리·신청관리·매칭관리·공지사항)의 BE API 8종 엔드포인트와 Announcement 새 테이블을 구현한다.
+
+**Architecture:** 기존 proxy 미들웨어가 `/api/admin/*`에 admin role 가드를 이미 적용하고 있다. 본 플랜은 라우트 핸들러 8개와 공통 헬퍼 2개(admin-guard / active-cycle)를 추가하고, 새 Announcement 모델·마이그레이션을 생성한다. 응답은 카멜케이스 통일, 배열형 응답은 `{ data, totalCount, page, limit }` 래퍼로 통일.
+
+**Tech Stack:** Next.js 16 Route Handlers, Prisma 7, PostgreSQL (Supabase), TypeScript, pnpm workspace.
+
+**Spec:** `docs/superpowers/specs/2026-05-10-admin-api-design.md`
+
+**프로젝트 컨벤션 메모:**
+- 본 프로젝트는 단위 테스트 도구를 채택하지 않음. CI는 typecheck + build 만 실행. 검증은 (a) `pnpm -F @plawcess/api typecheck` (b) curl/HTTP 호출로 수행.
+- 마이그레이션 timestamp 는 `YYYYMMDDhhmmss` (분·초까지). 공유 dev DB 적용은 PR 머지 후 별도 단계 — 본 플랜 안에서는 SQL 작성만.
+- BE 전용. `apps/web/` 수정 금지. FE 핸드오프 메모는 spec 마지막 섹션 참조.
+- PR 생성: gh CLI 미설치. push 후 URL + Title + Body 초안을 사용자에게 텍스트로 전달.
+
+---
+
+## Task 1: Announcement 스키마 + 마이그레이션 SQL
+
+**Files:**
+- Modify: `packages/database/prisma/schema.prisma`
+- Create: `packages/database/prisma/migrations/20260510130000_announcements/migration.sql`
+
+- [ ] **Step 1: schema.prisma 에 Announcement 모델 추가**
+
+`packages/database/prisma/schema.prisma` 끝(파일 마지막 `// ===` 주석 블록 직전)에 추가:
+
+```prisma
+// ----------------------------------------------------------------
+// 10. announcements (#176)
+//    - 관리자 작성 공지. 멘티/멘토/admin 모두 읽기 가능.
+//    - hard delete (soft delete 미적용)
+// ----------------------------------------------------------------
+model Announcement {
+  announcement_id    String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  title              String   @db.VarChar(100)
+  body               String   @db.Text
+  created_by_user_id String   @db.Uuid
+  created_at         DateTime @default(now())
+  updated_at         DateTime @updatedAt
+
+  created_by User @relation("AnnouncementCreatedBy", fields: [created_by_user_id], references: [user_id])
+
+  @@index([created_at])
+  @@map("announcements")
+}
+```
+
+- [ ] **Step 2: User 모델에 역참조 추가**
+
+`packages/database/prisma/schema.prisma`의 `model User { ... }` 안 `// relations` 섹션 (현재 `password_reset_tokens` 라인 아래)에 한 줄 추가:
+
+```prisma
+  created_announcements Announcement[] @relation("AnnouncementCreatedBy")
+```
+
+- [ ] **Step 3: 마이그레이션 SQL 작성**
+
+`packages/database/prisma/migrations/20260510130000_announcements/migration.sql` 생성:
+
+```sql
+-- CreateTable
+CREATE TABLE "announcements" (
+    "announcement_id"    UUID NOT NULL DEFAULT gen_random_uuid(),
+    "title"              VARCHAR(100) NOT NULL,
+    "body"               TEXT NOT NULL,
+    "created_by_user_id" UUID NOT NULL,
+    "created_at"         TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"         TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "announcements_pkey" PRIMARY KEY ("announcement_id")
+);
+
+-- CreateIndex
+CREATE INDEX "announcements_created_at_idx" ON "announcements"("created_at");
+
+-- AddForeignKey
+ALTER TABLE "announcements"
+    ADD CONSTRAINT "announcements_created_by_user_id_fkey"
+    FOREIGN KEY ("created_by_user_id") REFERENCES "users"("user_id")
+    ON DELETE RESTRICT ON UPDATE CASCADE;
+```
+
+- [ ] **Step 4: Prisma 클라이언트 재생성**
+
+```powershell
+pnpm -F @plawcess/database prisma generate
+```
+
+Expected: 콘솔에 `Generated Prisma Client` 메시지. 에러 없음.
+
+- [ ] **Step 5: typecheck 통과 확인**
+
+```powershell
+pnpm -F @plawcess/api typecheck
+```
+
+Expected: 에러 없음. (이 시점엔 라우트가 새 모델을 아직 안 쓰므로 영향 없음)
+
+- [ ] **Step 6: 커밋**
+
+```powershell
+git add packages/database/prisma/schema.prisma packages/database/prisma/migrations/20260510130000_announcements/
+git commit -m "feat(#176): Announcement 모델 + 마이그레이션 SQL"
+```
+
+---
+
+## Task 2: admin-guard 공통 헬퍼
+
+**Files:**
+- Create: `apps/api/src/lib/admin-guard.ts`
+
+기존 `cycle-schedules/route.ts` 의 `requireAdminInline` 패턴을 공통 헬퍼로 승격. 향후 admin 라우트에서 모두 import.
+
+- [ ] **Step 1: 헬퍼 파일 작성**
+
+`apps/api/src/lib/admin-guard.ts`:
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import { getTokenFromCookie, type TokenPayload } from "./auth";
+
+/**
+ * Admin 라우트 진입 시 호출. proxy 가드를 통과한 뒤에도 라우트 핸들러에서 한 번 더 검증한다(defense in depth).
+ *
+ * 사용:
+ *   const guard = requireAdmin(req);
+ *   if (guard.error) return guard.error;
+ *   const adminPayload = guard.payload;
+ */
+export function requireAdmin(
+  req: NextRequest,
+):
+  | { error: NextResponse; payload?: undefined }
+  | { error?: undefined; payload: TokenPayload } {
+  const payload = getTokenFromCookie(req);
+  if (!payload) {
+    return {
+      error: NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 }),
+    };
+  }
+  if (payload.current_role !== "admin") {
+    return {
+      error: NextResponse.json({ error: "관리자 권한이 필요합니다." }, { status: 403 }),
+    };
+  }
+  return { payload };
+}
+```
+
+- [ ] **Step 2: typecheck**
+
+```powershell
+pnpm -F @plawcess/api typecheck
+```
+
+Expected: 에러 없음.
+
+- [ ] **Step 3: 커밋**
+
+```powershell
+git add apps/api/src/lib/admin-guard.ts
+git commit -m "feat(#176): requireAdmin 공통 헬퍼"
+```
+
+---
+
+## Task 3: active-cycle 공통 헬퍼
+
+**Files:**
+- Create: `apps/api/src/lib/active-cycle.ts`
+
+`?year=YYYY` 파싱 + 활성 CycleSchedule fallback 을 공통화.
+
+- [ ] **Step 1: 헬퍼 파일 작성**
+
+`apps/api/src/lib/active-cycle.ts`:
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@plawcess/database";
+
+/**
+ * 쿼리스트링 ?year=YYYY 를 파싱한다. 미지정 시 활성 CycleSchedule.process_year 로 fallback.
+ * 활성 cycle 도 없고 year 도 없으면 400.
+ *
+ * 사용:
+ *   const r = await resolveProcessYear(req);
+ *   if (r.error) return r.error;
+ *   const year = r.year;
+ */
+export async function resolveProcessYear(
+  req: NextRequest,
+): Promise<
+  | { year: number; error?: undefined }
+  | { error: NextResponse; year?: undefined }
+> {
+  const raw = req.nextUrl.searchParams.get("year");
+  if (raw !== null) {
+    const match = raw.match(/\d{4}/);
+    if (!match) {
+      return {
+        error: NextResponse.json({ error: "year 형식이 올바르지 않습니다." }, { status: 400 }),
+      };
+    }
+    return { year: parseInt(match[0], 10) };
+  }
+
+  const active = await prisma.cycleSchedule.findFirst({
+    where: { is_active: true },
+    select: { process_year: true },
+  });
+  if (!active) {
+    return {
+      error: NextResponse.json(
+        { error: "활성 사이클이 없습니다. year 를 명시해주세요." },
+        { status: 400 },
+      ),
+    };
+  }
+  return { year: active.process_year };
+}
+```
+
+- [ ] **Step 2: typecheck**
+
+```powershell
+pnpm -F @plawcess/api typecheck
+```
+
+- [ ] **Step 3: 커밋**
+
+```powershell
+git add apps/api/src/lib/active-cycle.ts
+git commit -m "feat(#176): resolveProcessYear 공통 헬퍼"
+```
+
+---
+
+## Task 4: labels.ts — applicationStatusToLabel 추가
+
+**Files:**
+- Modify: `apps/api/src/lib/labels.ts`
+
+신청관리·기타 화면에서 BE enum → FE label 변환에 사용.
+
+- [ ] **Step 1: labels.ts 끝에 함수 추가**
+
+`apps/api/src/lib/labels.ts` 의 `yearToLabel` 함수 아래에 추가:
+
+```ts
+// ---------- application_status ----------
+const APPLICATION_STATUS_TO_LABEL: Record<string, string> = {
+  submitted: "pending",
+  approved: "approved",
+  rejected: "rejected",
+  revision_requested: "revision",
+};
+export function applicationStatusToLabel(s: string | null | undefined): string {
+  return s ? (APPLICATION_STATUS_TO_LABEL[s] ?? "") : "";
+}
+```
+
+- [ ] **Step 2: typecheck**
+
+```powershell
+pnpm -F @plawcess/api typecheck
+```
+
+- [ ] **Step 3: 커밋**
+
+```powershell
+git add apps/api/src/lib/labels.ts
+git commit -m "feat(#176): applicationStatusToLabel 라벨 매핑 추가"
+```
+
+---
+
+## Task 5: GET /api/admin/users
+
+**Files:**
+- Create: `apps/api/src/app/api/admin/users/route.ts`
+
+회원관리 — 멘티/멘토 회원 목록.
+
+- [ ] **Step 1: 라우트 작성**
+
+`apps/api/src/app/api/admin/users/route.ts`:
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@plawcess/database";
+import { requireAdmin } from "@/lib/admin-guard";
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+function parsePagination(req: NextRequest):
+  | { page: number; limit: number; error?: undefined }
+  | { error: NextResponse; page?: undefined; limit?: undefined } {
+  const pageRaw = req.nextUrl.searchParams.get("page");
+  const limitRaw = req.nextUrl.searchParams.get("limit");
+  const page = pageRaw ? parseInt(pageRaw, 10) : 1;
+  const limit = limitRaw ? parseInt(limitRaw, 10) : DEFAULT_LIMIT;
+  if (!Number.isInteger(page) || page < 1) {
+    return { error: NextResponse.json({ error: "page 가 올바르지 않습니다." }, { status: 400 }) };
+  }
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+    return { error: NextResponse.json({ error: `limit 은 1~${MAX_LIMIT} 사이여야 합니다.` }, { status: 400 }) };
+  }
+  return { page, limit };
+}
+
+export async function GET(req: NextRequest) {
+  const guard = requireAdmin(req);
+  if (guard.error) return guard.error;
+
+  const role = req.nextUrl.searchParams.get("role");
+  if (role !== "mentee" && role !== "mentor") {
+    return NextResponse.json(
+      { error: "role 은 mentee 또는 mentor 여야 합니다." },
+      { status: 400 },
+    );
+  }
+
+  const pg = parsePagination(req);
+  if (pg.error) return pg.error;
+  const { page, limit } = pg;
+
+  const where = { is_deleted: false, current_role: role } as const;
+  const [users, totalCount] = await prisma.$transaction([
+    prisma.user.findMany({
+      where,
+      orderBy: { name: "asc" },
+      skip: (page - 1) * limit,
+      take: limit,
+      select: {
+        user_id: true,
+        name: true,
+        student_id: true,
+        phone: true,
+        account_status: true,
+        undergrad_first_major: true,
+        undergrad_second_major: true,
+      },
+    }),
+    prisma.user.count({ where }),
+  ]);
+
+  if (role === "mentee") {
+    return NextResponse.json({
+      data: users.map((u) => ({
+        userId: u.user_id,
+        name: u.name,
+        studentId: u.student_id ?? "",
+        firstMajor: u.undergrad_first_major,
+        secondMajor: u.undergrad_second_major,
+        phone: u.phone ?? "",
+        accountStatus: u.account_status,
+      })),
+      totalCount,
+      page,
+      limit,
+    });
+  }
+
+  // role === "mentor": latest MentorRecord per user (페이지 사이즈만큼만)
+  const userIds = users.map((u) => u.user_id);
+  const records =
+    userIds.length === 0
+      ? []
+      : await prisma.mentorRecord.findMany({
+          where: { user_id: { in: userIds } },
+          orderBy: { process_year: "desc" },
+          select: { user_id: true, lawschool_name: true, lawschool_grade: true },
+        });
+  const latestByUser = new Map<string, { lawschool_name: string | null; lawschool_grade: number | null }>();
+  for (const r of records) {
+    if (!latestByUser.has(r.user_id)) {
+      latestByUser.set(r.user_id, { lawschool_name: r.lawschool_name, lawschool_grade: r.lawschool_grade });
+    }
+  }
+
+  return NextResponse.json({
+    data: users.map((u) => {
+      const r = latestByUser.get(u.user_id);
+      return {
+        userId: u.user_id,
+        name: u.name,
+        studentId: u.student_id ?? "",
+        lawSchool: r?.lawschool_name ?? null,
+        cohort: r?.lawschool_grade ?? null,
+        phone: u.phone ?? "",
+        accountStatus: u.account_status,
+      };
+    }),
+    totalCount,
+    page,
+    limit,
+  });
+}
+```
+
+- [ ] **Step 2: typecheck**
+
+```powershell
+pnpm -F @plawcess/api typecheck
+```
+
+- [ ] **Step 3: 커밋**
+
+```powershell
+git add apps/api/src/app/api/admin/users/route.ts
+git commit -m "feat(#176): GET /api/admin/users (회원관리)"
+```
+
+---
+
+## Task 6: GET /api/admin/applications
+
+**Files:**
+- Create: `apps/api/src/app/api/admin/applications/route.ts`
+
+신청관리 — 멘티/멘토 신청 목록.
+
+- [ ] **Step 1: 라우트 작성**
+
+`apps/api/src/app/api/admin/applications/route.ts`:
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@plawcess/database";
+import { requireAdmin } from "@/lib/admin-guard";
+import { resolveProcessYear } from "@/lib/active-cycle";
+import { applicationStatusToLabel } from "@/lib/labels";
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+function parsePagination(req: NextRequest):
+  | { page: number; limit: number; error?: undefined }
+  | { error: NextResponse; page?: undefined; limit?: undefined } {
+  const pageRaw = req.nextUrl.searchParams.get("page");
+  const limitRaw = req.nextUrl.searchParams.get("limit");
+  const page = pageRaw ? parseInt(pageRaw, 10) : 1;
+  const limit = limitRaw ? parseInt(limitRaw, 10) : DEFAULT_LIMIT;
+  if (!Number.isInteger(page) || page < 1) {
+    return { error: NextResponse.json({ error: "page 가 올바르지 않습니다." }, { status: 400 }) };
+  }
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+    return { error: NextResponse.json({ error: `limit 은 1~${MAX_LIMIT} 사이여야 합니다.` }, { status: 400 }) };
+  }
+  return { page, limit };
+}
+
+export async function GET(req: NextRequest) {
+  const guard = requireAdmin(req);
+  if (guard.error) return guard.error;
+
+  const role = req.nextUrl.searchParams.get("role");
+  if (role !== "mentee" && role !== "mentor") {
+    return NextResponse.json(
+      { error: "role 은 mentee 또는 mentor 여야 합니다." },
+      { status: 400 },
+    );
+  }
+
+  const yr = await resolveProcessYear(req);
+  if (yr.error) return yr.error;
+  const year = yr.year;
+
+  const pg = parsePagination(req);
+  if (pg.error) return pg.error;
+  const { page, limit } = pg;
+
+  const where = {
+    role,
+    process_year: year,
+    application_status: { in: ["submitted", "approved", "rejected", "revision_requested"] as const },
+  };
+
+  const [rows, totalCount] = await prisma.$transaction([
+    prisma.application.findMany({
+      where,
+      orderBy: { submitted_at: "desc" },
+      skip: (page - 1) * limit,
+      take: limit,
+      select: {
+        application_id: true,
+        application_status: true,
+        submitted_at: true,
+        user: {
+          select: {
+            user_id: true,
+            name: true,
+            student_id: true,
+            undergrad_first_major: true,
+          },
+        },
+        admin_memos: {
+          take: 1,
+          orderBy: { created_at: "desc" },
+          select: { memo_content: true },
+        },
+      },
+    }),
+    prisma.application.count({ where }),
+  ]);
+
+  // mentor 의 경우 페이지에 들어온 user_id 들로 latest mentor_record 조회
+  let lawschoolByUser: Map<string, string | null> | null = null;
+  if (role === "mentor") {
+    const userIds = rows.map((r) => r.user.user_id);
+    const records =
+      userIds.length === 0
+        ? []
+        : await prisma.mentorRecord.findMany({
+            where: { user_id: { in: userIds } },
+            orderBy: { process_year: "desc" },
+            select: { user_id: true, lawschool_name: true },
+          });
+    lawschoolByUser = new Map();
+    for (const r of records) {
+      if (!lawschoolByUser.has(r.user_id)) {
+        lawschoolByUser.set(r.user_id, r.lawschool_name);
+      }
+    }
+  }
+
+  const data = rows.map((row) => {
+    // Prisma include + take:1 결과는 객체가 아닌 길이 1 배열. [0]?. 로 추출.
+    const memo = row.admin_memos[0]?.memo_content ?? null;
+    const base = {
+      applicationId: row.application_id,
+      name: row.user.name,
+      studentId: row.user.student_id ?? "",
+      status: applicationStatusToLabel(row.application_status),
+      memo,
+      submittedAt: row.submitted_at?.toISOString() ?? null,
+    };
+    if (role === "mentee") {
+      return { ...base, major: row.user.undergrad_first_major ?? "" };
+    }
+    return { ...base, school: lawschoolByUser?.get(row.user.user_id) ?? null };
+  });
+
+  return NextResponse.json({ data, totalCount, page, limit });
+}
+```
+
+- [ ] **Step 2: typecheck**
+
+```powershell
+pnpm -F @plawcess/api typecheck
+```
+
+- [ ] **Step 3: 커밋**
+
+```powershell
+git add apps/api/src/app/api/admin/applications/route.ts
+git commit -m "feat(#176): GET /api/admin/applications (신청관리)"
+```
+
+---
+
+## Task 7: GET /api/admin/matchings/eligible
+
+**Files:**
+- Create: `apps/api/src/app/api/admin/matchings/eligible/route.ts`
+
+매칭관리 — approved 멘티+멘토 풀 통합 응답.
+
+- [ ] **Step 1: 라우트 작성**
+
+`apps/api/src/app/api/admin/matchings/eligible/route.ts`:
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@plawcess/database";
+import { requireAdmin } from "@/lib/admin-guard";
+import { resolveProcessYear } from "@/lib/active-cycle";
+
+export async function GET(req: NextRequest) {
+  const guard = requireAdmin(req);
+  if (guard.error) return guard.error;
+
+  const yr = await resolveProcessYear(req);
+  if (yr.error) return yr.error;
+  const year = yr.year;
+
+  const baseSelect = {
+    application_id: true,
+    user: {
+      select: {
+        user_id: true,
+        name: true,
+        student_id: true,
+        account_status: true,
+        undergrad_first_major: true,
+      },
+    },
+  } as const;
+
+  const [menteeRows, mentorRows] = await prisma.$transaction([
+    prisma.application.findMany({
+      where: { role: "mentee", process_year: year, application_status: "approved" },
+      orderBy: { user: { name: "asc" } },
+      select: baseSelect,
+    }),
+    prisma.application.findMany({
+      where: { role: "mentor", process_year: year, application_status: "approved" },
+      orderBy: { user: { name: "asc" } },
+      select: baseSelect,
+    }),
+  ]);
+
+  // 멘토 latest record 의 lawschool_name
+  const mentorUserIds = mentorRows.map((r) => r.user.user_id);
+  const records =
+    mentorUserIds.length === 0
+      ? []
+      : await prisma.mentorRecord.findMany({
+          where: { user_id: { in: mentorUserIds } },
+          orderBy: { process_year: "desc" },
+          select: { user_id: true, lawschool_name: true },
+        });
+  const lawschoolByUser = new Map<string, string | null>();
+  for (const r of records) {
+    if (!lawschoolByUser.has(r.user_id)) {
+      lawschoolByUser.set(r.user_id, r.lawschool_name);
+    }
+  }
+
+  return NextResponse.json({
+    year,
+    mentees: menteeRows.map((r) => ({
+      applicationId: r.application_id,
+      userId: r.user.user_id,
+      name: r.user.name,
+      studentId: r.user.student_id ?? "",
+      major: r.user.undergrad_first_major ?? "",
+      accountStatus: r.user.account_status,
+    })),
+    mentors: mentorRows.map((r) => ({
+      applicationId: r.application_id,
+      userId: r.user.user_id,
+      name: r.user.name,
+      studentId: r.user.student_id ?? "",
+      lawSchool: lawschoolByUser.get(r.user.user_id) ?? null,
+      accountStatus: r.user.account_status,
+    })),
+  });
+}
+```
+
+- [ ] **Step 2: typecheck**
+
+```powershell
+pnpm -F @plawcess/api typecheck
+```
+
+- [ ] **Step 3: 커밋**
+
+```powershell
+git add apps/api/src/app/api/admin/matchings/eligible/route.ts
+git commit -m "feat(#176): GET /api/admin/matchings/eligible (매칭 풀)"
+```
+
+---
+
+## Task 8: POST + GET /api/admin/announcements
+
+**Files:**
+- Create: `apps/api/src/app/api/admin/announcements/route.ts`
+
+공지 작성 + 관리자 목록.
+
+- [ ] **Step 1: 라우트 작성**
+
+`apps/api/src/app/api/admin/announcements/route.ts`:
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@plawcess/database";
+import { requireAdmin } from "@/lib/admin-guard";
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+const MAX_TITLE = 100;
+
+type AnnouncementRow = {
+  announcement_id: string;
+  title: string;
+  body: string;
+  created_at: Date;
+  created_by: { name: string };
+};
+
+function toResponse(row: AnnouncementRow) {
+  return {
+    announcementId: row.announcement_id,
+    title: row.title,
+    body: row.body,
+    createdAt: row.created_at.toISOString(),
+    author: row.created_by.name,
+  };
+}
+
+function parsePagination(req: NextRequest):
+  | { page: number; limit: number; error?: undefined }
+  | { error: NextResponse; page?: undefined; limit?: undefined } {
+  const pageRaw = req.nextUrl.searchParams.get("page");
+  const limitRaw = req.nextUrl.searchParams.get("limit");
+  const page = pageRaw ? parseInt(pageRaw, 10) : 1;
+  const limit = limitRaw ? parseInt(limitRaw, 10) : DEFAULT_LIMIT;
+  if (!Number.isInteger(page) || page < 1) {
+    return { error: NextResponse.json({ error: "page 가 올바르지 않습니다." }, { status: 400 }) };
+  }
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+    return { error: NextResponse.json({ error: `limit 은 1~${MAX_LIMIT} 사이여야 합니다.` }, { status: 400 }) };
+  }
+  return { page, limit };
+}
+
+export async function POST(req: NextRequest) {
+  const guard = requireAdmin(req);
+  if (guard.error) return guard.error;
+  const adminId = guard.payload.user_id;
+
+  let body: { title?: unknown; body?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "요청 형식이 올바르지 않습니다." }, { status: 400 });
+  }
+
+  const title = typeof body.title === "string" ? body.title.trim() : "";
+  const content = typeof body.body === "string" ? body.body.trim() : "";
+
+  if (title.length < 1 || title.length > MAX_TITLE) {
+    return NextResponse.json(
+      { error: `title 은 1~${MAX_TITLE}자여야 합니다.` },
+      { status: 400 },
+    );
+  }
+  if (content.length < 1) {
+    return NextResponse.json({ error: "body 는 1자 이상이어야 합니다." }, { status: 400 });
+  }
+
+  const created = await prisma.announcement.create({
+    data: { title, body: content, created_by_user_id: adminId },
+    include: { created_by: { select: { name: true } } },
+  });
+
+  return NextResponse.json(toResponse(created), { status: 201 });
+}
+
+export async function GET(req: NextRequest) {
+  const guard = requireAdmin(req);
+  if (guard.error) return guard.error;
+
+  const pg = parsePagination(req);
+  if (pg.error) return pg.error;
+  const { page, limit } = pg;
+
+  const [rows, totalCount] = await prisma.$transaction([
+    prisma.announcement.findMany({
+      orderBy: { created_at: "desc" },
+      skip: (page - 1) * limit,
+      take: limit,
+      include: { created_by: { select: { name: true } } },
+    }),
+    prisma.announcement.count(),
+  ]);
+
+  return NextResponse.json({
+    data: rows.map(toResponse),
+    totalCount,
+    page,
+    limit,
+  });
+}
+```
+
+- [ ] **Step 2: typecheck**
+
+```powershell
+pnpm -F @plawcess/api typecheck
+```
+
+- [ ] **Step 3: 커밋**
+
+```powershell
+git add apps/api/src/app/api/admin/announcements/route.ts
+git commit -m "feat(#176): POST·GET /api/admin/announcements"
+```
+
+---
+
+## Task 9: DELETE /api/admin/announcements/[id]
+
+**Files:**
+- Create: `apps/api/src/app/api/admin/announcements/[id]/route.ts`
+
+- [ ] **Step 1: 라우트 작성**
+
+`apps/api/src/app/api/admin/announcements/[id]/route.ts`:
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import { prisma, Prisma } from "@plawcess/database";
+import { requireAdmin } from "@/lib/admin-guard";
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const guard = requireAdmin(req);
+  if (guard.error) return guard.error;
+
+  const { id } = await params;
+  if (!id) {
+    return NextResponse.json({ error: "id 가 필요합니다." }, { status: 400 });
+  }
+
+  try {
+    await prisma.announcement.delete({ where: { announcement_id: id } });
+  } catch (e) {
+    if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2025") {
+      return NextResponse.json({ error: "해당 공지사항이 없습니다." }, { status: 404 });
+    }
+    throw e;
+  }
+  return NextResponse.json({ success: true });
+}
+```
+
+- [ ] **Step 2: typecheck**
+
+```powershell
+pnpm -F @plawcess/api typecheck
+```
+
+- [ ] **Step 3: 커밋**
+
+```powershell
+git add apps/api/src/app/api/admin/announcements/[id]/route.ts
+git commit -m "feat(#176): DELETE /api/admin/announcements/[id]"
+```
+
+---
+
+## Task 10: GET /api/announcements (공개 목록)
+
+**Files:**
+- Create: `apps/api/src/app/api/announcements/route.ts`
+
+비-admin 라우트. proxy 자동 가드 없음 → 라우트에서 로그인 강제.
+
+- [ ] **Step 1: 라우트 작성**
+
+`apps/api/src/app/api/announcements/route.ts`:
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@plawcess/database";
+import { getTokenFromCookie } from "@/lib/auth";
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+function parsePagination(req: NextRequest):
+  | { page: number; limit: number; error?: undefined }
+  | { error: NextResponse; page?: undefined; limit?: undefined } {
+  const pageRaw = req.nextUrl.searchParams.get("page");
+  const limitRaw = req.nextUrl.searchParams.get("limit");
+  const page = pageRaw ? parseInt(pageRaw, 10) : 1;
+  const limit = limitRaw ? parseInt(limitRaw, 10) : DEFAULT_LIMIT;
+  if (!Number.isInteger(page) || page < 1) {
+    return { error: NextResponse.json({ error: "page 가 올바르지 않습니다." }, { status: 400 }) };
+  }
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+    return { error: NextResponse.json({ error: `limit 은 1~${MAX_LIMIT} 사이여야 합니다.` }, { status: 400 }) };
+  }
+  return { page, limit };
+}
+
+export async function GET(req: NextRequest) {
+  const payload = getTokenFromCookie(req);
+  if (!payload) {
+    return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
+  }
+
+  const pg = parsePagination(req);
+  if (pg.error) return pg.error;
+  const { page, limit } = pg;
+
+  const [rows, totalCount] = await prisma.$transaction([
+    prisma.announcement.findMany({
+      orderBy: { created_at: "desc" },
+      skip: (page - 1) * limit,
+      take: limit,
+      include: { created_by: { select: { name: true } } },
+    }),
+    prisma.announcement.count(),
+  ]);
+
+  return NextResponse.json({
+    data: rows.map((row) => ({
+      announcementId: row.announcement_id,
+      title: row.title,
+      body: row.body,
+      createdAt: row.created_at.toISOString(),
+      author: row.created_by.name,
+    })),
+    totalCount,
+    page,
+    limit,
+  });
+}
+```
+
+- [ ] **Step 2: typecheck**
+
+```powershell
+pnpm -F @plawcess/api typecheck
+```
+
+- [ ] **Step 3: 커밋**
+
+```powershell
+git add apps/api/src/app/api/announcements/route.ts
+git commit -m "feat(#176): GET /api/announcements (공개 목록)"
+```
+
+---
+
+## Task 11: GET /api/announcements/[id] (공개 상세)
+
+**Files:**
+- Create: `apps/api/src/app/api/announcements/[id]/route.ts`
+
+- [ ] **Step 1: 라우트 작성**
+
+`apps/api/src/app/api/announcements/[id]/route.ts`:
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@plawcess/database";
+import { getTokenFromCookie } from "@/lib/auth";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const payload = getTokenFromCookie(req);
+  if (!payload) {
+    return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const row = await prisma.announcement.findUnique({
+    where: { announcement_id: id },
+    include: { created_by: { select: { name: true } } },
+  });
+  if (!row) {
+    return NextResponse.json({ error: "해당 공지사항이 없습니다." }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    announcementId: row.announcement_id,
+    title: row.title,
+    body: row.body,
+    createdAt: row.created_at.toISOString(),
+    author: row.created_by.name,
+  });
+}
+```
+
+- [ ] **Step 2: typecheck**
+
+```powershell
+pnpm -F @plawcess/api typecheck
+```
+
+- [ ] **Step 3: 커밋**
+
+```powershell
+git add apps/api/src/app/api/announcements/[id]/route.ts
+git commit -m "feat(#176): GET /api/announcements/[id] (공개 상세)"
+```
+
+---
+
+## Task 12: docs/api/api-spec.md 갱신
+
+**Files:**
+- Modify: `docs/api/api-spec.md`
+
+8개 엔드포인트 명세 추가. 형식은 기존 cycle-schedules 섹션과 동일 양식.
+
+- [ ] **Step 1: 기존 형식 확인**
+
+```powershell
+type docs\api\api-spec.md
+```
+
+문서 끝에 추가할 위치 결정 (보통 파일 마지막).
+
+- [ ] **Step 2: 8개 엔드포인트 섹션 추가**
+
+`docs/api/api-spec.md` 끝에 다음 섹션 추가:
+
+```markdown
+## #176 Admin 페이지 API
+
+### 공통 페이지네이션 래퍼
+배열형 응답은 모두 `{ data, totalCount, page, limit }` 형태. Query 파라미터 `?page=1&limit=50` (기본). `limit` 상한 200.
+
+### GET /api/admin/users
+- **Auth:** admin
+- **Query:** `role=mentee|mentor` (필수), `page`, `limit`
+- **응답:** 페이지네이션 래퍼. data 항목은 멘티/멘토 역할에 따라 다름.
+  - 멘티: `{ userId, name, studentId, firstMajor, secondMajor, phone, accountStatus }`
+  - 멘토: `{ userId, name, studentId, lawSchool, cohort, phone, accountStatus }` — 가장 최근 MentorRecord 기준.
+- **에러:** 400 (role 누락/오류, page/limit 오류)
+
+### GET /api/admin/applications
+- **Auth:** admin
+- **Query:** `role=mentee|mentor` (필수), `year=YYYY` (옵션, 기본 활성 cycle), `page`, `limit`
+- **응답:** 페이지네이션 래퍼. data 항목:
+  - 공통: `{ applicationId, name, studentId, status, memo, submittedAt }`
+  - 멘티: `+ major`, 멘토: `+ school`
+  - `status` 라벨 매핑: submitted→pending / approved→approved / rejected→rejected / revision_requested→revision
+- **에러:** 400 (role 누락/오류, year 형식, 활성 cycle 없음)
+
+### GET /api/admin/matchings/eligible
+- **Auth:** admin
+- **Query:** `year=YYYY` (옵션, 기본 활성 cycle)
+- **응답** (페이지네이션 미적용):
+```json
+{
+  "year": 2026,
+  "mentees": [{ "applicationId", "userId", "name", "studentId", "major", "accountStatus" }],
+  "mentors": [{ "applicationId", "userId", "name", "studentId", "lawSchool", "accountStatus" }]
+}
+```
+- **에러:** 400 (활성 cycle 없고 year 미지정)
+
+### POST /api/admin/announcements
+- **Auth:** admin
+- **Body:** `{ title: string (1~100자), body: string (1자 이상) }`
+- **응답 201:** `{ announcementId, title, body, createdAt, author }`
+- **에러:** 400 (검증 실패)
+
+### GET /api/admin/announcements
+- **Auth:** admin
+- **Query:** `page`, `limit`
+- **응답:** 페이지네이션 래퍼. data 항목 = POST 응답 형태.
+
+### DELETE /api/admin/announcements/:id
+- **Auth:** admin
+- **응답 200:** `{ "success": true }`
+- **에러:** 404 (없는 id)
+
+### GET /api/announcements
+- **Auth:** 로그인 필수 (멘티/멘토/admin)
+- **Query:** `page`, `limit`
+- **응답:** 페이지네이션 래퍼. data 항목 = POST 응답 형태.
+- **에러:** 401 (비로그인)
+
+### GET /api/announcements/:id
+- **Auth:** 로그인 필수
+- **응답 200:** `{ announcementId, title, body, createdAt, author }`
+- **에러:** 401, 404
+```
+
+- [ ] **Step 3: 커밋**
+
+```powershell
+git add docs/api/api-spec.md
+git commit -m "docs(#176): admin API 8개 엔드포인트 명세 추가"
+```
+
+---
+
+## Task 13: 빌드·typecheck 종단 검증 + push + PR 본문 초안
+
+**Files:** 없음 (검증 + 사용자 전달).
+
+- [ ] **Step 1: 전체 typecheck**
+
+```powershell
+pnpm -F @plawcess/api typecheck
+```
+
+Expected: 에러 없음.
+
+- [ ] **Step 2: 전체 build**
+
+```powershell
+pnpm -F @plawcess/api build
+```
+
+Expected: `✓ Compiled successfully` 등의 성공 출력. 새 라우트 8개가 라우트 매니페스트에 등록됨.
+
+- [ ] **Step 3: 브랜치 push**
+
+```powershell
+git push -u origin 176-be-admin-api-만들어죠
+```
+
+- [ ] **Step 4: PR URL + Title + Body 초안을 사용자에게 전달**
+
+PR Title 후보:
+```
+feat(#176): admin API 8종 + Announcement 모델
+```
+
+PR Body 초안 (사용자에게 텍스트로 전달, 사용자가 직접 PR 생성):
+```markdown
+## Summary
+- 회원관리·신청관리·매칭관리·공지사항 4개 화면용 BE API 8종
+- 새 테이블 `announcements` + 마이그레이션 `20260510130000_announcements`
+- 공통 헬퍼: `requireAdmin`, `resolveProcessYear`
+- 라벨 매핑: `applicationStatusToLabel`
+- 응답 케이스 통일: 카멜케이스, 배열형은 `{ data, totalCount, page, limit }` 래퍼
+
+## 엔드포인트
+| Method | Path | 설명 |
+|---|---|---|
+| GET | `/api/admin/users?role=mentee\|mentor` | 멘티/멘토 회원 목록 |
+| GET | `/api/admin/applications?role=mentee\|mentor&year=YYYY` | 멘티/멘토 신청 목록 |
+| GET | `/api/admin/matchings/eligible?year=YYYY` | approved 멘티+멘토 풀 |
+| POST | `/api/admin/announcements` | 공지 작성 |
+| GET | `/api/admin/announcements` | 관리자 공지 목록 |
+| DELETE | `/api/admin/announcements/:id` | 공지 삭제 |
+| GET | `/api/announcements` | 공개 목록 (로그인 필수) |
+| GET | `/api/announcements/:id` | 공개 상세 (로그인 필수) |
+
+## 마이그레이션
+`packages/database/prisma/migrations/20260510130000_announcements/migration.sql` — `announcements` 테이블 + index + FK. 머지 후 dev DB 적용 필요.
+
+## FE 핸드오프
+spec(`docs/superpowers/specs/2026-05-10-admin-api-design.md`) 마지막 섹션 참조. 4개 admin 화면 + `/announcements`, `/[role]/announcements` mock 제거 작업.
+
+## Test plan
+- [ ] admin 로그인 → 회원/신청/eligible/공지 4개 그룹 GET 200
+- [ ] `?page=2&limit=10` → totalCount 일치, data ≤ limit
+- [ ] role 누락/오류 → 400
+- [ ] `?limit=300` → 400
+- [ ] POST 공지 → 201, GET 목록에 등장
+- [ ] DELETE 공지 → 200, 재조회 시 404
+- [ ] mentee 로그인 → 공개 GET 200, admin GET 403
+- [ ] 비로그인 → 공개 GET 401
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+브랜치 push 완료 후, 위 본문을 사용자에게 그대로 전달하고 PR URL (origin/176-be-admin-api-... 의 compare URL)을 같이 안내한다.
+
+---
+
+## 자체 점검
+
+- 13개 task, 각 task 한 commit. 누락된 spec 항목 없음.
+- 모든 라우트 코드 inline 포함 (placeholder 없음).
+- 타입 일관: `requireAdmin`, `resolveProcessYear`, `applicationStatusToLabel`, `parsePagination` 시그니처가 모든 라우트에서 동일.
+- 마이그레이션은 SQL 작성만 — dev DB 적용은 머지 후 별도 (메모리 규율 일치).
+- `apps/web/` 비수정 (BE 전용).
+- gh CLI 없음 → push + 본문 초안 텍스트 전달.

--- a/docs/superpowers/specs/2026-05-10-admin-api-design.md
+++ b/docs/superpowers/specs/2026-05-10-admin-api-design.md
@@ -1,0 +1,358 @@
+# Admin 페이지 API 설계 (#176)
+
+작성일: 2026-05-10
+브랜치: `176-be-admin-api-만들어죠`
+
+## 목적
+
+Admin 페이지 4개 화면 (회원관리 / 신청관리 / 매칭관리 / 공지사항)의 BE API를 구현한다. 현재 FE는 mock 데이터로 그려져 있고, 본 PR에서 BE를 붙이면 mock을 즉시 제거할 수 있도록 BE 응답 형태를 FE 컴포넌트가 사용하는 모양에 맞춘다.
+
+## 스코프 결정 (브레인스토밍 합의)
+
+| 결정 | 선택 |
+|------|------|
+| 공지 API 범위 | POST + GET + DELETE (admin) + 공개 GET 목록·상세 |
+| 회원 정의 | `users.current_role = 'mentee' \| 'mentor'` 기준 (cycle 무관) |
+| 신청 필터 | `application_status` 가 `submitted` 이후 (`draft` 제외) 전체 |
+| 적격 정의 | `application_status='approved'` AND `process_year=$year` (이미 매칭 여부는 거르지 않음) |
+| 멘토 record 출처 | 사용자별 가장 최근 MentorRecord (`process_year DESC LIMIT 1`) |
+| Announcement 모델 | 최소 사양 (id, title, body, created_by, created_at, updated_at) — soft delete 미적용 |
+| Public 공지 GET | 로그인 강제 (멘티/멘토/admin 모두 허용, 비로그인 401) |
+
+## 엔드포인트 목록
+
+| # | Method | Path | proxy 가드 | 용도 |
+|---|--------|------|-----------|------|
+| 1 | GET | `/api/admin/users?role=mentee\|mentor` | admin | 회원관리 — 멘티/멘토 회원 목록 |
+| 2 | GET | `/api/admin/applications?role=mentee\|mentor&year=YYYY` | admin | 신청관리 — 멘티/멘토 신청 목록 |
+| 3 | GET | `/api/admin/matchings/eligible?year=YYYY` | admin | 매칭관리 — approved 멘티+멘토 풀 |
+| 4 | POST | `/api/admin/announcements` | admin | 공지 작성 |
+| 5 | GET | `/api/admin/announcements` | admin | 관리자 공지 목록 |
+| 6 | DELETE | `/api/admin/announcements/:id` | admin | 공지 삭제 (hard delete) |
+| 7 | GET | `/api/announcements` | 라우트 핸들러에서 로그인 체크 | 공개 목록 |
+| 8 | GET | `/api/announcements/:id` | 라우트 핸들러에서 로그인 체크 | 공개 상세 |
+
+## 1. GET /api/admin/users
+
+**Query**
+- `role` (필수): `mentee` 또는 `mentor`
+
+**WHERE**
+```
+users.is_deleted = false
+AND users.current_role = $role
+```
+
+**응답 케이스 정책** — 본 PR의 모든 응답은 **카멜케이스 통일**. Prisma raw 객체를 그대로 반환하지 않고 변환해서 응답.
+
+**SELECT 및 응답 (멘티)**
+```json
+[
+  {
+    "userId": "uuid",
+    "name": "김민준",
+    "studentId": "2020123456",
+    "firstMajor": "법학과",
+    "secondMajor": null,
+    "phone": "010-1234-5678",
+    "accountStatus": "active"
+  }
+]
+```
+
+**SELECT 및 응답 (멘토)**
+- 멘토는 latest MentorRecord 1개를 사용자별로 join 해 `lawschool_name`, `lawschool_grade`(=cohort) 표시.
+```json
+[
+  {
+    "userId": "uuid",
+    "name": "최수진",
+    "studentId": "2018456789",
+    "lawSchool": "서울대학교 로스쿨",
+    "cohort": 7,
+    "phone": "010-4567-8901",
+    "accountStatus": "active"
+  }
+]
+```
+- record가 없는 멘토(이론상 거의 없음): `lawSchool: null, cohort: null` 로 응답하고 행은 노출.
+
+**정렬**: `name ASC`
+
+**구현 노트**
+- 멘토 latest record 조회: `findMany({ where: { user_id: { in: [...] } }, orderBy: { process_year: 'desc' } })` → 메모리에서 `Map<user_id, record>` 로 첫 만남만 유지(N+1 회피).
+
+**에러**
+- 400: `role` 누락 또는 `mentee|mentor` 외 값
+
+## 2. GET /api/admin/applications
+
+**Query**
+- `role` (필수): `mentee` 또는 `mentor`
+- `year` (옵션): 기본값 = 활성 CycleSchedule.process_year. 활성 cycle이 없고 year 미지정이면 400.
+
+**WHERE**
+```
+applications.role = $role
+AND applications.process_year = $year
+AND applications.application_status IN
+    ('submitted','approved','rejected','revision_requested')
+```
+
+**JOIN**
+- User: name, student_id, undergrad_first_major
+- 멘토면 latest MentorRecord: lawschool_name
+- AdminMemo: 같은 application_id에 대한 가장 최근 1개 (`ORDER BY created_at DESC LIMIT 1`)
+
+**상태 라벨 매핑** (`apps/api/src/lib/labels.ts` 에 추가)
+| DB enum | FE label |
+|---------|----------|
+| `submitted` | `pending` |
+| `approved` | `approved` |
+| `rejected` | `rejected` |
+| `revision_requested` | `revision` |
+
+**응답 (멘티)**
+```json
+[
+  {
+    "applicationId": "uuid",
+    "name": "김민준",
+    "studentId": "2020123456",
+    "major": "법학과",
+    "status": "approved",
+    "memo": "서류 확인 완료",
+    "submittedAt": "2026-04-10T..."
+  }
+]
+```
+
+**응답 (멘토)** — `major` 대신 `school` (=lawschool_name).
+
+**정렬**: `submitted_at DESC`
+
+**에러**
+- 400: role 누락/오류, 활성 cycle 없고 year 미지정, year 형식 오류
+
+## 3. GET /api/admin/matchings/eligible
+
+**Query**
+- `year` (옵션): 기본 = 활성 cycle. 없으면 400.
+
+**WHERE**: `application_status='approved' AND process_year=$year`, role 별로 분리.
+
+**응답** (mentees+mentors 통합 — FE가 동시 표시)
+```json
+{
+  "year": 2026,
+  "mentees": [
+    {
+      "applicationId": "uuid",
+      "userId": "uuid",
+      "name": "김민준",
+      "studentId": "2020123456",
+      "major": "법학과",
+      "accountStatus": "active"
+    }
+  ],
+  "mentors": [
+    {
+      "applicationId": "uuid",
+      "userId": "uuid",
+      "name": "최수진",
+      "studentId": "2018456789",
+      "lawSchool": "서울대학교 로스쿨",
+      "accountStatus": "active"
+    }
+  ]
+}
+```
+
+**정렬**: 둘 다 `name ASC`
+
+**에러**: 400 (활성 cycle 없고 year 미지정)
+
+## 4. 공지사항 — DB
+
+**스키마 (`packages/database/prisma/schema.prisma` 추가)**
+```prisma
+model Announcement {
+  announcement_id    String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  title              String   @db.VarChar(100)
+  body               String   @db.Text
+  created_by_user_id String   @db.Uuid
+  created_at         DateTime @default(now())
+  updated_at         DateTime @updatedAt
+
+  created_by         User     @relation("AnnouncementCreatedBy", fields: [created_by_user_id], references: [user_id])
+
+  @@index([created_at])
+  @@map("announcements")
+}
+```
+
+**User 모델에 역참조 추가**
+```prisma
+created_announcements Announcement[] @relation("AnnouncementCreatedBy")
+```
+
+**마이그레이션**: `packages/database/prisma/migrations/20260510130000_announcements/migration.sql`
+```sql
+CREATE TABLE "announcements" (
+  "announcement_id"    UUID NOT NULL DEFAULT gen_random_uuid(),
+  "title"              VARCHAR(100) NOT NULL,
+  "body"               TEXT NOT NULL,
+  "created_by_user_id" UUID NOT NULL,
+  "created_at"         TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at"         TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "announcements_pkey" PRIMARY KEY ("announcement_id")
+);
+
+CREATE INDEX "announcements_created_at_idx" ON "announcements"("created_at");
+
+ALTER TABLE "announcements"
+  ADD CONSTRAINT "announcements_created_by_user_id_fkey"
+  FOREIGN KEY ("created_by_user_id") REFERENCES "users"("user_id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+```
+
+## 5. POST /api/admin/announcements
+
+**Body**: `{ title: string, body: string }`
+
+**검증**
+- title: trim 후 1~100자
+- body: trim 후 1자 이상
+
+**처리**
+```
+Announcement.create({
+  data: {
+    title: title.trim(),
+    body: body.trim(),
+    created_by_user_id: payload.user_id,
+  },
+  include: { created_by: { select: { name: true } } },
+})
+```
+응답 매핑은 `author: row.created_by.name` 으로 변환 (admin User 객체 통째 노출 금지).
+
+**응답 201**
+```json
+{
+  "announcementId": "uuid",
+  "title": "...",
+  "body": "...",
+  "createdAt": "...",
+  "author": "관리자 이름"
+}
+```
+
+**에러**
+- 400: title/body 누락 또는 길이 위반
+
+## 6. GET /api/admin/announcements
+
+- 정렬: `created_at DESC`
+- include: created_by → name
+- 응답 200: 위 형태 객체 배열
+
+## 7. DELETE /api/admin/announcements/:id
+
+- URL param: `:id` (uuid)
+- 처리: hard delete
+- 응답 200: `{ "success": true }`
+- 에러: 404 (없는 id)
+
+## 8. GET /api/announcements (공개)
+
+- 라우트 핸들러 시작에 `getTokenFromCookie(req)` 검증 → 없으면 401.
+- 정렬·응답 형태는 admin 목록과 동일.
+
+## 9. GET /api/announcements/:id (공개)
+
+- 동일 인증.
+- 단일 row 반환, 없으면 404.
+
+## 파일 구조
+
+**신규**
+```
+apps/api/src/lib/admin-guard.ts
+apps/api/src/lib/active-cycle.ts
+apps/api/src/app/api/admin/users/route.ts
+apps/api/src/app/api/admin/applications/route.ts
+apps/api/src/app/api/admin/matchings/eligible/route.ts
+apps/api/src/app/api/admin/announcements/route.ts
+apps/api/src/app/api/admin/announcements/[id]/route.ts
+apps/api/src/app/api/announcements/route.ts
+apps/api/src/app/api/announcements/[id]/route.ts
+packages/database/prisma/migrations/20260510130000_announcements/migration.sql
+```
+
+**수정**
+```
+packages/database/prisma/schema.prisma     ← Announcement 모델 + User.created_announcements 역참조
+apps/api/src/lib/labels.ts                 ← applicationStatusToLabel 추가
+docs/api/api-spec.md                       ← 8개 엔드포인트 문서화
+```
+
+**proxy.ts 미수정** — `/api/admin/*` 가드 이미 적용됨.
+
+## 공통 헬퍼
+
+### `apps/api/src/lib/admin-guard.ts`
+proxy 가드를 통과한 후 라우트 핸들러에서 한 번 더 admin payload를 확인 (defense-in-depth + payload 추출 통합). cycle-schedules 라우트의 `requireAdminInline` 패턴을 공통 헬퍼로 승격.
+
+```ts
+export function requireAdmin(req: NextRequest):
+  | { error: NextResponse; payload?: undefined }
+  | { error?: undefined; payload: TokenPayload };
+```
+
+### `apps/api/src/lib/active-cycle.ts`
+`?year` 쿼리 파싱 + 활성 cycle fallback.
+
+```ts
+export async function resolveProcessYear(req: NextRequest): Promise<
+  | { year: number; error?: undefined }
+  | { error: NextResponse; year?: undefined }
+>;
+```
+
+## 구현 순서 (커밋 단위)
+
+1. Announcement schema + 마이그레이션 (DIRECT_URL 로 dev DB 적용·검증)
+2. admin-guard / active-cycle 헬퍼
+3. /admin/users GET
+4. /admin/applications GET (+ labels.ts 보완)
+5. /admin/matchings/eligible GET
+6. /admin/announcements POST·GET·DELETE
+7. /announcements GET (공개 목록·상세)
+8. api-spec.md 갱신
+9. 빌드·typecheck 검증
+10. push + PR 본문 초안
+
+## E2E 검증 (curl)
+
+1. admin 로그인 → 쿠키 저장
+2. mentee/mentor 회원 목록 200
+3. mentee/mentor 신청 목록 200 (year 생략 시 활성 cycle 사용)
+4. eligible 200 (mentees + mentors 풀)
+5. POST 공지 201
+6. GET admin 공지 목록 200
+7. DELETE 공지 200 + 재조회 시 사라짐
+8. mentee 로그인 → 공개 공지 GET 200, admin GET 403
+9. 비로그인 → 공개 공지 GET 401
+10. role 누락/오류 → 400
+
+## FE 핸드오프 메모
+
+본 PR은 BE만. FE 작업은 별도:
+- `/admin/users` mock 제거 → `GET /api/admin/users?role=...`
+- `/admin/applications` mock 제거 → `GET /api/admin/applications?role=...&year=...`
+- `/admin/matchings` mock 제거 → `GET /api/admin/matchings/eligible?year=...`
+- `/admin/announcements/create` mock 제거 → POST/GET/DELETE 연결
+- `/announcements`, `/mentee/announcements`, `/mentor/announcements` mock 제거 → `GET /api/announcements`
+- `/[role]/announcements/[id]` → `GET /api/announcements/:id`
+- **응답 필드는 모두 카멜케이스** (snake_case 아님). 기존 mock의 `user_id` 등 snake 필드는 `userId`로 변경 필요. 응답에 type 정의 추가.

--- a/docs/superpowers/specs/2026-05-10-admin-api-design.md
+++ b/docs/superpowers/specs/2026-05-10-admin-api-design.md
@@ -18,6 +18,61 @@ Admin 페이지 4개 화면 (회원관리 / 신청관리 / 매칭관리 / 공지
 | 멘토 record 출처 | 사용자별 가장 최근 MentorRecord (`process_year DESC LIMIT 1`) |
 | Announcement 모델 | 최소 사양 (id, title, body, created_by, created_at, updated_at) — soft delete 미적용 |
 | Public 공지 GET | 로그인 강제 (멘티/멘토/admin 모두 허용, 비로그인 401) |
+| 응답 케이스 | 모든 응답 카멜케이스 통일 (snake → camel 변환) |
+| 페이지네이션 | 배열형 응답은 `{ data, totalCount, page, limit }` 으로 래핑. `?page=1&limit=50` 기본값. `eligible` 는 매칭 알고리즘 입력이라 적용 제외 |
+
+## 공통 응답 규약
+
+### 페이지네이션 래퍼 (배열형 응답)
+
+대상: `/admin/users`, `/admin/applications`, `/admin/announcements`, `/announcements`
+
+**Query** (모두 옵션, 기본값 명시)
+- `page` (기본 1, 정수, ≥1)
+- `limit` (기본 50, 정수, 1~200)
+
+**응답 형태**
+```json
+{
+  "data": [...],
+  "totalCount": 137,
+  "page": 1,
+  "limit": 50
+}
+```
+
+**구현**
+```ts
+const skip = (page - 1) * limit;
+const [data, totalCount] = await prisma.$transaction([
+  prisma.<model>.findMany({ where, orderBy, skip, take: limit, include }),
+  prisma.<model>.count({ where }),
+]);
+```
+
+**적용 제외**: `/admin/matchings/eligible` (매칭 알고리즘 입력 — 풀 전체 반환).
+
+### Prisma include + take: 1 함정
+
+`/admin/applications` 에서 AdminMemo 최근 1건을 join 시:
+
+```ts
+include: {
+  admin_memos: {
+    take: 1,
+    orderBy: { created_at: 'desc' },
+    select: { memo_content: true },
+  },
+}
+```
+
+→ `row.admin_memos` 는 **객체가 아닌 길이 1짜리 배열** (Prisma 1:N include의 take 동작).
+
+응답 매핑 시 반드시:
+```ts
+memo: row.admin_memos[0]?.memo_content ?? null
+```
+형태로 첫 요소를 안전 추출. `row.admin_memos.memo_content` 쓰면 `undefined`.
 
 ## 엔드포인트 목록
 
@@ -36,6 +91,7 @@ Admin 페이지 4개 화면 (회원관리 / 신청관리 / 매칭관리 / 공지
 
 **Query**
 - `role` (필수): `mentee` 또는 `mentor`
+- `page`, `limit` — 공통 페이지네이션 규약 따름
 
 **WHERE**
 ```
@@ -43,44 +99,51 @@ users.is_deleted = false
 AND users.current_role = $role
 ```
 
-**응답 케이스 정책** — 본 PR의 모든 응답은 **카멜케이스 통일**. Prisma raw 객체를 그대로 반환하지 않고 변환해서 응답.
+**응답 형태** — 페이지네이션 래퍼.
 
-**SELECT 및 응답 (멘티)**
+**data 항목 (멘티)**
 ```json
-[
-  {
-    "userId": "uuid",
-    "name": "김민준",
-    "studentId": "2020123456",
-    "firstMajor": "법학과",
-    "secondMajor": null,
-    "phone": "010-1234-5678",
-    "accountStatus": "active"
-  }
-]
+{
+  "userId": "uuid",
+  "name": "김민준",
+  "studentId": "2020123456",
+  "firstMajor": "법학과",
+  "secondMajor": null,
+  "phone": "010-1234-5678",
+  "accountStatus": "active"
+}
 ```
 
-**SELECT 및 응답 (멘토)**
+**data 항목 (멘토)**
 - 멘토는 latest MentorRecord 1개를 사용자별로 join 해 `lawschool_name`, `lawschool_grade`(=cohort) 표시.
 ```json
-[
-  {
-    "userId": "uuid",
-    "name": "최수진",
-    "studentId": "2018456789",
-    "lawSchool": "서울대학교 로스쿨",
-    "cohort": 7,
-    "phone": "010-4567-8901",
-    "accountStatus": "active"
-  }
-]
+{
+  "userId": "uuid",
+  "name": "최수진",
+  "studentId": "2018456789",
+  "lawSchool": "서울대학교 로스쿨",
+  "cohort": 7,
+  "phone": "010-4567-8901",
+  "accountStatus": "active"
+}
+```
+
+**전체 응답 예시**
+```json
+{
+  "data": [ ... ],
+  "totalCount": 137,
+  "page": 1,
+  "limit": 50
+}
 ```
 - record가 없는 멘토(이론상 거의 없음): `lawSchool: null, cohort: null` 로 응답하고 행은 노출.
 
 **정렬**: `name ASC`
 
 **구현 노트**
-- 멘토 latest record 조회: `findMany({ where: { user_id: { in: [...] } }, orderBy: { process_year: 'desc' } })` → 메모리에서 `Map<user_id, record>` 로 첫 만남만 유지(N+1 회피).
+- 페이지네이션은 User 테이블에 적용 (skip/take). count 도 같은 WHERE 로.
+- 멘토 latest record 조회: 페이지에 들어온 user_id 들로만 `findMany({ where: { user_id: { in: pageUserIds } }, orderBy: { process_year: 'desc' } })` → 메모리에서 `Map<user_id, record>` 로 첫 만남만 유지(N+1 회피, 페이지 사이즈만큼만 스캔).
 
 **에러**
 - 400: `role` 누락 또는 `mentee|mentor` 외 값
@@ -90,6 +153,7 @@ AND users.current_role = $role
 **Query**
 - `role` (필수): `mentee` 또는 `mentor`
 - `year` (옵션): 기본값 = 활성 CycleSchedule.process_year. 활성 cycle이 없고 year 미지정이면 400.
+- `page`, `limit` — 공통 페이지네이션 규약 따름
 
 **WHERE**
 ```
@@ -101,8 +165,8 @@ AND applications.application_status IN
 
 **JOIN**
 - User: name, student_id, undergrad_first_major
-- 멘토면 latest MentorRecord: lawschool_name
-- AdminMemo: 같은 application_id에 대한 가장 최근 1개 (`ORDER BY created_at DESC LIMIT 1`)
+- 멘토면 latest MentorRecord: lawschool_name (페이지에 들어온 user_id 들에 한해 추가 조회, /admin/users 와 동일 패턴)
+- AdminMemo: 같은 application_id에 대한 가장 최근 1개. include 의 `take: 1` 사용 — **반환은 객체가 아닌 길이 1짜리 배열**. 응답 매핑 시 `row.admin_memos[0]?.memo_content ?? null` (공통 응답 규약 참고).
 
 **상태 라벨 매핑** (`apps/api/src/lib/labels.ts` 에 추가)
 | DB enum | FE label |
@@ -112,22 +176,30 @@ AND applications.application_status IN
 | `rejected` | `rejected` |
 | `revision_requested` | `revision` |
 
-**응답 (멘티)**
+**data 항목 (멘티)**
 ```json
-[
-  {
-    "applicationId": "uuid",
-    "name": "김민준",
-    "studentId": "2020123456",
-    "major": "법학과",
-    "status": "approved",
-    "memo": "서류 확인 완료",
-    "submittedAt": "2026-04-10T..."
-  }
-]
+{
+  "applicationId": "uuid",
+  "name": "김민준",
+  "studentId": "2020123456",
+  "major": "법학과",
+  "status": "approved",
+  "memo": "서류 확인 완료",
+  "submittedAt": "2026-04-10T..."
+}
 ```
 
-**응답 (멘토)** — `major` 대신 `school` (=lawschool_name).
+**data 항목 (멘토)** — `major` 대신 `school` (=lawschool_name).
+
+**전체 응답 예시**
+```json
+{
+  "data": [ ... ],
+  "totalCount": 24,
+  "page": 1,
+  "limit": 50
+}
+```
 
 **정렬**: `submitted_at DESC`
 
@@ -253,9 +325,10 @@ Announcement.create({
 
 ## 6. GET /api/admin/announcements
 
+- Query: `page`, `limit` — 공통 페이지네이션 규약 따름
 - 정렬: `created_at DESC`
 - include: created_by → name
-- 응답 200: 위 형태 객체 배열
+- 응답 200: `{ data: [...], totalCount, page, limit }` 형태. `data` 항목은 POST 응답과 동일.
 
 ## 7. DELETE /api/admin/announcements/:id
 
@@ -267,7 +340,8 @@ Announcement.create({
 ## 8. GET /api/announcements (공개)
 
 - 라우트 핸들러 시작에 `getTokenFromCookie(req)` 검증 → 없으면 401.
-- 정렬·응답 형태는 admin 목록과 동일.
+- Query: `page`, `limit` — 공통 페이지네이션 규약 따름
+- 정렬·응답 형태는 admin 목록과 동일 (`{ data, totalCount, page, limit }`).
 
 ## 9. GET /api/announcements/:id (공개)
 
@@ -336,15 +410,17 @@ export async function resolveProcessYear(req: NextRequest): Promise<
 ## E2E 검증 (curl)
 
 1. admin 로그인 → 쿠키 저장
-2. mentee/mentor 회원 목록 200
-3. mentee/mentor 신청 목록 200 (year 생략 시 활성 cycle 사용)
-4. eligible 200 (mentees + mentors 풀)
-5. POST 공지 201
-6. GET admin 공지 목록 200
-7. DELETE 공지 200 + 재조회 시 사라짐
-8. mentee 로그인 → 공개 공지 GET 200, admin GET 403
-9. 비로그인 → 공개 공지 GET 401
-10. role 누락/오류 → 400
+2. mentee/mentor 회원 목록 200 (`{ data, totalCount, page, limit }` 형태 확인)
+3. `?page=2&limit=10` 으로 페이지 이동 → totalCount 일치, data 길이 ≤ limit
+4. mentee/mentor 신청 목록 200 (year 생략 시 활성 cycle 사용)
+5. eligible 200 (mentees + mentors 풀, 래퍼 없음)
+6. POST 공지 201
+7. GET admin 공지 목록 200
+8. DELETE 공지 200 + 재조회 시 사라짐
+9. mentee 로그인 → 공개 공지 GET 200, admin GET 403
+10. 비로그인 → 공개 공지 GET 401
+11. role 누락/오류 → 400
+12. `?limit=300` (상한 200 초과) → 400
 
 ## FE 핸드오프 메모
 
@@ -356,3 +432,4 @@ export async function resolveProcessYear(req: NextRequest): Promise<
 - `/announcements`, `/mentee/announcements`, `/mentor/announcements` mock 제거 → `GET /api/announcements`
 - `/[role]/announcements/[id]` → `GET /api/announcements/:id`
 - **응답 필드는 모두 카멜케이스** (snake_case 아님). 기존 mock의 `user_id` 등 snake 필드는 `userId`로 변경 필요. 응답에 type 정의 추가.
+- **배열형 응답은 페이지네이션 래퍼**: `users`, `applications`, `announcements` 응답이 `{ data, totalCount, page, limit }`. 기존 FE 클라이언트 페이지네이션을 서버 페이지네이션으로 교체해야 함 (page/limit 서버에 보내고 totalCount 로 totalPages 계산). `eligible` 만 단일 객체 응답.

--- a/packages/database/prisma/migrations/20260510130000_announcements/migration.sql
+++ b/packages/database/prisma/migrations/20260510130000_announcements/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "announcements" (
+    "announcement_id"    UUID NOT NULL DEFAULT gen_random_uuid(),
+    "title"              VARCHAR(100) NOT NULL,
+    "body"               TEXT NOT NULL,
+    "created_by_user_id" UUID NOT NULL,
+    "created_at"         TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"         TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "announcements_pkey" PRIMARY KEY ("announcement_id")
+);
+
+-- CreateIndex
+CREATE INDEX "announcements_created_at_idx" ON "announcements"("created_at");
+
+-- AddForeignKey
+ALTER TABLE "announcements"
+    ADD CONSTRAINT "announcements_created_by_user_id_fkey"
+    FOREIGN KEY ("created_by_user_id") REFERENCES "users"("user_id")
+    ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -132,6 +132,7 @@ model User {
   created_match_results MatchResult[]  @relation("MatchCreatedBy")
   admin_memos           AdminMemo[]
   password_reset_tokens PasswordResetToken[]
+  created_announcements Announcement[] @relation("AnnouncementCreatedBy")
 
   @@map("users")
 }
@@ -453,6 +454,25 @@ model PasswordResetToken {
 
   @@index([user_id])
   @@map("password_reset_tokens")
+}
+
+// ----------------------------------------------------------------
+// 10. announcements (#176)
+//    - 관리자 작성 공지. 멘티/멘토/admin 모두 읽기 가능.
+//    - hard delete (soft delete 미적용)
+// ----------------------------------------------------------------
+model Announcement {
+  announcement_id    String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  title              String   @db.VarChar(100)
+  body               String   @db.Text
+  created_by_user_id String   @db.Uuid
+  created_at         DateTime @default(now())
+  updated_at         DateTime @updatedAt
+
+  created_by User @relation("AnnouncementCreatedBy", fields: [created_by_user_id], references: [user_id])
+
+  @@index([created_at])
+  @@map("announcements")
 }
 
 // ================================================================


### PR DESCRIPTION
## Summary
  - 회원관리·신청관리·매칭관리·공지사항 4개 화면용 BE API 8종
  - 새 테이블 `announcements` + 마이그레이션 `20260510130000_announcements`
  - 공통 헬퍼: `requireAdmin`, `resolveProcessYear`
  - 라벨 매핑: `applicationStatusToLabel`
  - 응답 케이스 통일: 카멜케이스, 배열형은 `{ data, totalCount, page, limit }` 래퍼

  ## 엔드포인트
  | Method | Path | 설명 |
  |---|---|---|
  | GET | `/api/admin/users?role=mentee\|mentor` | 멘티/멘토 회원 목록 |
  | GET | `/api/admin/applications?role=mentee\|mentor&year=YYYY` | 멘티/멘토 신청 목록 |
  | GET | `/api/admin/matchings/eligible?year=YYYY` | approved 멘티+멘토 풀 |
  | POST | `/api/admin/announcements` | 공지 작성 |
  | GET | `/api/admin/announcements` | 관리자 공지 목록 |
  | DELETE | `/api/admin/announcements/:id` | 공지 삭제 |
  | GET | `/api/announcements` | 공개 목록 (로그인 필수) |
  | GET | `/api/announcements/:id` | 공개 상세 (로그인 필수) |

## 1. GET /api/admin/users (회원관리)

  Query: `?role=mentee|mentor` (필수), `?page`, `?limit`

  WHERE: `users.is_deleted = false AND current_role = $role`

  SELECT:
  - 공통: `userId, name, studentId, phone, accountStatus`
  - 멘티: + `firstMajor, secondMajor` (학부 제1전공·제2전공)
  - 멘토: + 가장 최근 MentorRecord 의 `lawSchool, cohort` (사용자별 `process_year DESC LIMIT 1`)

  정렬: `name ASC`

  응답 (멘티 예시):
  ```json
  {
    "data": [
      {
        "userId": "uuid",
        "name": "김민준",
        "studentId": "2020123456",
        "firstMajor": "법학과",
        "secondMajor": null,
        "phone": "010-1234-5678",
        "accountStatus": "active"
      }
    ],
    "totalCount": 12,
    "page": 1,
    "limit": 50
  }
  ```

  응답 (멘토 예시):
  ```json
  {
    "data": [
      {
        "userId": "uuid",
        "name": "최수진",
        "studentId": "2018456789",
        "lawSchool": "서울대학교 로스쿨",
        "cohort": 7,
        "phone": "010-4567-8901",
        "accountStatus": "active"
      }
    ],
    "totalCount": 7,
    "page": 1,
    "limit": 50
  }
  ```

  에러:
  - 400 (role 누락/오류, page/limit 범위 위반)
  - 401 (비로그인) / 403 (비-admin)

---

## 2. GET /api/admin/applications (신청관리)

  Query: `?role=mentee|mentor` (필수), `?year=YYYY` (옵션, 기본 활성 cycle), `?page`, `?limit`

  WHERE:
  ```
  applications.role = $role
  AND applications.process_year = $year
  AND applications.application_status IN
      ('submitted','approved','rejected','revision_requested')
  ```
  (즉 `draft` 임시저장은 제외)

  SELECT:
  - 공통: `applicationId, name, studentId, status, memo, submittedAt`
  - 멘티: + `major` (User.undergrad_first_major)
  - 멘토: + `school` (가장 최근 MentorRecord.lawschool_name)

  상태 라벨 매핑 (BE enum → FE 표시):
  | DB enum | FE label |
  |---|---|
  | `submitted` | `pending` |
  | `approved` | `approved` |
  | `rejected` | `rejected` |
  | `revision_requested` | `revision` |

  관리자 메모는 같은 application 의 가장 최근 1건만 단일 string 으로 (`memo`). 없으면 `null`.

  정렬: `submitted_at DESC`

  응답 (멘티 예시):
  ```json
  {
    "data": [
      {
        "applicationId": "uuid",
        "name": "김민준",
        "studentId": "2020123456",
        "major": "법학과",
        "status": "approved",
        "memo": "서류 확인 완료",
        "submittedAt": "2026-04-10T03:21:00.000Z"
      }
    ],
    "totalCount": 24,
    "page": 1,
    "limit": 50
  }
  ```

  응답 (멘토 예시): `major` 대신 `school: "서울대학교 로스쿨"`.

  에러:
  - 400 (role 누락/오류, year 형식, 활성 cycle 없고 year 미지정, page/limit 범위)
  - 401 / 403

---

## 3. GET /api/admin/matchings/eligible (매칭 적격 풀)

  Query: `?year=YYYY` (옵션, 기본 활성 cycle)

  역할: AI 매칭 알고리즘의 **입력 후보군**. `application_status='approved'` 인 멘티+멘토 양쪽을 한 번에 반환. 이미 매칭됐는지 여부는 거르지 않음(재배정 시나리오 허용).

  WHERE:
  - mentees: `role='mentee' AND application_status='approved' AND process_year=$year`
  - mentors: 위 + `role='mentor'`

  정렬: 둘 다 `name ASC`

  응답 (페이지네이션 미적용 — 단일 객체):
  ```json
  {
    "year": 2026,
    "mentees": [
      {
        "applicationId": "uuid",
        "userId": "uuid",
        "name": "김민준",
        "studentId": "2020123456",
        "major": "법학과",
        "accountStatus": "active"
      }
    ],
    "mentors": [
      {
        "applicationId": "uuid",
        "userId": "uuid",
        "name": "최수진",
        "studentId": "2018456789",
        "lawSchool": "서울대학교 로스쿨",
        "accountStatus": "active"
      }
    ]
  }
  ```

  에러:
  - 400 (활성 cycle 없고 year 미지정)
  - 401 / 403

---

## 4. POST /api/admin/announcements (공지 작성)

  Body:
  ```json
  { "title": "string (1~100자)", "body": "string (1자 이상)" }
  ```

  처리:
  - title/body 양쪽 trim 후 길이 검증
  - `created_by_user_id` 는 admin 세션 payload 에서 자동 채움

  응답 201:
  ```json
  {
    "announcementId": "uuid",
    "title": "...",
    "body": "...",
    "createdAt": "2026-05-11T01:23:45.000Z",
    "author": "관리자 이름"
  }
  ```

  에러:
  - 400 (title 길이/누락, body 누락, JSON 파싱 실패)
  - 401 / 403

---

## 5. GET /api/admin/announcements (관리자 공지 목록)

  Query: `?page`, `?limit`

  정렬: `created_at DESC`

  응답:
  ```json
  {
    "data": [
      {
        "announcementId": "uuid",
        "title": "2026학년도 멘토 모집 안내",
        "body": "본문 ...",
        "createdAt": "2026-04-10T00:00:00.000Z",
        "author": "관리자 이름"
      }
    ],
    "totalCount": 8,
    "page": 1,
    "limit": 50
  }
  ```

  에러:
  - 400 (page/limit 범위)
  - 401 / 403

---

## 6. DELETE /api/admin/announcements/:id (공지 삭제)

  URL 파라미터: `:id` = `announcementId`(uuid)

  처리: hard delete (복구 불가)

  응답 200:
  ```json
  { "success": true }
  ```

  에러:
  - 404 (없는 id)
  - 401 / 403

---

## 7. GET /api/announcements (공개 목록)

  대상: 로그인된 멘티/멘토/admin 모두.

  Query: `?page`, `?limit`

  정렬·응답 형태: 5번(관리자 목록)과 **동일**.

  응답:
  ```json
  {
    "data": [
      {
        "announcementId": "uuid",
        "title": "...",
        "body": "...",
        "createdAt": "...",
        "author": "관리자 이름"
      }
    ],
    "totalCount": 8,
    "page": 1,
    "limit": 50
  }
  ```

  에러:
  - 401 (비로그인)
  - 400 (page/limit 범위)

---

## 8. GET /api/announcements/:id (공개 상세)

  URL 파라미터: `:id` = `announcementId`(uuid)

  응답 200 (단일 객체):
  ```json
  {
    "announcementId": "uuid",
    "title": "...",
    "body": "...",
    "createdAt": "...",
    "author": "관리자 이름"
  }
  ```

  에러:
  - 401 (비로그인)
  - 404 (없는 id)