### PR TITLE
feat: 모바일 반응형 레이아웃 (JS 기반)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,9 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@rhwp/editor": "^0.7.11",
     "@types/jsonwebtoken": "^9.0.10",
     "jose": "^6.2.2",

--- a/apps/web/src/app/admin/applications/AdminApplicationsClient.tsx
+++ b/apps/web/src/app/admin/applications/AdminApplicationsClient.tsx
@@ -215,12 +215,12 @@ function ApplicationsPageContent({ initialSchedules, initialYear, initialMenteeD
           <h1 className="text-2xl font-bold text-text-primary">신청관리</h1>
           <p className="mt-1 text-sm text-text-secondary">회원의 신청 내역을 관리합니다</p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           {/* 연도 선택 커스텀 드롭다운 */}
           <div className="relative" ref={yearDropdownRef}>
             <button
               onClick={() => setYearDropdownOpen((o) => !o)}
-              className="flex items-center gap-2 px-3 py-1.5 bg-white border border-border rounded-lg hover:bg-gray-50 transition-colors"
+              className="flex items-center gap-2 px-3 py-1.5 bg-white border border-border rounded-lg hover:bg-gray-50 transition-colors whitespace-nowrap"
             >
               <span className="text-sm font-semibold text-text-primary">
                 {selectedYear != null ? `${selectedYear}년` : '연도'}
@@ -261,7 +261,7 @@ function ApplicationsPageContent({ initialSchedules, initialYear, initialMenteeD
           {current && (
             <button
               onClick={toggleActive}
-              className={`px-3 py-1.5 text-xs font-medium rounded-md border transition-colors ${
+              className={`px-3 py-1.5 text-xs font-medium rounded-md border transition-colors whitespace-nowrap ${
                 current.is_active
                   ? 'text-text-secondary border-border hover:bg-gray-50'
                   : 'text-brand border-brand/40 bg-brand/5 hover:bg-brand/10'
@@ -273,14 +273,14 @@ function ApplicationsPageContent({ initialSchedules, initialYear, initialMenteeD
           <button
             onClick={handleAddYear}
             disabled={addingYear}
-            className="px-3 py-1.5 text-xs font-medium text-text-secondary border border-border rounded-md hover:bg-gray-50 transition-colors disabled:opacity-50"
+            className="px-3 py-1.5 text-xs font-medium text-text-secondary border border-border rounded-md hover:bg-gray-50 transition-colors disabled:opacity-50 whitespace-nowrap"
           >
             + 새 연도
           </button>
           {current && (
             <button
               onClick={handleDelete}
-              className="px-3 py-1.5 text-xs font-medium text-red-500 border border-red-200 rounded-md hover:bg-red-50 transition-colors"
+              className="px-3 py-1.5 text-xs font-medium text-red-500 border border-red-200 rounded-md hover:bg-red-50 transition-colors whitespace-nowrap"
             >
               연도 삭제
             </button>
@@ -289,7 +289,7 @@ function ApplicationsPageContent({ initialSchedules, initialYear, initialMenteeD
       </div>
 
       {/* 사업 스케줄 */}
-      <section className="bg-white border border-border rounded-xl px-8 py-6">
+      <section className="bg-white border border-border rounded-xl px-4 sm:px-8 py-6">
         <div className="flex items-center justify-between mb-2">
           <h2 className="text-base font-semibold text-text-primary">pLAWcess 사업 스케줄</h2>
           {current && (
@@ -535,23 +535,23 @@ function ApplicationPanel<T extends AdminApplicationRow>({
   };
 
   return (
-    <section className="bg-white border border-border rounded-xl px-8 py-6">
-      <div className="flex items-center justify-between mb-4 gap-4">
+    <section className="bg-white border border-border rounded-xl px-4 sm:px-8 py-6">
+      <div className="flex flex-wrap items-center justify-between mb-4 gap-3">
         <div className="flex items-center gap-2 text-text-placeholder">
           <SearchIcon />
           <input
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="검색..."
-            className="w-56 text-sm bg-transparent focus:outline-none placeholder:text-text-placeholder"
+            className="w-44 sm:w-56 text-sm bg-transparent focus:outline-none placeholder:text-text-placeholder"
           />
         </div>
-        <div className="flex items-center gap-1 p-1 bg-gray-100 rounded-lg border border-border">
+        <div className="flex items-center gap-1 p-1 bg-gray-100 rounded-lg border border-border overflow-x-auto">
           {(['all', 'approved', 'pending', 'revision', 'rejected'] as const).map((s) => (
             <button
               key={s}
               onClick={() => setStatusFilter(s)}
-              className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
+              className={`px-2.5 sm:px-3 py-1.5 text-xs font-medium rounded-md transition-colors whitespace-nowrap ${
                 statusFilter === s
                   ? 'bg-white text-text-primary shadow-sm'
                   : 'text-text-secondary hover:text-text-primary'
@@ -563,11 +563,12 @@ function ApplicationPanel<T extends AdminApplicationRow>({
         </div>
       </div>
 
-      <table className="w-full table-auto">
+      <div className="overflow-x-auto">
+      <table className="w-full table-auto min-w-[600px]">
         <thead>
           <tr className="border-b border-border">
             {columns.map((col) => (
-              <th key={String(col.key)} className="text-left text-xs font-medium text-text-secondary py-3 pr-4 select-none">
+              <th key={String(col.key)} className="text-left text-xs font-medium text-text-secondary py-3 pr-4 select-none whitespace-nowrap">
                 {col.sortable ? (
                   <button onClick={() => onSort(col.key)} className="flex items-center gap-1 hover:text-text-primary transition-colors">
                     {col.label}
@@ -592,7 +593,7 @@ function ApplicationPanel<T extends AdminApplicationRow>({
             processed.map((row) => (
               <tr key={row.applicationId} className="border-b border-border last:border-b-0">
                 {columns.map((col) => (
-                  <td key={String(col.key)} className="py-4 pr-4 text-sm text-text-primary align-middle">
+                  <td key={String(col.key)} className="py-4 pr-4 text-sm text-text-primary align-middle whitespace-nowrap">
                     {col.render ? col.render(row) : String(row[col.key] ?? '')}
                   </td>
                 ))}
@@ -613,6 +614,7 @@ function ApplicationPanel<T extends AdminApplicationRow>({
           )}
         </tbody>
       </table>
+      </div>
 
       <div className="flex items-center justify-between mt-5">
         <span className="text-xs text-text-secondary">
@@ -704,7 +706,7 @@ function ApplicationEditModal<T extends AdminApplicationRow>({
         <div className="px-6 py-5 flex flex-col gap-6 overflow-y-auto">
           <div>
             <p className="text-xs font-medium text-text-secondary mb-2">신청자 정보</p>
-            <div className="bg-page-bg border border-border rounded-md px-4 py-3 grid grid-cols-2 gap-x-4 gap-y-2.5">
+            <div className="bg-page-bg border border-border rounded-md px-4 py-3 grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2.5">
               <div>
                 <span className="block text-xs text-text-secondary">이름</span>
                 <p className="text-sm font-medium text-text-primary">{target.name}</p>
@@ -720,7 +722,7 @@ function ApplicationEditModal<T extends AdminApplicationRow>({
 
           <div>
             <p className="text-sm font-medium text-text-primary mb-3">신청 상태</p>
-            <div className="grid grid-cols-4 gap-2">
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
               {(['approved', 'pending', 'revision', 'rejected'] as const).map((s) => (
                 <button
                   key={s}

--- a/apps/web/src/app/admin/matchings/AdminMatchingsClient.tsx
+++ b/apps/web/src/app/admin/matchings/AdminMatchingsClient.tsx
@@ -103,9 +103,9 @@ export default function AdminMatchingsClient({ initialPool }: { initialPool: Eli
         </p>
       </div>
 
-      <section className="bg-white border border-border rounded-xl px-8 py-6">
+      <section className="bg-white border border-border rounded-xl px-4 sm:px-8 py-6">
         <h2 className="text-base font-semibold text-text-primary mb-6">매칭 대상 조회</h2>
-        <div className="grid grid-cols-2 gap-10">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-10">
           <ApprovedTable
             title={`승인된 멘티 신청자 목록 (${pool.mentees.length}명)`}
             columns={['이름', '학번', '전공', '현재 역할', '상태']}
@@ -125,7 +125,7 @@ export default function AdminMatchingsClient({ initialPool }: { initialPool: Eli
         </div>
       </section>
 
-      <section className="bg-white border border-border rounded-xl px-8 py-6">
+      <section className="bg-white border border-border rounded-xl px-4 sm:px-8 py-6">
         <h2 className="text-base font-semibold text-text-primary mb-5">AI 매칭 실행</h2>
         <button
           onClick={handleRunMatching}
@@ -140,50 +140,53 @@ export default function AdminMatchingsClient({ initialPool }: { initialPool: Eli
         </button>
       </section>
 
-      <section className="bg-white border border-border rounded-xl px-8 py-6">
+      <section className="bg-white border border-border rounded-xl px-4 sm:px-8 py-6">
         <h2 className="text-base font-semibold text-text-primary mb-5">AI 매칭 결과 조회</h2>
         {!results ? (
           <p className="py-6 text-sm text-text-secondary">아직 매칭이 실행되지 않았습니다. 위에서 AI 매칭을 실행해주세요.</p>
         ) : results.length === 0 ? (
           <p className="py-6 text-sm text-text-secondary">매칭 결과가 비어 있습니다. (BE 매칭 알고리즘 구현 대기)</p>
         ) : (
-          <table className="w-full table-auto">
+          <div className="overflow-x-auto">
+          <table className="w-full table-auto min-w-[480px]">
             <thead>
               <tr className="border-b border-border">
-                <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4">멘티 이름</th>
-                <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4">멘토 이름</th>
-                <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4">매칭 점수</th>
-                <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4">추천 사유</th>
+                <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap">멘티 이름</th>
+                <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap">멘토 이름</th>
+                <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap">매칭 점수</th>
+                <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap">추천 사유</th>
               </tr>
             </thead>
             <tbody>
               {results.map((r) => (
                 <tr key={r.id} className="border-b border-border last:border-b-0">
-                  <td className="py-3 pr-4 text-sm text-text-primary">{r.menteeName}</td>
-                  <td className="py-3 pr-4 text-sm text-text-primary">{r.mentorName}</td>
+                  <td className="py-3 pr-4 text-sm text-text-primary whitespace-nowrap">{r.menteeName}</td>
+                  <td className="py-3 pr-4 text-sm text-text-primary whitespace-nowrap">{r.mentorName}</td>
                   <td className="py-3 pr-4"><ScoreBadge score={r.score} /></td>
                   <td className="py-3 pr-4 text-sm text-text-secondary">{r.reason}</td>
                 </tr>
               ))}
             </tbody>
           </table>
+          </div>
         )}
       </section>
 
-      <section className="bg-white border border-border rounded-xl px-8 py-6">
+      <section className="bg-white border border-border rounded-xl px-4 sm:px-8 py-6">
         <h2 className="text-base font-semibold text-text-primary mb-5">매칭 결과 수정 및 확정</h2>
         {!results || results.length === 0 ? (
           <p className="py-6 text-sm text-text-secondary">매칭 결과가 있어야 수정할 수 있습니다.</p>
         ) : (
           <>
-            <table className="w-full table-auto">
+            <div className="overflow-x-auto">
+            <table className="w-full table-auto min-w-[560px]">
               <thead>
                 <tr className="border-b border-border">
-                  <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 w-[16%]">멘티 이름</th>
-                  <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 w-[20%]">멘토 이름</th>
-                  <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 w-[12%]">매칭 점수</th>
-                  <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4">추천 사유</th>
-                  <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 w-[14%]">매칭 상태</th>
+                  <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap w-[16%]">멘티 이름</th>
+                  <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap w-[20%]">멘토 이름</th>
+                  <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap w-[12%]">매칭 점수</th>
+                  <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap">추천 사유</th>
+                  <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap w-[14%]">매칭 상태</th>
                 </tr>
               </thead>
               <tbody>
@@ -202,6 +205,7 @@ export default function AdminMatchingsClient({ initialPool }: { initialPool: Eli
                 ))}
               </tbody>
             </table>
+            </div>
             <div className="flex items-center gap-2 mt-6">
               <button onClick={handleSaveDraft} className="flex items-center gap-1.5 px-4 py-2 text-sm text-text-secondary border border-border rounded-md hover:bg-gray-50 transition-colors">
                 임시저장
@@ -221,7 +225,8 @@ function ApprovedTable({ title, columns, rows }: { title: string; columns: strin
   return (
     <div>
       <h3 className="text-sm font-semibold text-text-primary mb-4">{title}</h3>
-      <table className="w-full table-auto">
+      <div className="overflow-x-auto">
+      <table className="w-full table-auto min-w-[320px]">
         <thead>
           <tr className="border-b border-border">
             {columns.map((c) => (
@@ -243,6 +248,7 @@ function ApprovedTable({ title, columns, rows }: { title: string; columns: strin
           )}
         </tbody>
       </table>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/admin/personal-statements/PersonalStatementsClient.tsx
+++ b/apps/web/src/app/admin/personal-statements/PersonalStatementsClient.tsx
@@ -119,7 +119,7 @@ export default function PersonalStatementsClient({
       />
 
       {/* 패널 */}
-      <div className="bg-white border border-border rounded-xl px-8 py-6">
+      <div className="bg-white border border-border rounded-xl px-4 sm:px-8 py-6">
         {/* 검색 */}
         <div className="flex items-center gap-2 text-text-placeholder mb-4">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -130,17 +130,18 @@ export default function PersonalStatementsClient({
             value={search}
             onChange={(e) => handleSearch(e.target.value)}
             placeholder="학교명 검색..."
-            className="w-56 text-sm bg-transparent focus:outline-none placeholder:text-text-placeholder"
+            className="w-44 sm:w-56 text-sm bg-transparent focus:outline-none placeholder:text-text-placeholder"
           />
         </div>
 
         {/* 목록 */}
-        <table className="w-full table-auto">
+        <div className="overflow-x-auto">
+        <table className="w-full table-auto min-w-[400px]">
           <thead>
             <tr className="border-b border-border">
-              <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4">학교명</th>
-              <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4">상태</th>
-              <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4">최근 업데이트</th>
+              <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap">학교명</th>
+              <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap">상태</th>
+              <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap">최근 업데이트</th>
               <th className="py-3" />
             </tr>
           </thead>
@@ -193,6 +194,7 @@ export default function PersonalStatementsClient({
             )}
           </tbody>
         </table>
+        </div>
 
         {/* 페이지네이션 */}
         <div className="flex items-center justify-between mt-5">

--- a/apps/web/src/app/admin/personal-statements/[school]/PersonalStatementEditClient.tsx
+++ b/apps/web/src/app/admin/personal-statements/[school]/PersonalStatementEditClient.tsx
@@ -128,8 +128,13 @@ export default function PersonalStatementEditClient({
         </div>
       </div>
 
+      {/* 모바일 안내 */}
+      <div className="sm:hidden bg-amber-50 border border-amber-200 rounded-xl px-5 py-4 text-sm text-amber-800">
+        이 페이지는 PC 환경에서 이용해 주세요.
+      </div>
+
       {/* 2열 레이아웃 */}
-      <div className="grid grid-cols-2 gap-6" style={{ height: '80vh' }}>
+      <div className="hidden sm:grid grid-cols-2 gap-6" style={{ height: '80vh' }}>
         {/* 왼쪽: 문항 편집 */}
         <div className="bg-white border border-border rounded-xl flex flex-col overflow-hidden">
           <div className="flex items-center justify-between px-6 py-4 border-b border-border">

--- a/apps/web/src/app/admin/users/AdminUsersClient.tsx
+++ b/apps/web/src/app/admin/users/AdminUsersClient.tsx
@@ -76,18 +76,18 @@ function UsersPageContent({ initialMenteeData }: { initialMenteeData: Paged<Admi
 
   return (
     <div className="flex flex-col gap-8">
-      <div className="flex items-start justify-between">
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
         <div>
           <h1 className="text-2xl font-bold text-text-primary">회원관리</h1>
           <p className="mt-1 text-sm text-text-secondary">회원 정보를 조회하고 관리합니다</p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 flex-wrap">
           <div className="flex items-center gap-1 p-1 bg-gray-100 rounded-lg border border-border">
             {STATUS_FILTER_OPTIONS.map(({ value, label }) => (
               <button
                 key={value}
                 onClick={() => setStatusFilter(value)}
-                className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
+                className={`px-2.5 sm:px-3 py-1.5 text-xs font-medium rounded-md transition-colors whitespace-nowrap ${
                   statusFilter === value
                     ? 'bg-white text-text-primary shadow-sm'
                     : 'text-text-secondary hover:text-text-primary'
@@ -97,7 +97,7 @@ function UsersPageContent({ initialMenteeData }: { initialMenteeData: Paged<Admi
               </button>
             ))}
           </div>
-          <button className="flex items-center gap-1.5 px-4 py-2 text-sm font-semibold text-white bg-brand rounded-md hover:bg-brand-dark transition-colors">
+          <button className="flex items-center gap-1.5 px-4 py-2 text-sm font-semibold text-white bg-brand rounded-md hover:bg-brand-dark transition-colors whitespace-nowrap">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" /><circle cx="8.5" cy="7" r="4" /><line x1="20" y1="8" x2="20" y2="14" /><line x1="23" y1="11" x2="17" y2="11" />
             </svg>
@@ -251,7 +251,7 @@ function UserListPanel<T extends { userId: string; accountStatus: AdminAccountSt
   };
 
   return (
-    <section className="bg-white border border-border rounded-xl px-8 py-6">
+    <section className="bg-white border border-border rounded-xl px-4 sm:px-8 py-6">
       <div className="flex items-center mb-4 gap-4">
         <div className="flex items-center gap-2 text-text-placeholder">
           <SearchIcon />
@@ -259,11 +259,12 @@ function UserListPanel<T extends { userId: string; accountStatus: AdminAccountSt
         </div>
       </div>
 
-      <table className="w-full table-auto">
+      <div className="overflow-x-auto">
+      <table className="w-full table-auto min-w-[600px]">
         <thead>
           <tr className="border-b border-border">
             {columns.map((col) => (
-              <th key={String(col.key)} className="text-left text-xs font-medium text-text-secondary py-3 pr-4 select-none">
+              <th key={String(col.key)} className="text-left text-xs font-medium text-text-secondary py-3 pr-4 select-none whitespace-nowrap">
                 {col.sortable ? (
                   <button onClick={() => onSort(col.key)} className="flex items-center gap-1 hover:text-text-primary transition-colors">
                     {col.label}
@@ -285,7 +286,7 @@ function UserListPanel<T extends { userId: string; accountStatus: AdminAccountSt
             processed.map((row) => (
               <tr key={row.userId} className="border-b border-border last:border-b-0">
                 {columns.map((col) => (
-                  <td key={String(col.key)} className="py-4 pr-4 text-sm text-text-primary align-middle">
+                  <td key={String(col.key)} className="py-4 pr-4 text-sm text-text-primary align-middle whitespace-nowrap">
                     {col.render ? col.render(row) : String(row[col.key] ?? '')}
                   </td>
                 ))}
@@ -294,6 +295,7 @@ function UserListPanel<T extends { userId: string; accountStatus: AdminAccountSt
           )}
         </tbody>
       </table>
+      </div>
 
       <div className="flex items-center justify-between mt-5">
         <span className="text-xs text-text-secondary">총 {totalCount}명 · {safePage} / {totalPages} 페이지</span>

--- a/apps/web/src/app/admin/users/[userId]/AdminUserDetailClient.tsx
+++ b/apps/web/src/app/admin/users/[userId]/AdminUserDetailClient.tsx
@@ -164,7 +164,7 @@ function ProfileCard({
 
   return (
     <div className="bg-white rounded-xl border border-border shadow-sm">
-      <div className="flex items-center justify-between px-8 py-6 bg-brand-light border-b border-border rounded-t-xl">
+      <div className="flex items-center justify-between px-4 sm:px-8 py-6 bg-brand-light border-b border-border rounded-t-xl">
         <div className="flex items-center gap-4">
           <div className="w-14 h-14 rounded-full bg-brand-muted flex items-center justify-center text-brand">
             <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
@@ -189,7 +189,7 @@ function ProfileCard({
         <div className="px-8 pt-3 text-sm text-red-500">{saveError}</div>
       )}
 
-      <div className="px-8 py-2">
+      <div className="px-4 sm:px-8 py-2">
         {[
           [
             { label: '이름', view: user.name, edit: <UnderlineInput value={draft.name} onChange={(v) => setDraft({ ...draft, name: v })} /> },
@@ -214,10 +214,10 @@ function ProfileCard({
         ].map((row, rowIdx, all) => (
           <div
             key={rowIdx}
-            className={`grid grid-cols-2 divide-x divide-border py-5 ${rowIdx < all.length - 1 ? 'border-b border-border' : ''}`}
+            className={`grid grid-cols-1 sm:grid-cols-2 sm:divide-x divide-border py-5 ${rowIdx < all.length - 1 ? 'border-b border-border' : ''}`}
           >
             {row.map((cell, colIdx) => (
-              <div key={colIdx} className={`flex flex-col gap-2${colIdx === 1 ? ' pl-8' : ''}`}>
+              <div key={colIdx} className={`flex flex-col gap-2${colIdx === 1 ? ' sm:pl-8 pt-4 sm:pt-0' : ''}`}>
                 <span className="text-sm text-text-secondary">
                   {cell.label}
                   {cell.hint && <span className="ml-2 text-xs text-text-placeholder">({cell.hint})</span>}
@@ -238,20 +238,20 @@ function ProfileCard({
 
 function MentorCard({ user }: { user: AdminUserDetail }) {
   return (
-    <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+    <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-base font-semibold text-text-primary">멘토 정보</h2>
         <span className="text-xs text-text-placeholder">신청서에서 변경</span>
       </div>
 
-      <div className="grid grid-cols-2 divide-x divide-border">
-        <div className="pr-8 flex flex-col gap-2">
+      <div className="grid grid-cols-1 sm:grid-cols-2 sm:divide-x divide-border gap-4 sm:gap-0">
+        <div className="sm:pr-8 flex flex-col gap-2">
           <span className="text-sm text-text-secondary">소속 로스쿨</span>
           <div className="h-6">
             <span className="text-base text-text-primary">{user.currentLawschool || '-'}</span>
           </div>
         </div>
-        <div className="pl-8 flex flex-col gap-2">
+        <div className="sm:pl-8 flex flex-col gap-2">
           <span className="text-sm text-text-secondary">기수</span>
           <div className="h-6">
             <span className="text-base text-text-primary">{user.cohort != null ? `${user.cohort}기` : '-'}</span>
@@ -300,7 +300,7 @@ function AccountCard({
   const isActive = data.accountStatus === 'active';
 
   return (
-    <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+    <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-base font-semibold text-text-primary">계정 상태</h2>
         {isEditing
@@ -311,8 +311,8 @@ function AccountCard({
 
       {saveError && <p className="mb-3 text-sm text-red-500">{saveError}</p>}
 
-      <div className="grid grid-cols-2 divide-x divide-border">
-        <div className="pr-8 flex items-center justify-between">
+      <div className="grid grid-cols-1 sm:grid-cols-2 sm:divide-x divide-border gap-4 sm:gap-0">
+        <div className="sm:pr-8 flex items-center justify-between">
           <div>
             <p className="text-sm text-text-secondary">활성화 여부</p>
             <div className="h-6 flex items-center mt-2">
@@ -327,7 +327,7 @@ function AccountCard({
             onChange={(on) => setDraft({ ...draft, accountStatus: on ? 'active' : 'inactive' })}
           />
         </div>
-        <div className="pl-8 flex flex-col gap-2">
+        <div className="sm:pl-8 flex flex-col gap-2">
           <span className="text-sm text-text-secondary">현재 역할</span>
           <div className="h-6">
             {isEditing
@@ -345,16 +345,17 @@ function AccountCard({
 
 function ParticipationCard({ participation }: { participation: AdminUserDetail['participation'] }) {
   return (
-    <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+    <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
       <h2 className="text-base font-semibold text-text-primary mb-6">참여 이력</h2>
       {participation.length === 0 ? (
         <p className="py-2 text-sm text-text-secondary">참여 이력이 없습니다.</p>
       ) : (
+        <div className="overflow-x-auto">
         <table className="w-full table-auto">
           <thead>
             <tr className="border-b border-border">
-              <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4">프로세스 참여 연도</th>
-              <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4">당시 역할</th>
+              <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap">프로세스 참여 연도</th>
+              <th className="text-left text-xs font-medium text-text-secondary py-3 pr-4 whitespace-nowrap">당시 역할</th>
             </tr>
           </thead>
           <tbody>
@@ -370,6 +371,7 @@ function ParticipationCard({ participation }: { participation: AdminUserDetail['
             ))}
           </tbody>
         </table>
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -45,18 +45,3 @@ body {
   color: var(--foreground);
   font-family: var(--font-pretendard), 'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont, sans-serif;
 }
-
-/* Tailwind @layer utilities의 반응형 변수가 환경에 따라 누락되는 문제 보완 */
-@media (min-width: 640px) {
-  .sm\:hidden { display: none !important; }
-  .sm\:flex { display: flex !important; }
-  .sm\:block { display: block !important; }
-  .sm\:inline-block { display: inline-block !important; }
-}
-
-@media (min-width: 768px) {
-  .md\:hidden { display: none !important; }
-  .md\:flex { display: flex !important; }
-  .md\:block { display: block !important; }
-  .md\:inline-block { display: inline-block !important; }
-}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -45,3 +45,18 @@ body {
   color: var(--foreground);
   font-family: var(--font-pretendard), 'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont, sans-serif;
 }
+
+/* Tailwind @layer utilities의 반응형 변수가 환경에 따라 누락되는 문제 보완 */
+@media (min-width: 640px) {
+  .sm\:hidden { display: none !important; }
+  .sm\:flex { display: flex !important; }
+  .sm\:block { display: block !important; }
+  .sm\:inline-block { display: inline-block !important; }
+}
+
+@media (min-width: 768px) {
+  .md\:hidden { display: none !important; }
+  .md\:flex { display: flex !important; }
+  .md\:block { display: block !important; }
+  .md\:inline-block { display: inline-block !important; }
+}

--- a/apps/web/src/app/mentee/applications/ApplicationsClient.tsx
+++ b/apps/web/src/app/mentee/applications/ApplicationsClient.tsx
@@ -94,7 +94,7 @@ export default function ApplicationsClient({ initialSchedule, initialAdmission, 
 
       {/* 사업 일정 카드 */}
       {activeSchedule && (
-        <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+        <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
           <h2 className="text-base font-semibold text-text-primary mb-4">
             {activeSchedule.process_year}학년도 pLAWcess 일정
           </h2>
@@ -118,7 +118,7 @@ export default function ApplicationsClient({ initialSchedule, initialAdmission, 
       )}
 
       {/* 프로세스 안내 카드 */}
-      <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+      <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
         <h2 className="text-base font-semibold text-text-primary mb-5">프로세스 안내</h2>
         <div className="text-sm text-text-body leading-relaxed space-y-3 mb-6 pb-6 border-b border-border">
           <p>고려대학교 자유전공학부에서는 2023년 제15대 집행위원회 교육국에서부터 &apos;pLAWcess&apos;라는 사업을 진행하고 있습니다. &apos;로스쿨을 향하는 과정&apos;이라는 뜻을 담은 해당 사업은 다음 두 가지 주요 활동으로 이루어져 있습니다.</p>
@@ -177,7 +177,7 @@ export default function ApplicationsClient({ initialSchedule, initialAdmission, 
       />
 
       {/* 개인정보 동의 카드 */}
-      <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+      <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
         <h2 className="text-base font-semibold text-text-primary mb-5">개인정보 수집 및 이용 동의</h2>
         <div className="text-sm text-text-body leading-relaxed space-y-4 mb-6">
           <div>
@@ -222,7 +222,7 @@ export default function ApplicationsClient({ initialSchedule, initialAdmission, 
       </div>
 
       {/* 신청서 카드 */}
-      <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+      <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
         <div className="mb-6">
           <h2 className="text-base font-semibold text-text-primary">pLAWcess 신청서</h2>
         </div>
@@ -232,7 +232,7 @@ export default function ApplicationsClient({ initialSchedule, initialAdmission, 
           <div>
             <p className="text-sm font-medium text-text-primary mb-3">희망 로스쿨</p>
             {admission ? (
-              <div className="grid grid-cols-2 gap-6">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6">
                 {(['가', '나'] as const).map((group) => {
                   const slot = admission[group];
                   const preferred = admission.preferredGroup;

--- a/apps/web/src/app/mentee/dashboard/basic-info/BasicInfoClient.tsx
+++ b/apps/web/src/app/mentee/dashboard/basic-info/BasicInfoClient.tsx
@@ -132,7 +132,7 @@ export default function BasicInfoClient({ initialPersonal, initialAdmission, ini
 
       {/* 기본정보 카드 */}
       <div className="bg-white rounded-xl border border-border shadow-sm">
-        <div className="flex items-center justify-between px-8 py-6 bg-brand-light border-b border-border rounded-t-xl">
+        <div className="flex items-center justify-between px-4 sm:px-8 py-6 bg-brand-light border-b border-border rounded-t-xl">
           <div className="flex items-center gap-4">
             <div className="w-14 h-14 rounded-full bg-brand-muted flex items-center justify-center text-brand">
               <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
@@ -151,14 +151,14 @@ export default function BasicInfoClient({ initialPersonal, initialAdmission, ini
           }
         </div>
 
-        <div className="px-8 py-2">
+        <div className="px-4 sm:px-8 py-2">
           {fieldRows.map((row, rowIdx) => (
             <div
               key={rowIdx}
-              className={`grid grid-cols-2 divide-x divide-border py-5 ${rowIdx < fieldRows.length - 1 ? 'border-b border-border' : ''}`}
+              className={`grid grid-cols-1 sm:grid-cols-2 sm:divide-x divide-border py-5 ${rowIdx < fieldRows.length - 1 ? 'border-b border-border' : ''}`}
             >
               {row.map(({ label, key, type, options }, colIdx) => (
-                <div key={key} className={`flex flex-col gap-2${colIdx === 1 ? ' pl-8' : ''}`}>
+                <div key={key} className={`flex flex-col gap-2${colIdx === 1 ? ' sm:pl-8 pt-4 sm:pt-0' : ''}`}>
                   <div className="flex items-center gap-2">
                     <span className="text-sm text-text-secondary shrink-0">{label}</span>
                     {key === 'birthDate' && birthDateError && (
@@ -195,7 +195,7 @@ export default function BasicInfoClient({ initialPersonal, initialAdmission, ini
       </div>
 
       {/* 희망 학교 및 전형 카드 */}
-      <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+      <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
         <div className="flex items-center justify-between mb-6">
           <h2 className="text-base font-semibold text-text-primary">희망 학교 및 전형</h2>
           {isAdmissionEditing
@@ -204,12 +204,12 @@ export default function BasicInfoClient({ initialPersonal, initialAdmission, ini
           }
         </div>
 
-        <div className="grid grid-cols-2 divide-x divide-border">
+        <div className="grid grid-cols-1 sm:grid-cols-2 sm:divide-x divide-border gap-y-4 sm:gap-y-0">
           {(['가', '나'] as const).map((group) => {
             const item = isAdmissionEditing ? admissionDraft[group] : admissionInfo[group];
             const isPreferred = isAdmissionEditing ? preferredGroupDraft === group : preferredGroup === group;
             return (
-              <div key={group} className={`${group === '나' ? 'pl-8' : 'pr-8'} rounded-lg transition-colors ${isPreferred ? 'bg-brand-light' : ''}`}>
+              <div key={group} className={`${group === '나' ? 'sm:pl-8' : 'sm:pr-8'} rounded-lg transition-colors ${isPreferred ? 'bg-brand-light' : ''}`}>
                 <div className="flex items-center gap-3 mb-5">
                   <span className="inline-block text-sm font-semibold text-brand bg-brand-light px-3 py-1 rounded">{group}군</span>
                   {isAdmissionEditing ? (

--- a/apps/web/src/app/mentee/dashboard/personal-statement/PersonalStatementClient.tsx
+++ b/apps/web/src/app/mentee/dashboard/personal-statement/PersonalStatementClient.tsx
@@ -273,15 +273,20 @@ export default function PersonalStatementClient({
           <div key={group}>
             {mode === 'hwp' ? (
               activeGroup.hwp ? (
-                <div
-                  className="bg-white rounded-xl border border-border shadow-sm overflow-hidden"
-                  style={{ height: '80vh' }}
-                >
-                  <HwpEditor
-                    initialHwpBase64={activeGroup.hwp}
-                    onEditorReady={(editor) => onEditorReady(group, editor)}
-                  />
-                </div>
+                <>
+                  <div className="sm:hidden bg-amber-50 border border-amber-200 rounded-xl px-5 py-4 text-sm text-amber-800">
+                    HWP 에디터는 PC 환경에서 이용해 주세요.
+                  </div>
+                  <div
+                    className="hidden sm:block bg-white rounded-xl border border-border shadow-sm overflow-hidden"
+                    style={{ height: '80vh' }}
+                  >
+                    <HwpEditor
+                      initialHwpBase64={activeGroup.hwp}
+                      onEditorReady={(editor) => onEditorReady(group, editor)}
+                    />
+                  </div>
+                </>
               ) : (
                 <EmptyState
                   message={`${activeGroup.school} 자기소개서 양식이 아직 준비되지 않았습니다.`}
@@ -295,7 +300,7 @@ export default function PersonalStatementClient({
                   return (
                     <div
                       key={q.id}
-                      className="bg-white rounded-xl border border-border shadow-sm px-8 py-6"
+                      className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6"
                     >
                       {/* 문항 헤더 */}
                       <div className="flex items-center gap-3 mb-4">

--- a/apps/web/src/app/mentee/dashboard/qualitative/QualitativeClient.tsx
+++ b/apps/web/src/app/mentee/dashboard/qualitative/QualitativeClient.tsx
@@ -450,11 +450,11 @@ function ActivityFormCard({
 
   return (
     <div className="relative">
-      <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+      <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
       <h2 className="text-base font-semibold text-text-primary mb-6">활동 정보 입력</h2>
       <hr className="border-border mb-6" />
 
-      <div className="grid grid-cols-2 gap-8 mb-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 sm:gap-8 mb-6">
         <div className="flex flex-col gap-2">
           <label className="text-sm text-text-secondary">활동명 <span className="text-red-500">*</span></label>
           <input type="text" value={form.name} onChange={(e) => onChange({ ...form, name: e.target.value })}
@@ -469,7 +469,7 @@ function ActivityFormCard({
         </div>
       </div>
 
-      <div className="grid grid-cols-2 gap-8 mb-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 sm:gap-8 mb-6">
         <div className="flex flex-col gap-2">
           <label className="text-sm text-text-secondary">시작일</label>
           <DateInput
@@ -563,7 +563,7 @@ function CareerGoalCard({
   }
 
   return (
-    <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+    <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-base font-semibold text-text-primary">희망 진로</h2>
         {isEditing
@@ -661,7 +661,7 @@ function ActivityCard({
 
   return (
     <div className="flex flex-col gap-3 relative">
-      <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+      <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
         <div className="flex items-start justify-between gap-3">
           <h2 className="text-lg font-semibold text-text-primary">{activity.name}</h2>
           <button
@@ -785,7 +785,7 @@ function ActivityListTable({
   selectedUnified: string | null;
 }) {
   return (
-    <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+    <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
       <h2 className="text-lg font-semibold text-text-primary mb-1">활동 목록</h2>
       <p className="text-xs text-text-secondary mb-3">
         오른쪽 키워드를 누르면 의미가 같은 활동별 키워드가 강조돼요.
@@ -979,7 +979,7 @@ function StoryOutlineCard({ outline }: { outline: StoryOutline }) {
     { label: '결론', text: outline.conclusion },
   ];
   return (
-    <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+    <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
       <h2 className="text-lg font-semibold text-text-primary mb-1">AI 추천 자소서 흐름</h2>
       <p className="text-sm text-text-secondary mb-5">분석 결과를 바탕으로 자소서의 흐름을 제안해 드려요.</p>
       <div className="flex flex-col gap-3">
@@ -1537,14 +1537,14 @@ export default function QualitativeClient({ initialData }: { initialData?: Quali
 
       {pageLoading ? (
         <div className="flex flex-col gap-6 animate-pulse">
-          <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+          <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
             <div className="h-6 w-40 bg-gray-200 rounded mb-4" />
             <div className="space-y-3">
               <div className="h-5 w-full bg-gray-100 rounded" />
               <div className="h-5 w-3/4 bg-gray-100 rounded" />
             </div>
           </div>
-          <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+          <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
             <div className="h-6 w-32 bg-gray-200 rounded mb-6" />
             <div className="space-y-4">
               {[...Array(3)].map((_, i) => (
@@ -1556,7 +1556,7 @@ export default function QualitativeClient({ initialData }: { initialData?: Quali
               ))}
             </div>
           </div>
-          <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+          <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
             <div className="h-6 w-24 bg-gray-200 rounded mb-4" />
             <div className="h-5 w-1/2 bg-gray-100 rounded" />
           </div>

--- a/apps/web/src/app/mentee/dashboard/qualitative/QualitativeClient.tsx
+++ b/apps/web/src/app/mentee/dashboard/qualitative/QualitativeClient.tsx
@@ -7,6 +7,22 @@ import {
   type QualitativeActivity, type QualitativeData, type StarItem, type ActivityCategory, type KeywordCount,
   type StoryOutline, type Attachment,
 } from '@/lib/api';
+import {
+  DndContext,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  useSortable,
+  arrayMove,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 
 const TABS = ['대시보드', '교내', '대외', '사회경험', '자격·시험'] as const;
 type Tab = typeof TABS[number];
@@ -148,6 +164,15 @@ function IconSparkles({ className = 'w-5 h-5' }: { className?: string }) {
       <path d="M12 3l1.6 4.4L18 9l-4.4 1.6L12 15l-1.6-4.4L6 9l4.4-1.6L12 3z" />
       <path d="M19 15l.6 1.4L21 17l-1.4.6L19 19l-.6-1.4L17 17l1.4-.6L19 15z" />
       <path d="M5 16l.6 1.4L7 18l-1.4.6L5 20l-.6-1.4L3 18l1.4-.6L5 16z" />
+    </svg>
+  );
+}
+function IconDragHandle({ className = 'w-5 h-5' }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <line x1="8" y1="7" x2="16" y2="7" />
+      <line x1="8" y1="12" x2="16" y2="12" />
+      <line x1="8" y1="17" x2="16" y2="17" />
     </svg>
   );
 }
@@ -708,6 +733,41 @@ function ActivityCard({
   );
 }
 
+function SortableActivityCard({
+  id,
+  sortDisabled,
+  ...props
+}: React.ComponentProps<typeof ActivityCard> & { id: string; sortDisabled?: boolean }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id,
+    disabled: sortDisabled,
+  });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+    position: 'relative',
+    zIndex: isDragging ? 10 : undefined,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      {!sortDisabled && (
+        <div
+          {...attributes}
+          {...listeners}
+          className="absolute -left-7 top-6 cursor-grab active:cursor-grabbing text-text-placeholder hover:text-text-secondary touch-none select-none"
+          aria-label="드래그하여 순서 변경"
+        >
+          <IconDragHandle />
+        </div>
+      )}
+      <ActivityCard {...props} />
+    </div>
+  );
+}
+
 // ----------------------------------------------------------------
 // 대시보드: 활동 목록 표
 // 사이드바에서 통합 키워드를 선택하면, 해당 통합으로 묶이는 raw 키워드만 하이라이트.
@@ -983,6 +1043,11 @@ export default function QualitativeClient({ initialData }: { initialData?: Quali
   const [deletingIdx, setDeletingIdx] = useState<number | null>(null);
   const [selectedUnified, setSelectedUnified] = useState<string | null>(null);
 
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 5 } }),
+  );
+
   function getDraftFiles(category: CategoryTab, index: number): File[] {
     return draftFiles[`${category}:${index}`] ?? [];
   }
@@ -1231,6 +1296,49 @@ export default function QualitativeClient({ initialData }: { initialData?: Quali
     }
   }
 
+  async function handleReorder(category: CategoryTab, event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const categoryItems = serverActivities
+      .map((a, idx) => ({ activity: a, idx }))
+      .filter((x) => x.activity.category === category);
+
+    const oldCategoryPos = categoryItems.findIndex((x) => String(x.idx) === active.id);
+    const newCategoryPos = categoryItems.findIndex((x) => String(x.idx) === over.id);
+    if (oldCategoryPos === -1 || newCategoryPos === -1) return;
+
+    const reorderedCategory = arrayMove(categoryItems, oldCategoryPos, newCategoryPos);
+    const oldCategoryGlobalIdxes = categoryItems.map((x) => x.idx);
+    const newCategoryGlobalIdxes = reorderedCategory.map((x) => x.idx);
+
+    const newActivities = [...serverActivities];
+    oldCategoryGlobalIdxes.forEach((oldPos, i) => {
+      newActivities[oldPos] = reorderedCategory[i].activity;
+    });
+
+    const reorderMapping = serverActivities.map((_, oldIdx) => {
+      const catPos = oldCategoryGlobalIdxes.indexOf(oldIdx);
+      if (catPos === -1) return oldIdx;
+      return newCategoryGlobalIdxes[catPos];
+    });
+
+    const prevActivities = serverActivities;
+    setServerActivities(newActivities);
+
+    try {
+      const data = await patchQualitative(YEAR, {
+        activities: newActivities,
+        reorderMapping,
+      });
+      applyData(data);
+    } catch (err) {
+      console.error(err);
+      setServerActivities(prevActivities);
+      alert('순서 저장에 실패했어요. 잠시 후 다시 시도해주세요.');
+    }
+  }
+
   function toggleExpand(idx: number) {
     setExpandedSet((prev) => {
       const next = new Set(prev);
@@ -1315,40 +1423,56 @@ export default function QualitativeClient({ initialData }: { initialData?: Quali
   function renderCategoryTab(category: CategoryTab) {
     const inTab = activityWithIndex.filter((x) => x.activity.category === category);
     const draftList = drafts[category];
+    const sortDisabled = submitting || editingIdx !== null || inTab.length <= 1;
 
     return (
       <div className="flex flex-col gap-6">
-        {inTab.map((x) => {
-          if (editingIdx === x.idx && editDraft) {
-            return (
-              <ActivityFormCard
-                key={`edit-${x.idx}`}
-                form={editDraft}
-                onChange={(updated) => setEditDraft(updated)}
-                newFiles={editFiles}
-                onAddFiles={(files) => setEditFiles((prev) => [...prev, ...files])}
-                onRemoveNewFile={(idx) => setEditFiles((prev) => prev.filter((_, i) => i !== idx))}
-                onCancel={cancelEdit}
-                onSubmit={saveEdit}
-                submitting={submitting}
-                submitLabel="수정 및 재분석"
-              />
-            );
-          }
-          return (
-            <ActivityCard
-              key={`saved-${x.idx}`}
-              activity={x.activity}
-              star={findStar(x.idx)}
-              expanded={expandedSet.has(x.idx)}
-              onToggle={() => toggleExpand(x.idx)}
-              onEdit={() => startEdit(x.idx)}
-              onDelete={() => deleteActivity(x.idx)}
-              deleting={deletingIdx === x.idx}
-              isAnalyzing={analyzingIdx === x.idx}
-            />
-          );
-        })}
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={(event) => handleReorder(category, event)}
+        >
+          <SortableContext
+            items={inTab.map((x) => String(x.idx))}
+            strategy={verticalListSortingStrategy}
+          >
+            <div className={`flex flex-col gap-6 ${!sortDisabled ? 'pl-7' : ''}`}>
+              {inTab.map((x) => {
+                if (editingIdx === x.idx && editDraft) {
+                  return (
+                    <ActivityFormCard
+                      key={`edit-${x.idx}`}
+                      form={editDraft}
+                      onChange={(updated) => setEditDraft(updated)}
+                      newFiles={editFiles}
+                      onAddFiles={(files) => setEditFiles((prev) => [...prev, ...files])}
+                      onRemoveNewFile={(idx) => setEditFiles((prev) => prev.filter((_, i) => i !== idx))}
+                      onCancel={cancelEdit}
+                      onSubmit={saveEdit}
+                      submitting={submitting}
+                      submitLabel="수정 및 재분석"
+                    />
+                  );
+                }
+                return (
+                  <SortableActivityCard
+                    key={`saved-${x.idx}`}
+                    id={String(x.idx)}
+                    sortDisabled={sortDisabled}
+                    activity={x.activity}
+                    star={findStar(x.idx)}
+                    expanded={expandedSet.has(x.idx)}
+                    onToggle={() => toggleExpand(x.idx)}
+                    onEdit={() => startEdit(x.idx)}
+                    onDelete={() => deleteActivity(x.idx)}
+                    deleting={deletingIdx === x.idx}
+                    isAnalyzing={analyzingIdx === x.idx}
+                  />
+                );
+              })}
+            </div>
+          </SortableContext>
+        </DndContext>
         {draftList.map((form, i) => (
           <ActivityFormCard
             key={`draft-${i}`}

--- a/apps/web/src/app/mentor/dashboard/basic-info/MentorBasicInfoClient.tsx
+++ b/apps/web/src/app/mentor/dashboard/basic-info/MentorBasicInfoClient.tsx
@@ -93,7 +93,7 @@ export default function MentorBasicInfoClient({ initialData }: Props) {
       </div>
 
       <div className="bg-white rounded-xl border border-border shadow-sm">
-        <div className="flex items-center justify-between px-8 py-6 bg-brand-light border-b border-border rounded-t-xl">
+        <div className="flex items-center justify-between px-4 sm:px-8 py-6 bg-brand-light border-b border-border rounded-t-xl">
           <div className="flex items-center gap-4">
             <div className="w-14 h-14 rounded-full bg-brand-muted flex items-center justify-center text-brand">
               <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
@@ -109,14 +109,14 @@ export default function MentorBasicInfoClient({ initialData }: Props) {
           }
         </div>
 
-        <div className="px-8 py-2">
+        <div className="px-4 sm:px-8 py-2">
           {fieldRows.map((row, rowIdx) => (
             <div
               key={rowIdx}
-              className={`grid grid-cols-2 divide-x divide-border py-5 ${rowIdx < fieldRows.length - 1 ? 'border-b border-border' : ''}`}
+              className={`grid grid-cols-1 sm:grid-cols-2 sm:divide-x divide-border py-5 ${rowIdx < fieldRows.length - 1 ? 'border-b border-border' : ''}`}
             >
               {row.map(({ label, key, type, options }, colIdx) => (
-                <div key={key} className={`flex flex-col gap-2${colIdx === 1 ? ' pl-8' : ''}`}>
+                <div key={key} className={`flex flex-col gap-2${colIdx === 1 ? ' sm:pl-8 pt-4 sm:pt-0' : ''}`}>
                   <div className="flex items-center gap-2">
                     <span className="text-sm text-text-secondary shrink-0">{label}</span>
                     {key === 'birthDate' && birthDateError && (

--- a/apps/web/src/components/landing/LandingNavbar.tsx
+++ b/apps/web/src/components/landing/LandingNavbar.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { usePathname, useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { getUser, saveUser, type AuthUser } from '@/lib/api';
 import UserMenu from '@/components/layout/UserMenu';
 import NotificationBell from '@/components/layout/NotificationBell';
@@ -22,6 +22,8 @@ export default function LandingNavbar({ initialUser }: Props) {
   const router = useRouter();
   const [user, setUser] = useState<AuthUser | null>(initialUser ?? null);
   const [authChecked, setAuthChecked] = useState(initialUser !== undefined);
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
 
   async function fetchUser(): Promise<void> {
     try {
@@ -63,81 +65,112 @@ export default function LandingNavbar({ initialUser }: Props) {
     router.push('/');
   }
 
+  const allNavItems = [
+    ...NAV_ITEMS,
+    { href: '/mentee/dashboard', label: '멘티' },
+    { href: '/mentor/dashboard', label: '멘토' },
+    { href: '/admin/users', label: '어드민' },
+  ];
+
   return (
-    <header className="sticky top-0 z-50 h-16 bg-white border-b border-border flex items-center px-6 justify-between shrink-0">
-      {/* Left: Logo */}
-      <div className="flex-1">
-        <Link href="/">
-          <Image src="/logo/puzzleserif_logo.png" alt="pLAWcess" width={120} height={39} priority />
-        </Link>
-      </div>
-
-      {/* Center: Nav items */}
-      <nav className="flex items-center gap-6" aria-label="주요 메뉴">
-        {NAV_ITEMS.map(({ href, label }) => (
-          <Link
-            key={href}
-            href={href}
-            className={`text-sm font-medium transition-colors ${
-              pathname === href
-                ? 'text-text-primary'
-                : 'text-text-secondary hover:text-text-primary'
-            }`}
-          >
-            {label}
+    <header className="sticky top-0 z-50 bg-white border-b border-border shrink-0" ref={menuRef}>
+      <div className="h-16 flex items-center px-4 sm:px-6 justify-between">
+        {/* Left: Logo */}
+        <div className="flex-1">
+          <Link href="/">
+            <Image src="/logo/puzzleserif_logo.png" alt="pLAWcess" width={120} height={39} priority />
           </Link>
-        ))}
-        {/* {process.env.NODE_ENV === 'development' && ( */}
+        </div>
 
+        {/* Center: Nav items (desktop) */}
+        <nav className="hidden md:flex items-center gap-6" aria-label="주요 메뉴">
+          {NAV_ITEMS.map(({ href, label }) => (
+            <Link
+              key={href}
+              href={href}
+              className={`text-sm font-medium transition-colors ${
+                pathname === href
+                  ? 'text-text-primary'
+                  : 'text-text-secondary hover:text-text-primary'
+              }`}
+            >
+              {label}
+            </Link>
+          ))}
           <>
-            <Link
-              href="/mentee/dashboard"
-              className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors"
-            >
-              멘티
-            </Link>
-            <Link
-              href="/mentor/dashboard"
-              className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors"
-            >
-              멘토
-            </Link>
-            <Link
-              href="/admin/users"
-              className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors"
-            >
-              어드민
-            </Link>
+            <Link href="/mentee/dashboard" className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors">멘티</Link>
+            <Link href="/mentor/dashboard" className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors">멘토</Link>
+            <Link href="/admin/users" className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors">어드민</Link>
           </>
-        {/* )} */}
-      </nav>
+        </nav>
 
-      {/* Right: Action buttons */}
-      <div className="flex-1 flex items-center justify-end gap-2">
-        {!authChecked ? (
-          <div className="h-9" />
-        ) : user ? (
-          <>
-            <NotificationBell />
-            <UserMenu user={user} onLogout={handleLogout} />
-          </>
-        ) : (
-          <div className="flex items-center gap-3">
-            <Link
-              href="/login"
-              className="px-4 py-2 text-sm font-medium text-brand border border-brand rounded-md hover:bg-brand/5 transition-colors"
-            >
-              로그인
-            </Link>
-            <Link
-              href="/signup"
-              className="px-4 py-2 text-sm font-medium text-white bg-brand rounded-md hover:bg-brand-dark transition-colors"
-            >
-              회원가입
-            </Link>
-          </div>
-        )}
+        {/* Right: Action buttons + mobile hamburger */}
+        <div className="flex-1 flex items-center justify-end gap-2">
+          {!authChecked ? (
+            <div className="h-9" />
+          ) : user ? (
+            <>
+              <NotificationBell />
+              <UserMenu user={user} onLogout={handleLogout} />
+            </>
+          ) : (
+            <div className="hidden sm:flex items-center gap-3">
+              <Link href="/login" className="px-4 py-2 text-sm font-medium text-brand border border-brand rounded-md hover:bg-brand/5 transition-colors">
+                로그인
+              </Link>
+              <Link href="/signup" className="px-4 py-2 text-sm font-medium text-white bg-brand rounded-md hover:bg-brand-dark transition-colors">
+                회원가입
+              </Link>
+            </div>
+          )}
+          {/* 모바일 햄버거 */}
+          <button
+            onClick={() => setMobileOpen((o) => !o)}
+            aria-label="메뉴"
+            className="md:hidden w-9 h-9 flex items-center justify-center rounded-full hover:bg-gray-100 transition-colors"
+          >
+            {mobileOpen ? (
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            ) : (
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="3" y1="6" x2="21" y2="6" /><line x1="3" y1="12" x2="21" y2="12" /><line x1="3" y1="18" x2="21" y2="18" />
+              </svg>
+            )}
+          </button>
+        </div>
       </div>
+
+      {/* 모바일 드로어 */}
+      {mobileOpen && (
+        <div className="md:hidden border-t border-border bg-white px-4 py-3 flex flex-col gap-1">
+          {allNavItems.map(({ href, label }) => (
+            <Link
+              key={href}
+              href={href}
+              onClick={() => setMobileOpen(false)}
+              className={`px-3 py-2.5 text-sm font-medium rounded-md transition-colors ${
+                pathname === href
+                  ? 'bg-brand-light text-brand'
+                  : 'text-text-secondary hover:bg-gray-50 hover:text-text-primary'
+              }`}
+            >
+              {label}
+            </Link>
+          ))}
+          {!user && (
+            <div className="flex flex-col gap-2 pt-3 border-t border-border mt-1">
+              <Link href="/login" onClick={() => setMobileOpen(false)} className="w-full py-2.5 text-sm font-medium text-center text-brand border border-brand rounded-md hover:bg-brand/5 transition-colors">
+                로그인
+              </Link>
+              <Link href="/signup" onClick={() => setMobileOpen(false)} className="w-full py-2.5 text-sm font-medium text-center text-white bg-brand rounded-md hover:bg-brand-dark transition-colors">
+                회원가입
+              </Link>
+            </div>
+          )}
+        </div>
+      )}
     </header>
   );
 }

--- a/apps/web/src/components/landing/LandingNavbarInner.tsx
+++ b/apps/web/src/components/landing/LandingNavbarInner.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Link from 'next/link';
+import { useIsMobile } from '@/lib/useIsMobile';
+import type { AuthUser } from '@/lib/api';
+import LandingNavbarAuth from './LandingNavbarAuth';
+import LandingNavbarMobile from './LandingNavbarMobile';
+
+const NAV_ITEMS = [
+  { href: '/about', label: '서비스 소개' },
+  { href: '/guide', label: '이용 가이드' },
+  { href: '/faq', label: 'FAQ' },
+  { href: '/announcements', label: '공지사항' },
+  { href: '/mentee/dashboard', label: '멘티' },
+  { href: '/mentor/dashboard', label: '멘토' },
+  { href: '/admin/users', label: '어드민' },
+];
+
+export default function LandingNavbarInner({ initialUser }: { initialUser: AuthUser | null }) {
+  const isMobile = useIsMobile(768);
+
+  return (
+    <>
+      {/* Center: nav items (desktop only) */}
+      {!isMobile && (
+        <nav className="flex items-center gap-6" aria-label="주요 메뉴">
+          {NAV_ITEMS.map(({ href, label }) => (
+            <Link key={href} href={href} className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors">
+              {label}
+            </Link>
+          ))}
+        </nav>
+      )}
+
+      {/* Right: auth (desktop) or hamburger (mobile) */}
+      <div className="flex-1 flex items-center justify-end gap-2">
+        {isMobile ? (
+          <LandingNavbarMobile user={initialUser} />
+        ) : (
+          <LandingNavbarAuth initialUser={initialUser} />
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/components/landing/LandingNavbarMobile.tsx
+++ b/apps/web/src/components/landing/LandingNavbarMobile.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useState } from 'react';
+import type { AuthUser } from '@/lib/api';
+
+const NAV_ITEMS = [
+  { href: '/about', label: '서비스 소개' },
+  { href: '/guide', label: '이용 가이드' },
+  { href: '/faq', label: 'FAQ' },
+  { href: '/announcements', label: '공지사항' },
+  { href: '/mentee/dashboard', label: '멘티' },
+  { href: '/mentor/dashboard', label: '멘토' },
+  { href: '/admin/users', label: '어드민' },
+];
+
+export default function LandingNavbarMobile({ user }: { user: AuthUser | null }) {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen((o) => !o)}
+        aria-label="메뉴"
+        className="w-9 h-9 flex items-center justify-center rounded-full hover:bg-gray-100 transition-colors"
+      >
+        {open ? (
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        ) : (
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="3" y1="6" x2="21" y2="6" /><line x1="3" y1="12" x2="21" y2="12" /><line x1="3" y1="18" x2="21" y2="18" />
+          </svg>
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute top-16 left-0 right-0 bg-white border-t border-border px-4 py-3 flex flex-col gap-1 shadow-md z-50">
+          {NAV_ITEMS.map(({ href, label }) => (
+            <Link
+              key={href}
+              href={href}
+              onClick={() => setOpen(false)}
+              className={`px-3 py-2.5 text-sm font-medium rounded-md transition-colors ${
+                pathname === href
+                  ? 'bg-brand-light text-brand'
+                  : 'text-text-secondary hover:bg-gray-50 hover:text-text-primary'
+              }`}
+            >
+              {label}
+            </Link>
+          ))}
+          {!user && (
+            <div className="flex flex-col gap-2 pt-3 border-t border-border mt-1">
+              <Link
+                href="/login"
+                onClick={() => setOpen(false)}
+                className="w-full py-2.5 text-sm font-medium text-center text-brand border border-brand rounded-md hover:bg-brand/5 transition-colors"
+              >
+                로그인
+              </Link>
+              <Link
+                href="/signup"
+                onClick={() => setOpen(false)}
+                className="w-full py-2.5 text-sm font-medium text-center text-white bg-brand rounded-md hover:bg-brand-dark transition-colors"
+              >
+                회원가입
+              </Link>
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/components/landing/LandingNavbarServer.tsx
+++ b/apps/web/src/components/landing/LandingNavbarServer.tsx
@@ -4,13 +4,7 @@ import Image from 'next/image';
 import { serverFetch } from '@/lib/server-fetch';
 import type { AuthUser } from '@/lib/api';
 import LandingNavbarAuth from './LandingNavbarAuth';
-
-const NAV_ITEMS = [
-  { href: '/about', label: '서비스 소개' },
-  { href: '/guide', label: '이용 가이드' },
-  { href: '/faq', label: 'FAQ' },
-  { href: '/announcements', label: '공지사항' },
-];
+import LandingNavbarMobile from './LandingNavbarMobile';
 
 export default async function LandingNavbarServer() {
   const token = (await cookies()).get('plawcess_token')?.value ?? '';
@@ -20,37 +14,22 @@ export default async function LandingNavbarServer() {
   const initialUser = data?.user ?? null;
 
   return (
-    <header className="sticky top-0 z-50 h-16 bg-white border-b border-border flex items-center px-6 justify-between shrink-0">
-      {/* Left: Logo */}
-      <div className="flex-1">
-        <Link href="/">
-          <Image src="/logo/puzzleserif_logo.png" alt="pLAWcess" width={120} height={39} priority />
-        </Link>
-      </div>
-
-      {/* Center: Nav items */}
-      <nav className="flex items-center gap-6" aria-label="주요 메뉴">
-        {NAV_ITEMS.map(({ href, label }) => (
-          <Link
-            key={href}
-            href={href}
-            className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors"
-          >
-            {label}
+    <header className="sticky top-0 z-50 bg-white border-b border-border shrink-0">
+      <div className="h-16 flex items-center px-4 sm:px-6 justify-between relative">
+        {/* Left: Logo */}
+        <div className="flex-1">
+          <Link href="/">
+            <Image src="/logo/puzzleserif_logo.png" alt="pLAWcess" width={120} height={39} priority />
           </Link>
-        ))}
-        {/* {process.env.NODE_ENV === 'development' && ( */}
-        <>
-          <Link href="/mentee/dashboard" className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors">멘티</Link>
-          <Link href="/mentor/dashboard" className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors">멘토</Link>
-          <Link href="/admin/users" className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors">어드민</Link>
-        </>
-        {/* )} */}
-      </nav>
+        </div>
 
-      {/* Right: Auth section (client) */}
-      <div className="flex-1 flex items-center justify-end gap-2">
-        <LandingNavbarAuth initialUser={initialUser} />
+        {/* Right: Auth (desktop) + hamburger */}
+        <div className="flex items-center gap-2">
+          <div className="hidden md:flex items-center gap-2">
+            <LandingNavbarAuth initialUser={initialUser} />
+          </div>
+          <LandingNavbarMobile user={initialUser} />
+        </div>
       </div>
     </header>
   );

--- a/apps/web/src/components/landing/LandingNavbarServer.tsx
+++ b/apps/web/src/components/landing/LandingNavbarServer.tsx
@@ -3,8 +3,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { serverFetch } from '@/lib/server-fetch';
 import type { AuthUser } from '@/lib/api';
-import LandingNavbarAuth from './LandingNavbarAuth';
-import LandingNavbarMobile from './LandingNavbarMobile';
+import LandingNavbarInner from './LandingNavbarInner';
 
 export default async function LandingNavbarServer() {
   const token = (await cookies()).get('plawcess_token')?.value ?? '';
@@ -23,13 +22,8 @@ export default async function LandingNavbarServer() {
           </Link>
         </div>
 
-        {/* Right: Auth (desktop) + hamburger */}
-        <div className="flex items-center gap-2">
-          <div className="hidden md:flex items-center gap-2">
-            <LandingNavbarAuth initialUser={initialUser} />
-          </div>
-          <LandingNavbarMobile user={initialUser} />
-        </div>
+        {/* Center + Right: JS로 모바일/데스크탑 분기 */}
+        <LandingNavbarInner initialUser={initialUser} />
       </div>
     </header>
   );

--- a/apps/web/src/components/layout/DashboardShell.tsx
+++ b/apps/web/src/components/layout/DashboardShell.tsx
@@ -3,17 +3,28 @@
 import { useState } from 'react';
 import Navbar from '@/components/layout/Navbar';
 import Sidebar from '@/components/layout/Sidebar';
+import { useIsMobile } from '@/lib/useIsMobile';
 
 import type { AuthUser } from '@/lib/api';
 
 export default function DashboardShell({ children, role, initialUser }: { children: React.ReactNode; role?: string; initialUser?: AuthUser | null }) {
   const [mobileOpen, setMobileOpen] = useState(false);
+  const isMobile = useIsMobile(768);
 
   return (
     <div className="flex flex-col h-screen">
-      <Navbar onMenuToggle={() => setMobileOpen((o) => !o)} initialUser={initialUser} />
+      <Navbar
+        onMenuToggle={isMobile ? () => setMobileOpen((o) => !o) : undefined}
+        initialUser={initialUser}
+      />
       <div className="flex flex-1 overflow-hidden">
-        <Sidebar mobileOpen={mobileOpen} onClose={() => setMobileOpen(false)} initialRole={role} initialUser={initialUser} />
+        <Sidebar
+          mobileOpen={mobileOpen}
+          onClose={() => setMobileOpen(false)}
+          initialRole={role}
+          initialUser={initialUser}
+          isMobile={isMobile}
+        />
         <main className="flex-1 overflow-auto bg-page-bg">
           <div className="px-4 py-6 md:px-10 md:py-8">{children}</div>
         </main>

--- a/apps/web/src/components/layout/DashboardShell.tsx
+++ b/apps/web/src/components/layout/DashboardShell.tsx
@@ -15,6 +15,7 @@ export default function DashboardShell({ children, role, initialUser }: { childr
     <div className="flex flex-col h-screen">
       <Navbar
         onMenuToggle={isMobile ? () => setMobileOpen((o) => !o) : undefined}
+        mobileOpen={mobileOpen}
         initialUser={initialUser}
       />
       <div className="flex flex-1 overflow-hidden">

--- a/apps/web/src/components/layout/DashboardShell.tsx
+++ b/apps/web/src/components/layout/DashboardShell.tsx
@@ -13,9 +13,9 @@ export default function DashboardShell({ children, role, initialUser }: { childr
     <div className="flex flex-col h-screen">
       <Navbar onMenuToggle={() => setMobileOpen((o) => !o)} initialUser={initialUser} />
       <div className="flex flex-1 overflow-hidden">
-        <Sidebar mobileOpen={mobileOpen} onClose={() => setMobileOpen(false)} initialRole={role} />
+        <Sidebar mobileOpen={mobileOpen} onClose={() => setMobileOpen(false)} initialRole={role} initialUser={initialUser} />
         <main className="flex-1 overflow-auto bg-page-bg">
-          <div className="px-10 py-8">{children}</div>
+          <div className="px-4 py-6 md:px-10 md:py-8">{children}</div>
         </main>
       </div>
     </div>

--- a/apps/web/src/components/layout/Navbar.tsx
+++ b/apps/web/src/components/layout/Navbar.tsx
@@ -52,8 +52,15 @@ export default function Navbar({ onMenuToggle, initialUser }: NavbarProps) {
   }
 
   return (
-    <header className="h-16 bg-white border-b border-border flex items-center px-6 justify-between shrink-0">
+    <header className="h-16 bg-white border-b border-border flex items-center px-4 sm:px-6 justify-between shrink-0">
       <div className="flex items-center gap-3">
+        <Link href="/">
+          <Image src="/logo/puzzleserif_logo.png" alt="pLAWcess" width={120} height={39} priority />
+        </Link>
+      </div>
+      <div className="flex items-center gap-2">
+        <NotificationBell />
+        {user ? <span className="hidden md:block"><UserMenu user={user} onLogout={handleLogout} /></span> : null}
         {onMenuToggle && (
           <button
             onClick={onMenuToggle}
@@ -67,13 +74,6 @@ export default function Navbar({ onMenuToggle, initialUser }: NavbarProps) {
             </svg>
           </button>
         )}
-        <Link href="/">
-          <Image src="/logo/puzzleserif_logo.png" alt="pLAWcess" width={120} height={39} priority />
-        </Link>
-      </div>
-      <div className="flex items-center gap-2">
-        <NotificationBell />
-        {user ? <UserMenu user={user} onLogout={handleLogout} /> : null}
       </div>
     </header>
   );

--- a/apps/web/src/components/layout/Navbar.tsx
+++ b/apps/web/src/components/layout/Navbar.tsx
@@ -60,12 +60,12 @@ export default function Navbar({ onMenuToggle, initialUser }: NavbarProps) {
       </div>
       <div className="flex items-center gap-2">
         <NotificationBell />
-        {user ? <span className="hidden md:block"><UserMenu user={user} onLogout={handleLogout} /></span> : null}
+        {user && !onMenuToggle ? <UserMenu user={user} onLogout={handleLogout} /> : null}
         {onMenuToggle && (
           <button
             onClick={onMenuToggle}
             aria-label="메뉴"
-            className="md:hidden w-9 h-9 flex items-center justify-center rounded-full hover:bg-gray-100 transition-colors"
+            className="w-9 h-9 flex items-center justify-center rounded-full hover:bg-gray-100 transition-colors"
           >
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <line x1="3" y1="6" x2="21" y2="6" />

--- a/apps/web/src/components/layout/Navbar.tsx
+++ b/apps/web/src/components/layout/Navbar.tsx
@@ -12,10 +12,11 @@ const API_BASE = '';
 
 interface NavbarProps {
   onMenuToggle?: () => void;
+  mobileOpen?: boolean;
   initialUser?: AuthUser | null;
 }
 
-export default function Navbar({ onMenuToggle, initialUser }: NavbarProps) {
+export default function Navbar({ onMenuToggle, mobileOpen, initialUser }: NavbarProps) {
   const router = useRouter();
   const [user, setUser] = useState<AuthUser | null>(initialUser ?? null);
 
@@ -67,11 +68,17 @@ export default function Navbar({ onMenuToggle, initialUser }: NavbarProps) {
             aria-label="메뉴"
             className="w-9 h-9 flex items-center justify-center rounded-full hover:bg-gray-100 transition-colors"
           >
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <line x1="3" y1="6" x2="21" y2="6" />
-              <line x1="3" y1="12" x2="21" y2="12" />
-              <line x1="3" y1="18" x2="21" y2="18" />
-            </svg>
+            {mobileOpen ? (
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            ) : (
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="3" y1="6" x2="21" y2="6" />
+                <line x1="3" y1="12" x2="21" y2="12" />
+                <line x1="3" y1="18" x2="21" y2="18" />
+              </svg>
+            )}
           </button>
         )}
       </div>

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -137,23 +137,20 @@ export default function Sidebar({ mobileOpen, onClose, initialRole, initialUser,
 
       {/* 모바일 드롭다운 */}
       {isMobile && mobileOpen && (
-        <>
-          <div className="fixed inset-0 z-40 bg-black/40" onClick={onClose} />
-          <div className="fixed top-16 left-0 right-0 z-50 bg-white border-b border-border shadow-md px-4 py-3">
-            {navContent}
-            {initialUser && (
-              <div className="mt-2 pt-3 border-t border-border flex items-center justify-between">
-                <span className="text-sm font-medium text-text-primary">{initialUser.name}</span>
-                <button
-                  onClick={handleLogout}
-                  className="text-xs text-text-secondary hover:text-red-500 transition-colors"
-                >
-                  로그아웃
-                </button>
-              </div>
-            )}
-          </div>
-        </>
+        <div className="fixed top-16 left-0 right-0 z-50 bg-white border-t border-border shadow-md px-4 py-3">
+          {navContent}
+          {initialUser && (
+            <div className="mt-2 pt-3 border-t border-border flex items-center justify-between">
+              <span className="text-sm font-medium text-text-primary">{initialUser.name}</span>
+              <button
+                onClick={handleLogout}
+                className="text-xs text-text-secondary hover:text-red-500 transition-colors"
+              >
+                로그아웃
+              </button>
+            </div>
+          )}
+        </div>
       )}
     </>
   );

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -63,6 +63,7 @@ interface SidebarProps {
   onClose?: () => void;
   initialRole?: string;
   initialUser?: AuthUser | null;
+  isMobile?: boolean;
 }
 
 function NavLink({ item, pathname, onClose }: { item: NavItem; pathname: string; onClose?: () => void }) {
@@ -85,7 +86,7 @@ function NavLink({ item, pathname, onClose }: { item: NavItem; pathname: string;
   );
 }
 
-export default function Sidebar({ mobileOpen, onClose, initialRole, initialUser }: SidebarProps) {
+export default function Sidebar({ mobileOpen, onClose, initialRole, initialUser, isMobile }: SidebarProps) {
   const pathname = usePathname();
   const router = useRouter();
 
@@ -128,15 +129,17 @@ export default function Sidebar({ mobileOpen, onClose, initialRole, initialUser 
   return (
     <>
       {/* 데스크탑 사이드바 */}
-      <aside className="hidden md:flex w-44 bg-white border-r border-border flex-col py-6 shrink-0">
-        {navContent}
-      </aside>
+      {!isMobile && (
+        <aside className="w-44 bg-white border-r border-border flex flex-col py-6 shrink-0">
+          {navContent}
+        </aside>
+      )}
 
       {/* 모바일 드롭다운 */}
-      {mobileOpen && (
+      {isMobile && mobileOpen && (
         <>
-          <div className="fixed inset-0 z-40 bg-black/40 md:hidden" onClick={onClose} />
-          <div className="md:hidden fixed top-16 left-0 right-0 z-50 bg-white border-b border-border shadow-md px-4 py-3">
+          <div className="fixed inset-0 z-40 bg-black/40" onClick={onClose} />
+          <div className="fixed top-16 left-0 right-0 z-50 bg-white border-b border-border shadow-md px-4 py-3">
             {navContent}
             {initialUser && (
               <div className="mt-2 pt-3 border-t border-border flex items-center justify-between">

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
+import { clearUser, type AuthUser } from '@/lib/api';
 
 type NavItem = { label: string; href: string; match?: string; exact?: boolean; dividerBefore?: boolean };
 type NavSection = { section: string; items: NavItem[] };
@@ -61,6 +62,7 @@ interface SidebarProps {
   mobileOpen?: boolean;
   onClose?: () => void;
   initialRole?: string;
+  initialUser?: AuthUser | null;
 }
 
 function NavLink({ item, pathname, onClose }: { item: NavItem; pathname: string; onClose?: () => void }) {
@@ -83,8 +85,16 @@ function NavLink({ item, pathname, onClose }: { item: NavItem; pathname: string;
   );
 }
 
-export default function Sidebar({ mobileOpen, onClose, initialRole }: SidebarProps) {
+export default function Sidebar({ mobileOpen, onClose, initialRole, initialUser }: SidebarProps) {
   const pathname = usePathname();
+  const router = useRouter();
+
+  async function handleLogout() {
+    await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' });
+    clearUser();
+    onClose?.();
+    router.push('/');
+  }
 
   const isAdmin = pathname.startsWith('/admin') || initialRole === 'admin';
   const isMentor = pathname.startsWith('/mentor') || initialRole === 'mentor';
@@ -117,19 +127,31 @@ export default function Sidebar({ mobileOpen, onClose, initialRole }: SidebarPro
 
   return (
     <>
-      {mobileOpen && (
-        <div className="fixed inset-0 z-40 bg-black/40 md:hidden" onClick={onClose} />
-      )}
-      <aside
-        className={`
-          fixed top-16 left-0 h-[calc(100vh-4rem)] z-50 w-44 bg-white border-r border-border flex flex-col py-6 shrink-0
-          transition-transform duration-200
-          md:static md:top-auto md:h-auto md:translate-x-0 md:z-auto
-          ${mobileOpen ? 'translate-x-0' : '-translate-x-full'}
-        `}
-      >
+      {/* 데스크탑 사이드바 */}
+      <aside className="hidden md:flex w-44 bg-white border-r border-border flex-col py-6 shrink-0">
         {navContent}
       </aside>
+
+      {/* 모바일 드롭다운 */}
+      {mobileOpen && (
+        <>
+          <div className="fixed inset-0 z-40 bg-black/40 md:hidden" onClick={onClose} />
+          <div className="md:hidden fixed top-16 left-0 right-0 z-50 bg-white border-b border-border shadow-md px-4 py-3">
+            {navContent}
+            {initialUser && (
+              <div className="mt-2 pt-3 border-t border-border flex items-center justify-between">
+                <span className="text-sm font-medium text-text-primary">{initialUser.name}</span>
+                <button
+                  onClick={handleLogout}
+                  className="text-xs text-text-secondary hover:text-red-500 transition-colors"
+                >
+                  로그아웃
+                </button>
+              </div>
+            )}
+          </div>
+        </>
+      )}
     </>
   );
 }

--- a/apps/web/src/components/layout/UserMenu.tsx
+++ b/apps/web/src/components/layout/UserMenu.tsx
@@ -74,7 +74,7 @@ export default function UserMenu({ user, onLogout }: Props) {
       {open && (
         <div
           role="menu"
-          className="absolute right-0 top-full mt-2 w-64 bg-white border border-border rounded-md shadow-lg py-1 z-50"
+          className="absolute right-0 top-full mt-2 w-56 sm:w-64 max-w-[calc(100vw-2rem)] bg-white border border-border rounded-md shadow-lg py-1 z-50"
         >
           <div className="px-4 py-3 border-b border-border">
             <div className="flex items-center gap-2">

--- a/apps/web/src/components/quantitative/GpaCard.tsx
+++ b/apps/web/src/components/quantitative/GpaCard.tsx
@@ -62,7 +62,7 @@ export default function GpaCard({ initialData, onSave }: Props) {
   }
 
   return (
-    <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+    <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-base font-semibold text-text-primary">GPA</h2>
         {isEditing
@@ -71,7 +71,7 @@ export default function GpaCard({ initialData, onSave }: Props) {
         }
       </div>
 
-      <div className="grid grid-cols-3 gap-8">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-5 sm:gap-8">
         {/* 전체 평점 평균 */}
         <div className="flex flex-col gap-2">
           <span className="text-sm text-text-secondary">전체 평점 평균</span>
@@ -166,7 +166,7 @@ export default function GpaCard({ initialData, onSave }: Props) {
             </div>
             <p className="text-xs text-text-secondary">학업 성적표를 불러오기 위해 KUPID 계정으로 로그인해주세요.</p>
           </div>
-          <div className="grid grid-cols-2 gap-6 mb-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6 mb-6">
             <div className="flex flex-col gap-1.5">
               <label className="text-sm text-text-secondary">ID</label>
               <input

--- a/apps/web/src/components/quantitative/LanguageCard.tsx
+++ b/apps/web/src/components/quantitative/LanguageCard.tsx
@@ -39,7 +39,7 @@ export default function LanguageCard({ initialData, onSave }: Props) {
   }
 
   return (
-    <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+    <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-base font-semibold text-text-primary">어학 성적</h2>
         {isEditing
@@ -47,7 +47,7 @@ export default function LanguageCard({ initialData, onSave }: Props) {
           : <EditButton onClick={() => { setDraft(data); setIsEditing(true); }} />
         }
       </div>
-      <div className="grid grid-cols-3 gap-8">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-5 sm:gap-8">
         {fields.map(({ label, key }) => (
           <div key={key} className="flex flex-col gap-2">
             <span className="text-sm text-text-secondary">{label}</span>

--- a/apps/web/src/lib/useIsMobile.ts
+++ b/apps/web/src/lib/useIsMobile.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function useIsMobile(breakpoint = 768) {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const update = () => setIsMobile(window.innerWidth < breakpoint);
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, [breakpoint]);
+
+  return isMobile;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,17 +6,7 @@ settings:
 
 importers:
 
-  .:
-    dependencies:
-      '@dnd-kit/core':
-        specifier: ^6.3.1
-        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@dnd-kit/sortable':
-        specifier: ^10.0.0
-        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
-      '@dnd-kit/utilities':
-        specifier: ^3.2.2
-        version: 3.2.2(react@19.2.4)
+  .: {}
 
   apps/api:
     dependencies:
@@ -31,7 +21,7 @@ importers:
         version: 7.6.0
       '@prisma/client':
         specifier: ^7.6.0
-        version: 7.6.0(prisma@7.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.6.0(prisma@7.6.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
@@ -86,7 +76,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.2.2
-        version: 16.2.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.2.2(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       prisma:
         specifier: ^7.6.0
         version: 7.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
@@ -135,7 +125,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.2.2
-        version: 16.2.2(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.2.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       tailwindcss:
         specifier: ^4
         version: 4.2.2
@@ -150,7 +140,7 @@ importers:
         version: 7.6.0
       '@prisma/client':
         specifier: ^7.6.0
-        version: 7.6.0(prisma@7.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.6.0(prisma@7.6.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
       pg:
         specifier: ^8.13.3
         version: 8.20.0
@@ -243,28 +233,6 @@ packages:
 
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
-
-  '@dnd-kit/accessibility@3.1.1':
-    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
-    peerDependencies:
-      react: '>=16.8.0'
-
-  '@dnd-kit/core@6.3.1':
-    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-
-  '@dnd-kit/sortable@10.0.0':
-    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
-    peerDependencies:
-      '@dnd-kit/core': ^6.3.0
-      react: '>=16.8.0'
-
-  '@dnd-kit/utilities@3.2.2':
-    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
-    peerDependencies:
-      react: '>=16.8.0'
 
   '@electric-sql/pglite-socket@0.1.1':
     resolution: {integrity: sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==}
@@ -3088,31 +3056,6 @@ snapshots:
 
   '@borewit/text-codec@0.2.2': {}
 
-  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
-    dependencies:
-      react: 19.2.4
-      tslib: 2.8.1
-
-  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
-      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      tslib: 2.8.1
-
-  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
-      react: 19.2.4
-      tslib: 2.8.1
-
-  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
-    dependencies:
-      react: 19.2.4
-      tslib: 2.8.1
-
   '@electric-sql/pglite-socket@0.1.1(@electric-sql/pglite@0.4.1)':
     dependencies:
       '@electric-sql/pglite': 0.4.1
@@ -3439,7 +3382,7 @@ snapshots:
 
   '@prisma/client-runtime-utils@7.6.0': {}
 
-  '@prisma/client@7.6.0(prisma@7.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)':
+  '@prisma/client@7.6.0(prisma@7.6.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@prisma/client-runtime-utils': 7.6.0
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,17 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
 
   apps/api:
     dependencies:
@@ -233,6 +243,28 @@ packages:
 
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@electric-sql/pglite-socket@0.1.1':
     resolution: {integrity: sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==}
@@ -3055,6 +3087,31 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@borewit/text-codec@0.2.2': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
 
   '@electric-sql/pglite-socket@0.1.1(@electric-sql/pglite@0.4.1)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         version: 7.6.0
       '@prisma/client':
         specifier: ^7.6.0
-        version: 7.6.0(prisma@7.6.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.6.0(prisma@7.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
@@ -76,7 +76,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.2.2
-        version: 16.2.2(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.2.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       prisma:
         specifier: ^7.6.0
         version: 7.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
@@ -86,6 +86,15 @@ importers:
 
   apps/web:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@rhwp/editor':
         specifier: ^0.7.11
         version: 0.7.11
@@ -125,7 +134,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.2.2
-        version: 16.2.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.2.2(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       tailwindcss:
         specifier: ^4
         version: 4.2.2
@@ -140,7 +149,7 @@ importers:
         version: 7.6.0
       '@prisma/client':
         specifier: ^7.6.0
-        version: 7.6.0(prisma@7.6.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.6.0(prisma@7.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
       pg:
         specifier: ^8.13.3
         version: 8.20.0
@@ -233,6 +242,28 @@ packages:
 
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@electric-sql/pglite-socket@0.1.1':
     resolution: {integrity: sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==}
@@ -3056,6 +3087,31 @@ snapshots:
 
   '@borewit/text-codec@0.2.2': {}
 
+  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
   '@electric-sql/pglite-socket@0.1.1(@electric-sql/pglite@0.4.1)':
     dependencies:
       '@electric-sql/pglite': 0.4.1
@@ -3382,7 +3438,7 @@ snapshots:
 
   '@prisma/client-runtime-utils@7.6.0': {}
 
-  '@prisma/client@7.6.0(prisma@7.6.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)':
+  '@prisma/client@7.6.0(prisma@7.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@prisma/client-runtime-utils': 7.6.0
     optionalDependencies:


### PR DESCRIPTION
## Summary

- `useIsMobile` 훅으로 `window.innerWidth`를 직접 감지해 CSS `@layer utilities` 미디어쿼리 누락 문제 우회
- **랜딩 navbar**: `LandingNavbarInner` (신규 Client Component) — 768px 미만이면 햄버거, 이상이면 데스크탑 nav + 로그인 버튼
- **대시보드 navbar**: `onMenuToggle`을 모바일일 때만 전달 → 햄버거 버튼 JS 조건부 렌더링
- **대시보드 사이드바**: `isMobile` prop으로 데스크탑 aside / 모바일 드롭다운 전환, CSS `hidden md:flex` 제거
- 어드민 테이블·그리드 반응형(`overflow-x-auto`, `whitespace-nowrap`, `grid-cols-*`) 유지

## Test plan

- [ ] 데스크탑(≥768px): 랜딩 nav 항목 + 로그인 버튼 노출, 햄버거 없음
- [ ] 모바일(<768px): 햄버거만 노출, 클릭 시 드롭다운 펼쳐짐
- [ ] 대시보드 데스크탑: 좌측 사이드바 표시, 햄버거 없음
- [ ] 대시보드 모바일: 사이드바 없음, navbar 햄버거 → 드롭다운
- [ ] 어드민 테이블 모바일: 가로 스크롤 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)