### PR TITLE
feat: 모바일 반응형 레이아웃 적용

### DIFF
--- a/apps/web/src/app/admin/applications/AdminApplicationsClient.tsx
+++ b/apps/web/src/app/admin/applications/AdminApplicationsClient.tsx
@@ -706,7 +706,7 @@ function ApplicationEditModal<T extends AdminApplicationRow>({
         <div className="px-6 py-5 flex flex-col gap-6 overflow-y-auto">
           <div>
             <p className="text-xs font-medium text-text-secondary mb-2">신청자 정보</p>
-            <div className="bg-page-bg border border-border rounded-md px-4 py-3 grid grid-cols-2 gap-x-4 gap-y-2.5">
+            <div className="bg-page-bg border border-border rounded-md px-4 py-3 grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2.5">
               <div>
                 <span className="block text-xs text-text-secondary">이름</span>
                 <p className="text-sm font-medium text-text-primary">{target.name}</p>
@@ -722,7 +722,7 @@ function ApplicationEditModal<T extends AdminApplicationRow>({
 
           <div>
             <p className="text-sm font-medium text-text-primary mb-3">신청 상태</p>
-            <div className="grid grid-cols-4 gap-2">
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
               {(['approved', 'pending', 'revision', 'rejected'] as const).map((s) => (
                 <button
                   key={s}

--- a/apps/web/src/app/admin/applications/AdminApplicationsClient.tsx
+++ b/apps/web/src/app/admin/applications/AdminApplicationsClient.tsx
@@ -215,12 +215,12 @@ function ApplicationsPageContent({ initialSchedules, initialYear, initialMenteeD
           <h1 className="text-2xl font-bold text-text-primary">신청관리</h1>
           <p className="mt-1 text-sm text-text-secondary">회원의 신청 내역을 관리합니다</p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           {/* 연도 선택 커스텀 드롭다운 */}
           <div className="relative" ref={yearDropdownRef}>
             <button
               onClick={() => setYearDropdownOpen((o) => !o)}
-              className="flex items-center gap-2 px-3 py-1.5 bg-white border border-border rounded-lg hover:bg-gray-50 transition-colors"
+              className="flex items-center gap-2 px-3 py-1.5 bg-white border border-border rounded-lg hover:bg-gray-50 transition-colors whitespace-nowrap"
             >
               <span className="text-sm font-semibold text-text-primary">
                 {selectedYear != null ? `${selectedYear}년` : '연도'}
@@ -261,7 +261,7 @@ function ApplicationsPageContent({ initialSchedules, initialYear, initialMenteeD
           {current && (
             <button
               onClick={toggleActive}
-              className={`px-3 py-1.5 text-xs font-medium rounded-md border transition-colors ${
+              className={`px-3 py-1.5 text-xs font-medium rounded-md border transition-colors whitespace-nowrap ${
                 current.is_active
                   ? 'text-text-secondary border-border hover:bg-gray-50'
                   : 'text-brand border-brand/40 bg-brand/5 hover:bg-brand/10'
@@ -273,14 +273,14 @@ function ApplicationsPageContent({ initialSchedules, initialYear, initialMenteeD
           <button
             onClick={handleAddYear}
             disabled={addingYear}
-            className="px-3 py-1.5 text-xs font-medium text-text-secondary border border-border rounded-md hover:bg-gray-50 transition-colors disabled:opacity-50"
+            className="px-3 py-1.5 text-xs font-medium text-text-secondary border border-border rounded-md hover:bg-gray-50 transition-colors disabled:opacity-50 whitespace-nowrap"
           >
             + 새 연도
           </button>
           {current && (
             <button
               onClick={handleDelete}
-              className="px-3 py-1.5 text-xs font-medium text-red-500 border border-red-200 rounded-md hover:bg-red-50 transition-colors"
+              className="px-3 py-1.5 text-xs font-medium text-red-500 border border-red-200 rounded-md hover:bg-red-50 transition-colors whitespace-nowrap"
             >
               연도 삭제
             </button>

--- a/apps/web/src/app/admin/applications/AdminApplicationsClient.tsx
+++ b/apps/web/src/app/admin/applications/AdminApplicationsClient.tsx
@@ -289,7 +289,7 @@ function ApplicationsPageContent({ initialSchedules, initialYear, initialMenteeD
       </div>
 
       {/* 사업 스케줄 */}
-      <section className="bg-white border border-border rounded-xl px-8 py-6">
+      <section className="bg-white border border-border rounded-xl px-4 sm:px-8 py-6">
         <div className="flex items-center justify-between mb-2">
           <h2 className="text-base font-semibold text-text-primary">pLAWcess 사업 스케줄</h2>
           {current && (
@@ -535,23 +535,23 @@ function ApplicationPanel<T extends AdminApplicationRow>({
   };
 
   return (
-    <section className="bg-white border border-border rounded-xl px-8 py-6">
-      <div className="flex items-center justify-between mb-4 gap-4">
+    <section className="bg-white border border-border rounded-xl px-4 sm:px-8 py-6">
+      <div className="flex flex-wrap items-center justify-between mb-4 gap-3">
         <div className="flex items-center gap-2 text-text-placeholder">
           <SearchIcon />
           <input
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="검색..."
-            className="w-56 text-sm bg-transparent focus:outline-none placeholder:text-text-placeholder"
+            className="w-44 sm:w-56 text-sm bg-transparent focus:outline-none placeholder:text-text-placeholder"
           />
         </div>
-        <div className="flex items-center gap-1 p-1 bg-gray-100 rounded-lg border border-border">
+        <div className="flex items-center gap-1 p-1 bg-gray-100 rounded-lg border border-border overflow-x-auto">
           {(['all', 'approved', 'pending', 'revision', 'rejected'] as const).map((s) => (
             <button
               key={s}
               onClick={() => setStatusFilter(s)}
-              className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
+              className={`px-2.5 sm:px-3 py-1.5 text-xs font-medium rounded-md transition-colors whitespace-nowrap ${
                 statusFilter === s
                   ? 'bg-white text-text-primary shadow-sm'
                   : 'text-text-secondary hover:text-text-primary'
@@ -563,7 +563,8 @@ function ApplicationPanel<T extends AdminApplicationRow>({
         </div>
       </div>
 
-      <table className="w-full table-auto">
+      <div className="overflow-x-auto">
+      <table className="w-full table-auto min-w-[560px]">
         <thead>
           <tr className="border-b border-border">
             {columns.map((col) => (
@@ -613,6 +614,7 @@ function ApplicationPanel<T extends AdminApplicationRow>({
           )}
         </tbody>
       </table>
+      </div>
 
       <div className="flex items-center justify-between mt-5">
         <span className="text-xs text-text-secondary">

--- a/apps/web/src/app/admin/applications/AdminApplicationsClient.tsx
+++ b/apps/web/src/app/admin/applications/AdminApplicationsClient.tsx
@@ -564,11 +564,11 @@ function ApplicationPanel<T extends AdminApplicationRow>({
       </div>
 
       <div className="overflow-x-auto">
-      <table className="w-full table-auto min-w-[560px]">
+      <table className="w-full table-auto min-w-[600px]">
         <thead>
           <tr className="border-b border-border">
             {columns.map((col) => (
-              <th key={String(col.key)} className="text-left text-xs font-medium text-text-secondary py-3 pr-4 select-none">
+              <th key={String(col.key)} className="text-left text-xs font-medium text-text-secondary py-3 pr-4 select-none whitespace-nowrap">
                 {col.sortable ? (
                   <button onClick={() => onSort(col.key)} className="flex items-center gap-1 hover:text-text-primary transition-colors">
                     {col.label}
@@ -593,7 +593,7 @@ function ApplicationPanel<T extends AdminApplicationRow>({
             processed.map((row) => (
               <tr key={row.applicationId} className="border-b border-border last:border-b-0">
                 {columns.map((col) => (
-                  <td key={String(col.key)} className="py-4 pr-4 text-sm text-text-primary align-middle">
+                  <td key={String(col.key)} className="py-4 pr-4 text-sm text-text-primary align-middle whitespace-nowrap">
                     {col.render ? col.render(row) : String(row[col.key] ?? '')}
                   </td>
                 ))}

--- a/apps/web/src/app/admin/matchings/AdminMatchingsClient.tsx
+++ b/apps/web/src/app/admin/matchings/AdminMatchingsClient.tsx
@@ -103,9 +103,9 @@ export default function AdminMatchingsClient({ initialPool }: { initialPool: Eli
         </p>
       </div>
 
-      <section className="bg-white border border-border rounded-xl px-8 py-6">
+      <section className="bg-white border border-border rounded-xl px-4 sm:px-8 py-6">
         <h2 className="text-base font-semibold text-text-primary mb-6">매칭 대상 조회</h2>
-        <div className="grid grid-cols-2 gap-10">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-10">
           <ApprovedTable
             title={`승인된 멘티 신청자 목록 (${pool.mentees.length}명)`}
             columns={['이름', '학번', '전공', '현재 역할', '상태']}
@@ -125,7 +125,7 @@ export default function AdminMatchingsClient({ initialPool }: { initialPool: Eli
         </div>
       </section>
 
-      <section className="bg-white border border-border rounded-xl px-8 py-6">
+      <section className="bg-white border border-border rounded-xl px-4 sm:px-8 py-6">
         <h2 className="text-base font-semibold text-text-primary mb-5">AI 매칭 실행</h2>
         <button
           onClick={handleRunMatching}
@@ -140,50 +140,53 @@ export default function AdminMatchingsClient({ initialPool }: { initialPool: Eli
         </button>
       </section>
 
-      <section className="bg-white border border-border rounded-xl px-8 py-6">
+      <section className="bg-white border border-border rounded-xl px-4 sm:px-8 py-6">
         <h2 className="text-base font-semibold text-text-primary mb-5">AI 매칭 결과 조회</h2>
         {!results ? (
           <p className="py-6 text-sm text-text-secondary">아직 매칭이 실행되지 않았습니다. 위에서 AI 매칭을 실행해주세요.</p>
         ) : results.length === 0 ? (
           <p className="py-6 text-sm text-text-secondary">매칭 결과가 비어 있습니다. (BE 매칭 알고리즘 구현 대기)</p>
         ) : (
-          <table className="w-full table-auto">
+          <div className="overflow-x-auto">
+          <table className="w-full table-auto min-w-[480px]">
             <thead>
               <tr className="border-b border-border">
-                <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4">멘티 이름</th>
-                <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4">멘토 이름</th>
-                <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4">매칭 점수</th>
-                <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4">추천 사유</th>
+                <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap">멘티 이름</th>
+                <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap">멘토 이름</th>
+                <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap">매칭 점수</th>
+                <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap">추천 사유</th>
               </tr>
             </thead>
             <tbody>
               {results.map((r) => (
                 <tr key={r.id} className="border-b border-border last:border-b-0">
-                  <td className="py-3 pr-4 text-sm text-text-primary">{r.menteeName}</td>
-                  <td className="py-3 pr-4 text-sm text-text-primary">{r.mentorName}</td>
+                  <td className="py-3 pr-4 text-sm text-text-primary whitespace-nowrap">{r.menteeName}</td>
+                  <td className="py-3 pr-4 text-sm text-text-primary whitespace-nowrap">{r.mentorName}</td>
                   <td className="py-3 pr-4"><ScoreBadge score={r.score} /></td>
                   <td className="py-3 pr-4 text-sm text-text-secondary">{r.reason}</td>
                 </tr>
               ))}
             </tbody>
           </table>
+          </div>
         )}
       </section>
 
-      <section className="bg-white border border-border rounded-xl px-8 py-6">
+      <section className="bg-white border border-border rounded-xl px-4 sm:px-8 py-6">
         <h2 className="text-base font-semibold text-text-primary mb-5">매칭 결과 수정 및 확정</h2>
         {!results || results.length === 0 ? (
           <p className="py-6 text-sm text-text-secondary">매칭 결과가 있어야 수정할 수 있습니다.</p>
         ) : (
           <>
-            <table className="w-full table-auto">
+            <div className="overflow-x-auto">
+            <table className="w-full table-auto min-w-[560px]">
               <thead>
                 <tr className="border-b border-border">
-                  <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 w-[16%]">멘티 이름</th>
-                  <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 w-[20%]">멘토 이름</th>
-                  <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 w-[12%]">매칭 점수</th>
-                  <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4">추천 사유</th>
-                  <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 w-[14%]">매칭 상태</th>
+                  <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap w-[16%]">멘티 이름</th>
+                  <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap w-[20%]">멘토 이름</th>
+                  <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap w-[12%]">매칭 점수</th>
+                  <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap">추천 사유</th>
+                  <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap w-[14%]">매칭 상태</th>
                 </tr>
               </thead>
               <tbody>
@@ -202,6 +205,7 @@ export default function AdminMatchingsClient({ initialPool }: { initialPool: Eli
                 ))}
               </tbody>
             </table>
+            </div>
             <div className="flex items-center gap-2 mt-6">
               <button onClick={handleSaveDraft} className="flex items-center gap-1.5 px-4 py-2 text-sm text-text-secondary border border-border rounded-md hover:bg-gray-50 transition-colors">
                 임시저장
@@ -221,7 +225,8 @@ function ApprovedTable({ title, columns, rows }: { title: string; columns: strin
   return (
     <div>
       <h3 className="text-sm font-semibold text-text-primary mb-4">{title}</h3>
-      <table className="w-full table-auto">
+      <div className="overflow-x-auto">
+      <table className="w-full table-auto min-w-[320px]">
         <thead>
           <tr className="border-b border-border">
             {columns.map((c) => (
@@ -243,6 +248,7 @@ function ApprovedTable({ title, columns, rows }: { title: string; columns: strin
           )}
         </tbody>
       </table>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/admin/personal-statements/PersonalStatementsClient.tsx
+++ b/apps/web/src/app/admin/personal-statements/PersonalStatementsClient.tsx
@@ -119,7 +119,7 @@ export default function PersonalStatementsClient({
       />
 
       {/* 패널 */}
-      <div className="bg-white border border-border rounded-xl px-8 py-6">
+      <div className="bg-white border border-border rounded-xl px-4 sm:px-8 py-6">
         {/* 검색 */}
         <div className="flex items-center gap-2 text-text-placeholder mb-4">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -130,12 +130,13 @@ export default function PersonalStatementsClient({
             value={search}
             onChange={(e) => handleSearch(e.target.value)}
             placeholder="학교명 검색..."
-            className="w-56 text-sm bg-transparent focus:outline-none placeholder:text-text-placeholder"
+            className="w-44 sm:w-56 text-sm bg-transparent focus:outline-none placeholder:text-text-placeholder"
           />
         </div>
 
         {/* 목록 */}
-        <table className="w-full table-auto">
+        <div className="overflow-x-auto">
+        <table className="w-full table-auto min-w-[400px]">
           <thead>
             <tr className="border-b border-border">
               <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4">학교명</th>
@@ -193,6 +194,7 @@ export default function PersonalStatementsClient({
             )}
           </tbody>
         </table>
+        </div>
 
         {/* 페이지네이션 */}
         <div className="flex items-center justify-between mt-5">

--- a/apps/web/src/app/admin/personal-statements/PersonalStatementsClient.tsx
+++ b/apps/web/src/app/admin/personal-statements/PersonalStatementsClient.tsx
@@ -139,9 +139,9 @@ export default function PersonalStatementsClient({
         <table className="w-full table-auto min-w-[400px]">
           <thead>
             <tr className="border-b border-border">
-              <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4">학교명</th>
-              <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4">상태</th>
-              <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4">최근 업데이트</th>
+              <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap">학교명</th>
+              <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap">상태</th>
+              <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap">최근 업데이트</th>
               <th className="py-3" />
             </tr>
           </thead>

--- a/apps/web/src/app/admin/personal-statements/[school]/PersonalStatementEditClient.tsx
+++ b/apps/web/src/app/admin/personal-statements/[school]/PersonalStatementEditClient.tsx
@@ -128,8 +128,13 @@ export default function PersonalStatementEditClient({
         </div>
       </div>
 
+      {/* 모바일 안내 */}
+      <div className="sm:hidden bg-amber-50 border border-amber-200 rounded-xl px-5 py-4 text-sm text-amber-800">
+        이 페이지는 PC 환경에서 이용해 주세요.
+      </div>
+
       {/* 2열 레이아웃 */}
-      <div className="grid grid-cols-2 gap-6" style={{ height: '80vh' }}>
+      <div className="hidden sm:grid grid-cols-2 gap-6" style={{ height: '80vh' }}>
         {/* 왼쪽: 문항 편집 */}
         <div className="bg-white border border-border rounded-xl flex flex-col overflow-hidden">
           <div className="flex items-center justify-between px-6 py-4 border-b border-border">

--- a/apps/web/src/app/admin/users/AdminUsersClient.tsx
+++ b/apps/web/src/app/admin/users/AdminUsersClient.tsx
@@ -251,7 +251,7 @@ function UserListPanel<T extends { userId: string; accountStatus: AdminAccountSt
   };
 
   return (
-    <section className="bg-white border border-border rounded-xl px-8 py-6">
+    <section className="bg-white border border-border rounded-xl px-4 sm:px-8 py-6">
       <div className="flex items-center mb-4 gap-4">
         <div className="flex items-center gap-2 text-text-placeholder">
           <SearchIcon />
@@ -259,7 +259,8 @@ function UserListPanel<T extends { userId: string; accountStatus: AdminAccountSt
         </div>
       </div>
 
-      <table className="w-full table-auto">
+      <div className="overflow-x-auto">
+      <table className="w-full table-auto min-w-[500px]">
         <thead>
           <tr className="border-b border-border">
             {columns.map((col) => (
@@ -294,6 +295,7 @@ function UserListPanel<T extends { userId: string; accountStatus: AdminAccountSt
           )}
         </tbody>
       </table>
+      </div>
 
       <div className="flex items-center justify-between mt-5">
         <span className="text-xs text-text-secondary">총 {totalCount}명 · {safePage} / {totalPages} 페이지</span>

--- a/apps/web/src/app/admin/users/AdminUsersClient.tsx
+++ b/apps/web/src/app/admin/users/AdminUsersClient.tsx
@@ -76,18 +76,18 @@ function UsersPageContent({ initialMenteeData }: { initialMenteeData: Paged<Admi
 
   return (
     <div className="flex flex-col gap-8">
-      <div className="flex items-start justify-between">
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
         <div>
           <h1 className="text-2xl font-bold text-text-primary">회원관리</h1>
           <p className="mt-1 text-sm text-text-secondary">회원 정보를 조회하고 관리합니다</p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 flex-wrap">
           <div className="flex items-center gap-1 p-1 bg-gray-100 rounded-lg border border-border">
             {STATUS_FILTER_OPTIONS.map(({ value, label }) => (
               <button
                 key={value}
                 onClick={() => setStatusFilter(value)}
-                className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
+                className={`px-2.5 sm:px-3 py-1.5 text-xs font-medium rounded-md transition-colors whitespace-nowrap ${
                   statusFilter === value
                     ? 'bg-white text-text-primary shadow-sm'
                     : 'text-text-secondary hover:text-text-primary'
@@ -97,7 +97,7 @@ function UsersPageContent({ initialMenteeData }: { initialMenteeData: Paged<Admi
               </button>
             ))}
           </div>
-          <button className="flex items-center gap-1.5 px-4 py-2 text-sm font-semibold text-white bg-brand rounded-md hover:bg-brand-dark transition-colors">
+          <button className="flex items-center gap-1.5 px-4 py-2 text-sm font-semibold text-white bg-brand rounded-md hover:bg-brand-dark transition-colors whitespace-nowrap">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" /><circle cx="8.5" cy="7" r="4" /><line x1="20" y1="8" x2="20" y2="14" /><line x1="23" y1="11" x2="17" y2="11" />
             </svg>
@@ -260,11 +260,11 @@ function UserListPanel<T extends { userId: string; accountStatus: AdminAccountSt
       </div>
 
       <div className="overflow-x-auto">
-      <table className="w-full table-auto min-w-[500px]">
+      <table className="w-full table-auto min-w-[600px]">
         <thead>
           <tr className="border-b border-border">
             {columns.map((col) => (
-              <th key={String(col.key)} className="text-left text-xs font-medium text-text-secondary py-3 pr-4 select-none">
+              <th key={String(col.key)} className="text-left text-xs font-medium text-text-secondary py-3 pr-4 select-none whitespace-nowrap">
                 {col.sortable ? (
                   <button onClick={() => onSort(col.key)} className="flex items-center gap-1 hover:text-text-primary transition-colors">
                     {col.label}
@@ -286,7 +286,7 @@ function UserListPanel<T extends { userId: string; accountStatus: AdminAccountSt
             processed.map((row) => (
               <tr key={row.userId} className="border-b border-border last:border-b-0">
                 {columns.map((col) => (
-                  <td key={String(col.key)} className="py-4 pr-4 text-sm text-text-primary align-middle">
+                  <td key={String(col.key)} className="py-4 pr-4 text-sm text-text-primary align-middle whitespace-nowrap">
                     {col.render ? col.render(row) : String(row[col.key] ?? '')}
                   </td>
                 ))}

--- a/apps/web/src/app/admin/users/[userId]/AdminUserDetailClient.tsx
+++ b/apps/web/src/app/admin/users/[userId]/AdminUserDetailClient.tsx
@@ -164,7 +164,7 @@ function ProfileCard({
 
   return (
     <div className="bg-white rounded-xl border border-border shadow-sm">
-      <div className="flex items-center justify-between px-8 py-6 bg-brand-light border-b border-border rounded-t-xl">
+      <div className="flex items-center justify-between px-4 sm:px-8 py-6 bg-brand-light border-b border-border rounded-t-xl">
         <div className="flex items-center gap-4">
           <div className="w-14 h-14 rounded-full bg-brand-muted flex items-center justify-center text-brand">
             <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
@@ -189,7 +189,7 @@ function ProfileCard({
         <div className="px-8 pt-3 text-sm text-red-500">{saveError}</div>
       )}
 
-      <div className="px-8 py-2">
+      <div className="px-4 sm:px-8 py-2">
         {[
           [
             { label: '이름', view: user.name, edit: <UnderlineInput value={draft.name} onChange={(v) => setDraft({ ...draft, name: v })} /> },
@@ -214,10 +214,10 @@ function ProfileCard({
         ].map((row, rowIdx, all) => (
           <div
             key={rowIdx}
-            className={`grid grid-cols-2 divide-x divide-border py-5 ${rowIdx < all.length - 1 ? 'border-b border-border' : ''}`}
+            className={`grid grid-cols-1 sm:grid-cols-2 sm:divide-x divide-border py-5 ${rowIdx < all.length - 1 ? 'border-b border-border' : ''}`}
           >
             {row.map((cell, colIdx) => (
-              <div key={colIdx} className={`flex flex-col gap-2${colIdx === 1 ? ' pl-8' : ''}`}>
+              <div key={colIdx} className={`flex flex-col gap-2${colIdx === 1 ? ' sm:pl-8 pt-4 sm:pt-0' : ''}`}>
                 <span className="text-sm text-text-secondary">
                   {cell.label}
                   {cell.hint && <span className="ml-2 text-xs text-text-placeholder">({cell.hint})</span>}
@@ -238,20 +238,20 @@ function ProfileCard({
 
 function MentorCard({ user }: { user: AdminUserDetail }) {
   return (
-    <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+    <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-base font-semibold text-text-primary">멘토 정보</h2>
         <span className="text-xs text-text-placeholder">신청서에서 변경</span>
       </div>
 
-      <div className="grid grid-cols-2 divide-x divide-border">
-        <div className="pr-8 flex flex-col gap-2">
+      <div className="grid grid-cols-1 sm:grid-cols-2 sm:divide-x divide-border gap-4 sm:gap-0">
+        <div className="sm:pr-8 flex flex-col gap-2">
           <span className="text-sm text-text-secondary">소속 로스쿨</span>
           <div className="h-6">
             <span className="text-base text-text-primary">{user.currentLawschool || '-'}</span>
           </div>
         </div>
-        <div className="pl-8 flex flex-col gap-2">
+        <div className="sm:pl-8 flex flex-col gap-2">
           <span className="text-sm text-text-secondary">기수</span>
           <div className="h-6">
             <span className="text-base text-text-primary">{user.cohort != null ? `${user.cohort}기` : '-'}</span>
@@ -300,7 +300,7 @@ function AccountCard({
   const isActive = data.accountStatus === 'active';
 
   return (
-    <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+    <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-base font-semibold text-text-primary">계정 상태</h2>
         {isEditing
@@ -311,8 +311,8 @@ function AccountCard({
 
       {saveError && <p className="mb-3 text-sm text-red-500">{saveError}</p>}
 
-      <div className="grid grid-cols-2 divide-x divide-border">
-        <div className="pr-8 flex items-center justify-between">
+      <div className="grid grid-cols-1 sm:grid-cols-2 sm:divide-x divide-border gap-4 sm:gap-0">
+        <div className="sm:pr-8 flex items-center justify-between">
           <div>
             <p className="text-sm text-text-secondary">활성화 여부</p>
             <div className="h-6 flex items-center mt-2">
@@ -327,7 +327,7 @@ function AccountCard({
             onChange={(on) => setDraft({ ...draft, accountStatus: on ? 'active' : 'inactive' })}
           />
         </div>
-        <div className="pl-8 flex flex-col gap-2">
+        <div className="sm:pl-8 flex flex-col gap-2">
           <span className="text-sm text-text-secondary">현재 역할</span>
           <div className="h-6">
             {isEditing
@@ -345,16 +345,17 @@ function AccountCard({
 
 function ParticipationCard({ participation }: { participation: AdminUserDetail['participation'] }) {
   return (
-    <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+    <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
       <h2 className="text-base font-semibold text-text-primary mb-6">참여 이력</h2>
       {participation.length === 0 ? (
         <p className="py-2 text-sm text-text-secondary">참여 이력이 없습니다.</p>
       ) : (
+        <div className="overflow-x-auto">
         <table className="w-full table-auto">
           <thead>
             <tr className="border-b border-border">
-              <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4">프로세스 참여 연도</th>
-              <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4">당시 역할</th>
+              <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap">프로세스 참여 연도</th>
+              <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap">당시 역할</th>
             </tr>
           </thead>
           <tbody>
@@ -370,6 +371,7 @@ function ParticipationCard({ participation }: { participation: AdminUserDetail['
             ))}
           </tbody>
         </table>
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/app/mentee/applications/ApplicationsClient.tsx
+++ b/apps/web/src/app/mentee/applications/ApplicationsClient.tsx
@@ -94,7 +94,7 @@ export default function ApplicationsClient({ initialSchedule, initialAdmission, 
 
       {/* 사업 일정 카드 */}
       {activeSchedule && (
-        <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+        <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
           <h2 className="text-base font-semibold text-text-primary mb-4">
             {activeSchedule.process_year}학년도 pLAWcess 일정
           </h2>
@@ -118,7 +118,7 @@ export default function ApplicationsClient({ initialSchedule, initialAdmission, 
       )}
 
       {/* 프로세스 안내 카드 */}
-      <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+      <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
         <h2 className="text-base font-semibold text-text-primary mb-5">프로세스 안내</h2>
         <div className="text-sm text-text-body leading-relaxed space-y-3 mb-6 pb-6 border-b border-border">
           <p>고려대학교 자유전공학부에서는 2023년 제15대 집행위원회 교육국에서부터 &apos;pLAWcess&apos;라는 사업을 진행하고 있습니다. &apos;로스쿨을 향하는 과정&apos;이라는 뜻을 담은 해당 사업은 다음 두 가지 주요 활동으로 이루어져 있습니다.</p>
@@ -177,7 +177,7 @@ export default function ApplicationsClient({ initialSchedule, initialAdmission, 
       />
 
       {/* 개인정보 동의 카드 */}
-      <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+      <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
         <h2 className="text-base font-semibold text-text-primary mb-5">개인정보 수집 및 이용 동의</h2>
         <div className="text-sm text-text-body leading-relaxed space-y-4 mb-6">
           <div>
@@ -222,7 +222,7 @@ export default function ApplicationsClient({ initialSchedule, initialAdmission, 
       </div>
 
       {/* 신청서 카드 */}
-      <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+      <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
         <div className="mb-6">
           <h2 className="text-base font-semibold text-text-primary">pLAWcess 신청서</h2>
         </div>
@@ -232,7 +232,7 @@ export default function ApplicationsClient({ initialSchedule, initialAdmission, 
           <div>
             <p className="text-sm font-medium text-text-primary mb-3">희망 로스쿨</p>
             {admission ? (
-              <div className="grid grid-cols-2 gap-6">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6">
                 {(['가', '나'] as const).map((group) => {
                   const slot = admission[group];
                   const preferred = admission.preferredGroup;

--- a/apps/web/src/app/mentee/dashboard/basic-info/BasicInfoClient.tsx
+++ b/apps/web/src/app/mentee/dashboard/basic-info/BasicInfoClient.tsx
@@ -132,7 +132,7 @@ export default function BasicInfoClient({ initialPersonal, initialAdmission, ini
 
       {/* 기본정보 카드 */}
       <div className="bg-white rounded-xl border border-border shadow-sm">
-        <div className="flex items-center justify-between px-8 py-6 bg-brand-light border-b border-border rounded-t-xl">
+        <div className="flex items-center justify-between px-4 sm:px-8 py-6 bg-brand-light border-b border-border rounded-t-xl">
           <div className="flex items-center gap-4">
             <div className="w-14 h-14 rounded-full bg-brand-muted flex items-center justify-center text-brand">
               <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
@@ -151,14 +151,14 @@ export default function BasicInfoClient({ initialPersonal, initialAdmission, ini
           }
         </div>
 
-        <div className="px-8 py-2">
+        <div className="px-4 sm:px-8 py-2">
           {fieldRows.map((row, rowIdx) => (
             <div
               key={rowIdx}
-              className={`grid grid-cols-2 divide-x divide-border py-5 ${rowIdx < fieldRows.length - 1 ? 'border-b border-border' : ''}`}
+              className={`grid grid-cols-1 sm:grid-cols-2 sm:divide-x divide-border py-5 ${rowIdx < fieldRows.length - 1 ? 'border-b border-border' : ''}`}
             >
               {row.map(({ label, key, type, options }, colIdx) => (
-                <div key={key} className={`flex flex-col gap-2${colIdx === 1 ? ' pl-8' : ''}`}>
+                <div key={key} className={`flex flex-col gap-2${colIdx === 1 ? ' sm:pl-8 pt-4 sm:pt-0' : ''}`}>
                   <div className="flex items-center gap-2">
                     <span className="text-sm text-text-secondary shrink-0">{label}</span>
                     {key === 'birthDate' && birthDateError && (
@@ -195,7 +195,7 @@ export default function BasicInfoClient({ initialPersonal, initialAdmission, ini
       </div>
 
       {/* 희망 학교 및 전형 카드 */}
-      <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+      <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
         <div className="flex items-center justify-between mb-6">
           <h2 className="text-base font-semibold text-text-primary">희망 학교 및 전형</h2>
           {isAdmissionEditing
@@ -204,12 +204,12 @@ export default function BasicInfoClient({ initialPersonal, initialAdmission, ini
           }
         </div>
 
-        <div className="grid grid-cols-2 divide-x divide-border">
+        <div className="grid grid-cols-1 sm:grid-cols-2 sm:divide-x divide-border gap-y-4 sm:gap-y-0">
           {(['가', '나'] as const).map((group) => {
             const item = isAdmissionEditing ? admissionDraft[group] : admissionInfo[group];
             const isPreferred = isAdmissionEditing ? preferredGroupDraft === group : preferredGroup === group;
             return (
-              <div key={group} className={`${group === '나' ? 'pl-8' : 'pr-8'} rounded-lg transition-colors ${isPreferred ? 'bg-brand-light' : ''}`}>
+              <div key={group} className={`${group === '나' ? 'sm:pl-8' : 'sm:pr-8'} rounded-lg transition-colors ${isPreferred ? 'bg-brand-light' : ''}`}>
                 <div className="flex items-center gap-3 mb-5">
                   <span className="inline-block text-sm font-semibold text-brand bg-brand-light px-3 py-1 rounded">{group}군</span>
                   {isAdmissionEditing ? (

--- a/apps/web/src/app/mentee/dashboard/personal-statement/PersonalStatementClient.tsx
+++ b/apps/web/src/app/mentee/dashboard/personal-statement/PersonalStatementClient.tsx
@@ -273,15 +273,20 @@ export default function PersonalStatementClient({
           <div key={group}>
             {mode === 'hwp' ? (
               activeGroup.hwp ? (
-                <div
-                  className="bg-white rounded-xl border border-border shadow-sm overflow-hidden"
-                  style={{ height: '80vh' }}
-                >
-                  <HwpEditor
-                    initialHwpBase64={activeGroup.hwp}
-                    onEditorReady={(editor) => onEditorReady(group, editor)}
-                  />
-                </div>
+                <>
+                  <div className="sm:hidden bg-amber-50 border border-amber-200 rounded-xl px-5 py-4 text-sm text-amber-800">
+                    HWP 에디터는 PC 환경에서 이용해 주세요.
+                  </div>
+                  <div
+                    className="hidden sm:block bg-white rounded-xl border border-border shadow-sm overflow-hidden"
+                    style={{ height: '80vh' }}
+                  >
+                    <HwpEditor
+                      initialHwpBase64={activeGroup.hwp}
+                      onEditorReady={(editor) => onEditorReady(group, editor)}
+                    />
+                  </div>
+                </>
               ) : (
                 <EmptyState
                   message={`${activeGroup.school} 자기소개서 양식이 아직 준비되지 않았습니다.`}
@@ -295,7 +300,7 @@ export default function PersonalStatementClient({
                   return (
                     <div
                       key={q.id}
-                      className="bg-white rounded-xl border border-border shadow-sm px-8 py-6"
+                      className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6"
                     >
                       {/* 문항 헤더 */}
                       <div className="flex items-center gap-3 mb-4">

--- a/apps/web/src/app/mentee/dashboard/qualitative/QualitativeClient.tsx
+++ b/apps/web/src/app/mentee/dashboard/qualitative/QualitativeClient.tsx
@@ -425,11 +425,11 @@ function ActivityFormCard({
 
   return (
     <div className="relative">
-      <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+      <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
       <h2 className="text-base font-semibold text-text-primary mb-6">활동 정보 입력</h2>
       <hr className="border-border mb-6" />
 
-      <div className="grid grid-cols-2 gap-8 mb-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 sm:gap-8 mb-6">
         <div className="flex flex-col gap-2">
           <label className="text-sm text-text-secondary">활동명 <span className="text-red-500">*</span></label>
           <input type="text" value={form.name} onChange={(e) => onChange({ ...form, name: e.target.value })}
@@ -444,7 +444,7 @@ function ActivityFormCard({
         </div>
       </div>
 
-      <div className="grid grid-cols-2 gap-8 mb-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 sm:gap-8 mb-6">
         <div className="flex flex-col gap-2">
           <label className="text-sm text-text-secondary">시작일</label>
           <DateInput
@@ -538,7 +538,7 @@ function CareerGoalCard({
   }
 
   return (
-    <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+    <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-base font-semibold text-text-primary">희망 진로</h2>
         {isEditing
@@ -636,7 +636,7 @@ function ActivityCard({
 
   return (
     <div className="flex flex-col gap-3 relative">
-      <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+      <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
         <div className="flex items-start justify-between gap-3">
           <h2 className="text-lg font-semibold text-text-primary">{activity.name}</h2>
           <button
@@ -725,7 +725,7 @@ function ActivityListTable({
   selectedUnified: string | null;
 }) {
   return (
-    <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+    <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
       <h2 className="text-lg font-semibold text-text-primary mb-1">활동 목록</h2>
       <p className="text-xs text-text-secondary mb-3">
         오른쪽 키워드를 누르면 의미가 같은 활동별 키워드가 강조돼요.
@@ -919,7 +919,7 @@ function StoryOutlineCard({ outline }: { outline: StoryOutline }) {
     { label: '결론', text: outline.conclusion },
   ];
   return (
-    <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+    <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
       <h2 className="text-lg font-semibold text-text-primary mb-1">AI 추천 자소서 흐름</h2>
       <p className="text-sm text-text-secondary mb-5">분석 결과를 바탕으로 자소서의 흐름을 제안해 드려요.</p>
       <div className="flex flex-col gap-3">
@@ -1413,14 +1413,14 @@ export default function QualitativeClient({ initialData }: { initialData?: Quali
 
       {pageLoading ? (
         <div className="flex flex-col gap-6 animate-pulse">
-          <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+          <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
             <div className="h-6 w-40 bg-gray-200 rounded mb-4" />
             <div className="space-y-3">
               <div className="h-5 w-full bg-gray-100 rounded" />
               <div className="h-5 w-3/4 bg-gray-100 rounded" />
             </div>
           </div>
-          <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+          <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
             <div className="h-6 w-32 bg-gray-200 rounded mb-6" />
             <div className="space-y-4">
               {[...Array(3)].map((_, i) => (
@@ -1432,7 +1432,7 @@ export default function QualitativeClient({ initialData }: { initialData?: Quali
               ))}
             </div>
           </div>
-          <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+          <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
             <div className="h-6 w-24 bg-gray-200 rounded mb-4" />
             <div className="h-5 w-1/2 bg-gray-100 rounded" />
           </div>

--- a/apps/web/src/app/mentor/dashboard/basic-info/MentorBasicInfoClient.tsx
+++ b/apps/web/src/app/mentor/dashboard/basic-info/MentorBasicInfoClient.tsx
@@ -93,7 +93,7 @@ export default function MentorBasicInfoClient({ initialData }: Props) {
       </div>
 
       <div className="bg-white rounded-xl border border-border shadow-sm">
-        <div className="flex items-center justify-between px-8 py-6 bg-brand-light border-b border-border rounded-t-xl">
+        <div className="flex items-center justify-between px-4 sm:px-8 py-6 bg-brand-light border-b border-border rounded-t-xl">
           <div className="flex items-center gap-4">
             <div className="w-14 h-14 rounded-full bg-brand-muted flex items-center justify-center text-brand">
               <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
@@ -109,14 +109,14 @@ export default function MentorBasicInfoClient({ initialData }: Props) {
           }
         </div>
 
-        <div className="px-8 py-2">
+        <div className="px-4 sm:px-8 py-2">
           {fieldRows.map((row, rowIdx) => (
             <div
               key={rowIdx}
-              className={`grid grid-cols-2 divide-x divide-border py-5 ${rowIdx < fieldRows.length - 1 ? 'border-b border-border' : ''}`}
+              className={`grid grid-cols-1 sm:grid-cols-2 sm:divide-x divide-border py-5 ${rowIdx < fieldRows.length - 1 ? 'border-b border-border' : ''}`}
             >
               {row.map(({ label, key, type, options }, colIdx) => (
-                <div key={key} className={`flex flex-col gap-2${colIdx === 1 ? ' pl-8' : ''}`}>
+                <div key={key} className={`flex flex-col gap-2${colIdx === 1 ? ' sm:pl-8 pt-4 sm:pt-0' : ''}`}>
                   <div className="flex items-center gap-2">
                     <span className="text-sm text-text-secondary shrink-0">{label}</span>
                     {key === 'birthDate' && birthDateError && (

--- a/apps/web/src/components/landing/LandingNavbar.tsx
+++ b/apps/web/src/components/landing/LandingNavbar.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { usePathname, useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { getUser, saveUser, type AuthUser } from '@/lib/api';
 import UserMenu from '@/components/layout/UserMenu';
 import NotificationBell from '@/components/layout/NotificationBell';
@@ -22,6 +22,8 @@ export default function LandingNavbar({ initialUser }: Props) {
   const router = useRouter();
   const [user, setUser] = useState<AuthUser | null>(initialUser ?? null);
   const [authChecked, setAuthChecked] = useState(initialUser !== undefined);
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
 
   async function fetchUser(): Promise<void> {
     try {
@@ -63,81 +65,112 @@ export default function LandingNavbar({ initialUser }: Props) {
     router.push('/');
   }
 
+  const allNavItems = [
+    ...NAV_ITEMS,
+    { href: '/mentee/dashboard', label: '멘티' },
+    { href: '/mentor/dashboard', label: '멘토' },
+    { href: '/admin/users', label: '어드민' },
+  ];
+
   return (
-    <header className="sticky top-0 z-50 h-16 bg-white border-b border-border flex items-center px-6 justify-between shrink-0">
-      {/* Left: Logo */}
-      <div className="flex-1">
-        <Link href="/">
-          <Image src="/logo/puzzleserif_logo.png" alt="pLAWcess" width={120} height={39} priority />
-        </Link>
-      </div>
-
-      {/* Center: Nav items */}
-      <nav className="flex items-center gap-6" aria-label="주요 메뉴">
-        {NAV_ITEMS.map(({ href, label }) => (
-          <Link
-            key={href}
-            href={href}
-            className={`text-sm font-medium transition-colors ${
-              pathname === href
-                ? 'text-text-primary'
-                : 'text-text-secondary hover:text-text-primary'
-            }`}
-          >
-            {label}
+    <header className="sticky top-0 z-50 bg-white border-b border-border shrink-0" ref={menuRef}>
+      <div className="h-16 flex items-center px-4 sm:px-6 justify-between">
+        {/* Left: Logo */}
+        <div className="flex-1">
+          <Link href="/">
+            <Image src="/logo/puzzleserif_logo.png" alt="pLAWcess" width={120} height={39} priority />
           </Link>
-        ))}
-        {/* {process.env.NODE_ENV === 'development' && ( */}
+        </div>
 
+        {/* Center: Nav items (desktop) */}
+        <nav className="hidden md:flex items-center gap-6" aria-label="주요 메뉴">
+          {NAV_ITEMS.map(({ href, label }) => (
+            <Link
+              key={href}
+              href={href}
+              className={`text-sm font-medium transition-colors ${
+                pathname === href
+                  ? 'text-text-primary'
+                  : 'text-text-secondary hover:text-text-primary'
+              }`}
+            >
+              {label}
+            </Link>
+          ))}
           <>
-            <Link
-              href="/mentee/dashboard"
-              className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors"
-            >
-              멘티
-            </Link>
-            <Link
-              href="/mentor/dashboard"
-              className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors"
-            >
-              멘토
-            </Link>
-            <Link
-              href="/admin/users"
-              className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors"
-            >
-              어드민
-            </Link>
+            <Link href="/mentee/dashboard" className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors">멘티</Link>
+            <Link href="/mentor/dashboard" className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors">멘토</Link>
+            <Link href="/admin/users" className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors">어드민</Link>
           </>
-        {/* )} */}
-      </nav>
+        </nav>
 
-      {/* Right: Action buttons */}
-      <div className="flex-1 flex items-center justify-end gap-2">
-        {!authChecked ? (
-          <div className="h-9" />
-        ) : user ? (
-          <>
-            <NotificationBell />
-            <UserMenu user={user} onLogout={handleLogout} />
-          </>
-        ) : (
-          <div className="flex items-center gap-3">
-            <Link
-              href="/login"
-              className="px-4 py-2 text-sm font-medium text-brand border border-brand rounded-md hover:bg-brand/5 transition-colors"
-            >
-              로그인
-            </Link>
-            <Link
-              href="/signup"
-              className="px-4 py-2 text-sm font-medium text-white bg-brand rounded-md hover:bg-brand-dark transition-colors"
-            >
-              회원가입
-            </Link>
-          </div>
-        )}
+        {/* Right: Action buttons + mobile hamburger */}
+        <div className="flex-1 flex items-center justify-end gap-2">
+          {!authChecked ? (
+            <div className="h-9" />
+          ) : user ? (
+            <>
+              <NotificationBell />
+              <UserMenu user={user} onLogout={handleLogout} />
+            </>
+          ) : (
+            <div className="hidden sm:flex items-center gap-3">
+              <Link href="/login" className="px-4 py-2 text-sm font-medium text-brand border border-brand rounded-md hover:bg-brand/5 transition-colors">
+                로그인
+              </Link>
+              <Link href="/signup" className="px-4 py-2 text-sm font-medium text-white bg-brand rounded-md hover:bg-brand-dark transition-colors">
+                회원가입
+              </Link>
+            </div>
+          )}
+          {/* 모바일 햄버거 */}
+          <button
+            onClick={() => setMobileOpen((o) => !o)}
+            aria-label="메뉴"
+            className="md:hidden w-9 h-9 flex items-center justify-center rounded-full hover:bg-gray-100 transition-colors"
+          >
+            {mobileOpen ? (
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            ) : (
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="3" y1="6" x2="21" y2="6" /><line x1="3" y1="12" x2="21" y2="12" /><line x1="3" y1="18" x2="21" y2="18" />
+              </svg>
+            )}
+          </button>
+        </div>
       </div>
+
+      {/* 모바일 드로어 */}
+      {mobileOpen && (
+        <div className="md:hidden border-t border-border bg-white px-4 py-3 flex flex-col gap-1">
+          {allNavItems.map(({ href, label }) => (
+            <Link
+              key={href}
+              href={href}
+              onClick={() => setMobileOpen(false)}
+              className={`px-3 py-2.5 text-sm font-medium rounded-md transition-colors ${
+                pathname === href
+                  ? 'bg-brand-light text-brand'
+                  : 'text-text-secondary hover:bg-gray-50 hover:text-text-primary'
+              }`}
+            >
+              {label}
+            </Link>
+          ))}
+          {!user && (
+            <div className="flex flex-col gap-2 pt-3 border-t border-border mt-1">
+              <Link href="/login" onClick={() => setMobileOpen(false)} className="w-full py-2.5 text-sm font-medium text-center text-brand border border-brand rounded-md hover:bg-brand/5 transition-colors">
+                로그인
+              </Link>
+              <Link href="/signup" onClick={() => setMobileOpen(false)} className="w-full py-2.5 text-sm font-medium text-center text-white bg-brand rounded-md hover:bg-brand-dark transition-colors">
+                회원가입
+              </Link>
+            </div>
+          )}
+        </div>
+      )}
     </header>
   );
 }

--- a/apps/web/src/components/landing/LandingNavbarMobile.tsx
+++ b/apps/web/src/components/landing/LandingNavbarMobile.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useState } from 'react';
+import type { AuthUser } from '@/lib/api';
+
+const NAV_ITEMS = [
+  { href: '/about', label: '서비스 소개' },
+  { href: '/guide', label: '이용 가이드' },
+  { href: '/faq', label: 'FAQ' },
+  { href: '/announcements', label: '공지사항' },
+  { href: '/mentee/dashboard', label: '멘티' },
+  { href: '/mentor/dashboard', label: '멘토' },
+  { href: '/admin/users', label: '어드민' },
+];
+
+export default function LandingNavbarMobile({ user }: { user: AuthUser | null }) {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen((o) => !o)}
+        aria-label="메뉴"
+        className="w-9 h-9 flex items-center justify-center rounded-full hover:bg-gray-100 transition-colors"
+      >
+        {open ? (
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        ) : (
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="3" y1="6" x2="21" y2="6" /><line x1="3" y1="12" x2="21" y2="12" /><line x1="3" y1="18" x2="21" y2="18" />
+          </svg>
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute top-16 left-0 right-0 bg-white border-t border-border px-4 py-3 flex flex-col gap-1 shadow-md z-50">
+          {NAV_ITEMS.map(({ href, label }) => (
+            <Link
+              key={href}
+              href={href}
+              onClick={() => setOpen(false)}
+              className={`px-3 py-2.5 text-sm font-medium rounded-md transition-colors ${
+                pathname === href
+                  ? 'bg-brand-light text-brand'
+                  : 'text-text-secondary hover:bg-gray-50 hover:text-text-primary'
+              }`}
+            >
+              {label}
+            </Link>
+          ))}
+          {!user && (
+            <div className="flex flex-col gap-2 pt-3 border-t border-border mt-1">
+              <Link
+                href="/login"
+                onClick={() => setOpen(false)}
+                className="w-full py-2.5 text-sm font-medium text-center text-brand border border-brand rounded-md hover:bg-brand/5 transition-colors"
+              >
+                로그인
+              </Link>
+              <Link
+                href="/signup"
+                onClick={() => setOpen(false)}
+                className="w-full py-2.5 text-sm font-medium text-center text-white bg-brand rounded-md hover:bg-brand-dark transition-colors"
+              >
+                회원가입
+              </Link>
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/components/landing/LandingNavbarServer.tsx
+++ b/apps/web/src/components/landing/LandingNavbarServer.tsx
@@ -4,13 +4,7 @@ import Image from 'next/image';
 import { serverFetch } from '@/lib/server-fetch';
 import type { AuthUser } from '@/lib/api';
 import LandingNavbarAuth from './LandingNavbarAuth';
-
-const NAV_ITEMS = [
-  { href: '/about', label: '서비스 소개' },
-  { href: '/guide', label: '이용 가이드' },
-  { href: '/faq', label: 'FAQ' },
-  { href: '/announcements', label: '공지사항' },
-];
+import LandingNavbarMobile from './LandingNavbarMobile';
 
 export default async function LandingNavbarServer() {
   const token = (await cookies()).get('plawcess_token')?.value ?? '';
@@ -20,37 +14,22 @@ export default async function LandingNavbarServer() {
   const initialUser = data?.user ?? null;
 
   return (
-    <header className="sticky top-0 z-50 h-16 bg-white border-b border-border flex items-center px-6 justify-between shrink-0">
-      {/* Left: Logo */}
-      <div className="flex-1">
-        <Link href="/">
-          <Image src="/logo/puzzleserif_logo.png" alt="pLAWcess" width={120} height={39} priority />
-        </Link>
-      </div>
-
-      {/* Center: Nav items */}
-      <nav className="flex items-center gap-6" aria-label="주요 메뉴">
-        {NAV_ITEMS.map(({ href, label }) => (
-          <Link
-            key={href}
-            href={href}
-            className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors"
-          >
-            {label}
+    <header className="sticky top-0 z-50 bg-white border-b border-border shrink-0">
+      <div className="h-16 flex items-center px-4 sm:px-6 justify-between relative">
+        {/* Left: Logo */}
+        <div className="flex-1">
+          <Link href="/">
+            <Image src="/logo/puzzleserif_logo.png" alt="pLAWcess" width={120} height={39} priority />
           </Link>
-        ))}
-        {/* {process.env.NODE_ENV === 'development' && ( */}
-        <>
-          <Link href="/mentee/dashboard" className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors">멘티</Link>
-          <Link href="/mentor/dashboard" className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors">멘토</Link>
-          <Link href="/admin/users" className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors">어드민</Link>
-        </>
-        {/* )} */}
-      </nav>
+        </div>
 
-      {/* Right: Auth section (client) */}
-      <div className="flex-1 flex items-center justify-end gap-2">
-        <LandingNavbarAuth initialUser={initialUser} />
+        {/* Right: Auth (desktop) + hamburger */}
+        <div className="flex items-center gap-2">
+          <div className="hidden md:flex items-center gap-2">
+            <LandingNavbarAuth initialUser={initialUser} />
+          </div>
+          <LandingNavbarMobile user={initialUser} />
+        </div>
       </div>
     </header>
   );

--- a/apps/web/src/components/layout/DashboardShell.tsx
+++ b/apps/web/src/components/layout/DashboardShell.tsx
@@ -15,7 +15,7 @@ export default function DashboardShell({ children, role, initialUser }: { childr
       <div className="flex flex-1 overflow-hidden">
         <Sidebar mobileOpen={mobileOpen} onClose={() => setMobileOpen(false)} initialRole={role} />
         <main className="flex-1 overflow-auto bg-page-bg">
-          <div className="px-10 py-8">{children}</div>
+          <div className="px-4 py-6 md:px-10 md:py-8">{children}</div>
         </main>
       </div>
     </div>

--- a/apps/web/src/components/layout/DashboardShell.tsx
+++ b/apps/web/src/components/layout/DashboardShell.tsx
@@ -13,7 +13,7 @@ export default function DashboardShell({ children, role, initialUser }: { childr
     <div className="flex flex-col h-screen">
       <Navbar onMenuToggle={() => setMobileOpen((o) => !o)} initialUser={initialUser} />
       <div className="flex flex-1 overflow-hidden">
-        <Sidebar mobileOpen={mobileOpen} onClose={() => setMobileOpen(false)} initialRole={role} />
+        <Sidebar mobileOpen={mobileOpen} onClose={() => setMobileOpen(false)} initialRole={role} initialUser={initialUser} />
         <main className="flex-1 overflow-auto bg-page-bg">
           <div className="px-4 py-6 md:px-10 md:py-8">{children}</div>
         </main>

--- a/apps/web/src/components/layout/Navbar.tsx
+++ b/apps/web/src/components/layout/Navbar.tsx
@@ -52,7 +52,7 @@ export default function Navbar({ onMenuToggle, initialUser }: NavbarProps) {
   }
 
   return (
-    <header className="h-16 bg-white border-b border-border flex items-center px-6 justify-between shrink-0">
+    <header className="h-16 bg-white border-b border-border flex items-center px-4 sm:px-6 justify-between shrink-0">
       <div className="flex items-center gap-3">
         <Link href="/">
           <Image src="/logo/puzzleserif_logo.png" alt="pLAWcess" width={120} height={39} priority />

--- a/apps/web/src/components/layout/Navbar.tsx
+++ b/apps/web/src/components/layout/Navbar.tsx
@@ -54,6 +54,13 @@ export default function Navbar({ onMenuToggle, initialUser }: NavbarProps) {
   return (
     <header className="h-16 bg-white border-b border-border flex items-center px-6 justify-between shrink-0">
       <div className="flex items-center gap-3">
+        <Link href="/">
+          <Image src="/logo/puzzleserif_logo.png" alt="pLAWcess" width={120} height={39} priority />
+        </Link>
+      </div>
+      <div className="flex items-center gap-2">
+        <NotificationBell />
+        {user ? <UserMenu user={user} onLogout={handleLogout} /> : null}
         {onMenuToggle && (
           <button
             onClick={onMenuToggle}
@@ -67,13 +74,6 @@ export default function Navbar({ onMenuToggle, initialUser }: NavbarProps) {
             </svg>
           </button>
         )}
-        <Link href="/">
-          <Image src="/logo/puzzleserif_logo.png" alt="pLAWcess" width={120} height={39} priority />
-        </Link>
-      </div>
-      <div className="flex items-center gap-2">
-        <NotificationBell />
-        {user ? <UserMenu user={user} onLogout={handleLogout} /> : null}
       </div>
     </header>
   );

--- a/apps/web/src/components/layout/Navbar.tsx
+++ b/apps/web/src/components/layout/Navbar.tsx
@@ -60,7 +60,7 @@ export default function Navbar({ onMenuToggle, initialUser }: NavbarProps) {
       </div>
       <div className="flex items-center gap-2">
         <NotificationBell />
-        {user ? <UserMenu user={user} onLogout={handleLogout} /> : null}
+        {user ? <span className="hidden md:block"><UserMenu user={user} onLogout={handleLogout} /></span> : null}
         {onMenuToggle && (
           <button
             onClick={onMenuToggle}

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
+import { clearUser, type AuthUser } from '@/lib/api';
 
 type NavItem = { label: string; href: string; match?: string; exact?: boolean; dividerBefore?: boolean };
 type NavSection = { section: string; items: NavItem[] };
@@ -61,6 +62,7 @@ interface SidebarProps {
   mobileOpen?: boolean;
   onClose?: () => void;
   initialRole?: string;
+  initialUser?: AuthUser | null;
 }
 
 function NavLink({ item, pathname, onClose }: { item: NavItem; pathname: string; onClose?: () => void }) {
@@ -83,8 +85,16 @@ function NavLink({ item, pathname, onClose }: { item: NavItem; pathname: string;
   );
 }
 
-export default function Sidebar({ mobileOpen, onClose, initialRole }: SidebarProps) {
+export default function Sidebar({ mobileOpen, onClose, initialRole, initialUser }: SidebarProps) {
   const pathname = usePathname();
+  const router = useRouter();
+
+  async function handleLogout() {
+    await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' });
+    clearUser();
+    onClose?.();
+    router.push('/');
+  }
 
   const isAdmin = pathname.startsWith('/admin') || initialRole === 'admin';
   const isMentor = pathname.startsWith('/mentor') || initialRole === 'mentor';
@@ -128,6 +138,17 @@ export default function Sidebar({ mobileOpen, onClose, initialRole }: SidebarPro
           <div className="fixed inset-0 z-40 bg-black/40 md:hidden" onClick={onClose} />
           <div className="md:hidden fixed top-16 left-0 right-0 z-50 bg-white border-b border-border shadow-md px-4 py-3">
             {navContent}
+            {initialUser && (
+              <div className="mt-2 pt-3 border-t border-border flex items-center justify-between">
+                <span className="text-sm font-medium text-text-primary">{initialUser.name}</span>
+                <button
+                  onClick={handleLogout}
+                  className="text-xs text-text-secondary hover:text-red-500 transition-colors"
+                >
+                  로그아웃
+                </button>
+              </div>
+            )}
           </div>
         </>
       )}

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -117,19 +117,20 @@ export default function Sidebar({ mobileOpen, onClose, initialRole }: SidebarPro
 
   return (
     <>
-      {mobileOpen && (
-        <div className="fixed inset-0 z-40 bg-black/40 md:hidden" onClick={onClose} />
-      )}
-      <aside
-        className={`
-          fixed top-16 left-0 h-[calc(100vh-4rem)] z-50 w-44 bg-white border-r border-border flex flex-col py-6 shrink-0
-          transition-transform duration-200
-          md:static md:top-auto md:h-auto md:translate-x-0 md:z-auto
-          ${mobileOpen ? 'translate-x-0' : '-translate-x-full'}
-        `}
-      >
+      {/* 데스크탑 사이드바 */}
+      <aside className="hidden md:flex w-44 bg-white border-r border-border flex-col py-6 shrink-0">
         {navContent}
       </aside>
+
+      {/* 모바일 드롭다운 */}
+      {mobileOpen && (
+        <>
+          <div className="fixed inset-0 z-40 bg-black/40 md:hidden" onClick={onClose} />
+          <div className="md:hidden fixed top-16 left-0 right-0 z-50 bg-white border-b border-border shadow-md px-4 py-3">
+            {navContent}
+          </div>
+        </>
+      )}
     </>
   );
 }

--- a/apps/web/src/components/layout/UserMenu.tsx
+++ b/apps/web/src/components/layout/UserMenu.tsx
@@ -74,7 +74,7 @@ export default function UserMenu({ user, onLogout }: Props) {
       {open && (
         <div
           role="menu"
-          className="absolute right-0 top-full mt-2 w-64 bg-white border border-border rounded-md shadow-lg py-1 z-50"
+          className="absolute right-0 top-full mt-2 w-56 sm:w-64 max-w-[calc(100vw-2rem)] bg-white border border-border rounded-md shadow-lg py-1 z-50"
         >
           <div className="px-4 py-3 border-b border-border">
             <div className="flex items-center gap-2">

--- a/apps/web/src/components/quantitative/GpaCard.tsx
+++ b/apps/web/src/components/quantitative/GpaCard.tsx
@@ -62,7 +62,7 @@ export default function GpaCard({ initialData, onSave }: Props) {
   }
 
   return (
-    <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+    <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-base font-semibold text-text-primary">GPA</h2>
         {isEditing
@@ -71,7 +71,7 @@ export default function GpaCard({ initialData, onSave }: Props) {
         }
       </div>
 
-      <div className="grid grid-cols-3 gap-8">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-5 sm:gap-8">
         {/* 전체 평점 평균 */}
         <div className="flex flex-col gap-2">
           <span className="text-sm text-text-secondary">전체 평점 평균</span>
@@ -166,7 +166,7 @@ export default function GpaCard({ initialData, onSave }: Props) {
             </div>
             <p className="text-xs text-text-secondary">학업 성적표를 불러오기 위해 KUPID 계정으로 로그인해주세요.</p>
           </div>
-          <div className="grid grid-cols-2 gap-6 mb-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6 mb-6">
             <div className="flex flex-col gap-1.5">
               <label className="text-sm text-text-secondary">ID</label>
               <input

--- a/apps/web/src/components/quantitative/LanguageCard.tsx
+++ b/apps/web/src/components/quantitative/LanguageCard.tsx
@@ -39,7 +39,7 @@ export default function LanguageCard({ initialData, onSave }: Props) {
   }
 
   return (
-    <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+    <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-base font-semibold text-text-primary">어학 성적</h2>
         {isEditing
@@ -47,7 +47,7 @@ export default function LanguageCard({ initialData, onSave }: Props) {
           : <EditButton onClick={() => { setDraft(data); setIsEditing(true); }} />
         }
       </div>
-      <div className="grid grid-cols-3 gap-8">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-5 sm:gap-8">
         {fields.map(({ label, key }) => (
           <div key={key} className="flex flex-col gap-2">
             <span className="text-sm text-text-secondary">{label}</span>


### PR DESCRIPTION
## Summary

- **DashboardShell**: 전체 콘텐츠 패딩 반응형 (`px-4 py-6` → `md:px-10 md:py-8`)
- **BasicInfoClient**: 기본정보·희망학교 카드 2열 그리드 → 모바일 1열 전환, `divide-x` 모바일 제거
- **QualitativeClient**: 활동 입력 폼 필드 2열 → 모바일 1열, 카드 패딩 반응형 (`px-4 sm:px-8`)
- **ApplicationsClient**: 희망 로스쿨 2열 그리드 → 모바일 1열
- **어드민 테이블 3곳** (회원관리·신청관리·자소서양식관리): `overflow-x-auto` 래퍼 + `min-w` 적용
- **자소서 HWP 에디터**: 모바일에서 에디터 숨김 + "PC 환경에서 이용해 주세요" 안내 표시
- **어드민 자소서 편집 페이지**: 모바일 전체 PC 이용 안내 표시

## Test plan

- [ ] 데스크탑(≥640px)에서 기존 레이아웃 동일한지 확인
- [ ] 모바일(< 640px) 뷰포트에서 기본정보·정성데이터 1열 그리드 확인
- [ ] 모바일에서 어드민 테이블 가로 스크롤 동작 확인
- [ ] 모바일에서 자소서 HWP 에디터 대신 안내 문구 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)