### PR TITLE
feat(#195): 정성 페이지 활동 카드 드래그 순서 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ out/
 
 # superpowers (local design/plan docs)
 /.superpowers/
+/docs/superpowers/
 
 # 로컬 작업 로그 (#176 등 — 원격에 안 올림)
 /docs/2026-05-11-176-fe-work.md

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,17 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
 
   apps/api:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,17 +6,7 @@ settings:
 
 importers:
 
-  .:
-    dependencies:
-      '@dnd-kit/core':
-        specifier: ^6.3.1
-        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@dnd-kit/sortable':
-        specifier: ^10.0.0
-        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
-      '@dnd-kit/utilities':
-        specifier: ^3.2.2
-        version: 3.2.2(react@19.2.4)
+  .: {}
 
   apps/api:
     dependencies:
@@ -31,7 +21,7 @@ importers:
         version: 7.6.0
       '@prisma/client':
         specifier: ^7.6.0
-        version: 7.6.0(prisma@7.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.6.0(prisma@7.6.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
@@ -86,7 +76,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.2.2
-        version: 16.2.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.2.2(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       prisma:
         specifier: ^7.6.0
         version: 7.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
@@ -144,7 +134,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.2.2
-        version: 16.2.2(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.2.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       tailwindcss:
         specifier: ^4
         version: 4.2.2
@@ -159,7 +149,7 @@ importers:
         version: 7.6.0
       '@prisma/client':
         specifier: ^7.6.0
-        version: 7.6.0(prisma@7.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.6.0(prisma@7.6.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
       pg:
         specifier: ^8.13.3
         version: 8.20.0
@@ -3448,7 +3438,7 @@ snapshots:
 
   '@prisma/client-runtime-utils@7.6.0': {}
 
-  '@prisma/client@7.6.0(prisma@7.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)':
+  '@prisma/client@7.6.0(prisma@7.6.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@prisma/client-runtime-utils': 7.6.0
     optionalDependencies:


### PR DESCRIPTION
## Summary

- 정성 데이터 페이지의 교내/대외/사회경험/자격·시험 탭에서 활동 카드를 드래그하여 순서 변경 기능 추가
- 카드 좌측 드래그 핸들(≡)을 클릭/드래그하여 같은 카테고리 내에서 순서 변경 가능
- 드롭 후 즉시 서버 저장 (낙관적 업데이트 + 실패 시 롤백)
- 모바일 터치 지원 (250ms 길게 누르면 드래그 활성화)

## Changes

- **`@dnd-kit/core` + `@dnd-kit/sortable`** 패키지 추가
- **`QualitativeClient.tsx`**: `SortableActivityCard` 컴포넌트, `handleReorder` 함수, DnD context 추가
- **`apps/api/.../qualitative/route.ts`**: PATCH에 `reorderMapping` 처리 추가 — 순서 변경 시 `star_analysis.activity_index` 및 `star_input_hashes` 재매핑
- **`apps/web/src/lib/api.ts`**: `patchQualitative` body에 `reorderMapping?: number[]` 추가

## Behavior

- 활동 1개 이하이거나 편집/저장 중일 때는 드래그 비활성화
- 카테고리 간 이동 불가 (같은 탭 내에서만)
- 서버 저장 실패 시 자동 롤백

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)