### PR TITLE
fix(security): /api/mentee/grades CORS wildcard 제거 + 입력 검증 (#181)

### DIFF
--- a/apps/api/src/app/api/mentee/grades/route.ts
+++ b/apps/api/src/app/api/mentee/grades/route.ts
@@ -1,43 +1,85 @@
-import { NextResponse } from 'next/server';
-import { spawn } from 'child_process';
-import { readFileSync, unlinkSync, existsSync } from 'fs';
-import { join } from 'path';
-import { tmpdir } from 'os';
+import { NextRequest, NextResponse } from "next/server";
+import { spawn } from "child_process";
+import { readFileSync, unlinkSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { getTokenFromCookie } from "@/lib/auth";
 
-const CORS = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type',
-};
+const ID_PATTERN = /^[A-Za-z0-9._@-]{1,32}$/;
+const PW_MAX_LEN = 128;
+const RATE_LIMIT_WINDOW_MS = 60_000;
 
-export async function OPTIONS() {
-  return new NextResponse(null, { status: 204, headers: CORS });
+const lastCallByUser = new Map<string, number>();
+
+function validateCredentials(id: unknown, pw: unknown): { ok: true } | { ok: false; error: string } {
+  if (typeof id !== "string" || typeof pw !== "string") {
+    return { ok: false, error: "ID와 비밀번호를 입력해주세요." };
+  }
+  if (!ID_PATTERN.test(id)) {
+    return { ok: false, error: "ID 형식이 올바르지 않습니다." };
+  }
+  if (pw.length < 1 || pw.length > PW_MAX_LEN) {
+    return { ok: false, error: "비밀번호 길이가 올바르지 않습니다." };
+  }
+  // 제어문자 차단
+  if (/[\x00-\x1f]/.test(pw)) {
+    return { ok: false, error: "비밀번호에 허용되지 않은 문자가 포함되어 있습니다." };
+  }
+  // argparse 옵션 인젝션 차단 (`--`-prefix)
+  if (id.startsWith("--") || pw.startsWith("--")) {
+    return { ok: false, error: "허용되지 않은 형식입니다." };
+  }
+  return { ok: true };
 }
 
-export async function POST(req: Request) {
-  const { id, pw } = await req.json();
-
-  if (!id || !pw) {
-    return NextResponse.json({ error: 'ID와 비밀번호를 입력해주세요.' }, { status: 400, headers: CORS });
+export async function POST(req: NextRequest) {
+  const token = getTokenFromCookie(req);
+  if (!token) {
+    return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
   }
 
+  const now = Date.now();
+  const last = lastCallByUser.get(token.user_id) ?? 0;
+  if (now - last < RATE_LIMIT_WINDOW_MS) {
+    const retryAfter = Math.ceil((RATE_LIMIT_WINDOW_MS - (now - last)) / 1000);
+    return NextResponse.json(
+      { error: `잠시 후 다시 시도해주세요. (${retryAfter}초)` },
+      { status: 429, headers: { "Retry-After": String(retryAfter) } },
+    );
+  }
+  lastCallByUser.set(token.user_id, now);
+
+  let body: { id?: unknown; pw?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "요청 형식이 올바르지 않습니다." }, { status: 400 });
+  }
+
+  const validation = validateCredentials(body.id, body.pw);
+  if (!validation.ok) {
+    return NextResponse.json({ error: validation.error }, { status: 400 });
+  }
+  const id = body.id as string;
+  const pw = body.pw as string;
+
   const outputFile = join(tmpdir(), `grades_${Date.now()}.csv`);
-  const scriptPath = join(process.cwd(), '../../tools/scrape_grades.py');
+  const scriptPath = join(process.cwd(), "../../tools/scrape_grades.py");
 
   const rows = await new Promise<Record<string, string>[] | null>((resolve) => {
-    const proc = spawn('python3', [scriptPath, outputFile, '--id', id, '--pw', pw]);
+    const proc = spawn("python3", [scriptPath, outputFile, "--id", id, "--pw", pw]);
 
-    let stderr = '';
-    proc.stderr.on('data', (d: Buffer) => { stderr += d.toString(); });
+    let stderr = "";
+    proc.stderr.on("data", (d: Buffer) => { stderr += d.toString(); });
 
-    proc.on('close', (code) => {
+    proc.on("close", (code) => {
       if (code !== 0 || !existsSync(outputFile)) {
-        console.error('scrape_grades stderr:', stderr);
+        console.error("scrape_grades stderr:", stderr);
         resolve(null);
         return;
       }
       try {
-        const csv = readFileSync(outputFile, 'utf-8');
+        const csv = readFileSync(outputFile, "utf-8");
         unlinkSync(outputFile);
         resolve(parseCSV(csv));
       } catch {
@@ -48,21 +90,21 @@ export async function POST(req: Request) {
 
   if (!rows) {
     return NextResponse.json(
-      { error: '로그인에 실패했거나 성적을 불러올 수 없습니다.' },
-      { status: 401, headers: CORS },
+      { error: "로그인에 실패했거나 성적을 불러올 수 없습니다." },
+      { status: 401 },
     );
   }
 
-  return NextResponse.json({ rows }, { headers: CORS });
+  return NextResponse.json({ rows });
 }
 
 function parseCSV(csv: string): Record<string, string>[] {
-  const lines = csv.replace(/\r/g, '').split('\n').filter(Boolean);
+  const lines = csv.replace(/\r/g, "").split("\n").filter(Boolean);
   if (lines.length < 2) return [];
 
-  const headers = lines[0].split(',');
+  const headers = lines[0].split(",");
   return lines.slice(1).map((line) => {
-    const values = line.split(',');
-    return Object.fromEntries(headers.map((h, i) => [h.trim(), (values[i] ?? '').trim()]));
+    const values = line.split(",");
+    return Object.fromEntries(headers.map((h, i) => [h.trim(), (values[i] ?? "").trim()]));
   });
 }


### PR DESCRIPTION
## Summary
  - 외부 origin 의 자유로운 호출 차단 (CORS wildcard 제거)
  - 자식 프로세스 인자 안전화 (입력 검증 + argparse 옵션 인젝션 방어)
  - 학교 포털 차단 회피 (사용자별 rate limit 분당 1회)

  > **자격증명 릴레이 자체의 위험** (학교 SSO id/pw 평문 수신·외부 포털 자동 로그인) 은 본 PR 스코프 외. 별도 이슈로 분리 권장 — vault 모델 도입 (스키마 변경·암호화 키 관리 등 큰 작업).

  ## 변경 사항

  **파일**: `apps/api/src/app/api/mentee/grades/route.ts` (단일 파일)

  | 항목 | 변경 |
  |---|---|
  | 자체 CORS 헤더 (`Access-Control-Allow-Origin: '*'`) | 삭제 |
  | `OPTIONS` 핸들러 | 삭제 (proxy.ts 가 preflight 처리) |
  | 인증 가드 | `getTokenFromCookie` 로 명시화 (proxy.ts 의 mentee role 가드는 그대로) |
  | id/pw 검증 | 패턴(`^[A-Za-z0-9._@-]{1,32}$`) / 길이(pw ≤ 128) / 제어문자 / `--` prefix 차단 |
  | Rate limit | 사용자별 분당 1회 (in-memory Map) |
  | 응답 status code | 401 / 429 / 400 명확화 |

  ## 보안 효과

  - **CORS wildcard 제거**: proxy.ts 의 origin allowlist 가 일관적으로 적용됨. 허용 외 origin 의 응답에는 `Access-Control-Allow-Origin` 헤더가 부재 → 브라우저가 자동 차단.
  - **CLI 인자 인젝션 방어**: `spawn` array form 으로 shell injection 은 원래 차단되어 있었지만, argparse 의 `--`-prefix 옵션 우회 가능성 제거.
  - **DoS / 학교 차단 회피**: 분당 1회 제한으로 동일 사용자 반복 호출 차단 (학교 측 IP 차단·계정 잠금 회피).

  ## 검증

  - `pnpm exec tsc --noEmit` (apps/api) — 0 errors
  - `pnpm run lint` (apps/api) — 0 errors, 2 pre-existing warnings (본 변경 무관)
  - dev 서버 (`http://localhost:3001`) curl 3종:

  ```
  # Test 1: EVIL origin OPTIONS
  $ curl -i -X OPTIONS http://localhost:3001/api/mentee/grades \
    -H "Origin: https://evil.com" -H "Access-Control-Request-Method: POST"
  HTTP/1.1 204 No Content
  # → access-control-allow-origin 헤더 부재 (브라우저 차단)

  # Test 2: ALLOWED origin OPTIONS
  $ curl -i -X OPTIONS http://localhost:3001/api/mentee/grades \
    -H "Origin: http://localhost:3000" -H "Access-Control-Request-Method: POST"
  HTTP/1.1 204 No Content
  access-control-allow-origin: http://localhost:3000   # ← 정확히 echo

  # Test 3: 인증 없는 POST
  $ curl -i -X POST http://localhost:3001/api/mentee/grades \
    -H "Content-Type: application/json" -d '{"id":"test","pw":"test"}'
  HTTP/1.1 401 Unauthorized   # ← proxy.ts mentee 가드
  ```

  ## 후속 작업 (별도 이슈)

  - **`grades 자격증명 vault 모델`** — 학교 SSO id/pw 를 매 요청마다 평문 수신하는 구조 자체 재설계. 1회 수집 → KMS/pgcrypto 암호화 저장 → 백엔드만 복호화. 스키마 변경·암호화 키 관리·재발급 흐름 등 별도 spec 필요.
  - **Rate limit 인프라 통합** — 본 PR 은 in-memory Map (단일 인스턴스 한정). vault 이슈 또는 별도 PR 에서 Upstash Redis 같은 중앙 저장소로 전환.