### PR TITLE
feat(#205): 희망 진로 자유 입력 지원

### DIFF
--- a/apps/api/src/app/api/mentee/qualitative/route.ts
+++ b/apps/api/src/app/api/mentee/qualitative/route.ts
@@ -17,16 +17,6 @@ function getProcessYear(req: NextRequest): number {
   return match ? parseInt(match[0]) : new Date().getFullYear();
 }
 
-const CAREER_LABEL: Record<string, string> = {
-  lawyer: "변호사",
-  prosecutor: "검사",
-  judge: "판사",
-};
-const CAREER_ENUM: Record<string, "lawyer" | "prosecutor" | "judge"> = {
-  변호사: "lawyer",
-  검사: "prosecutor",
-  판사: "judge",
-};
 
 type ActivityForm = {
   name: string;
@@ -101,7 +91,7 @@ function buildResponse(record: FullRecord, extras?: { inlineStar?: StarItem; inl
   const starAnalysis = (record?.star_analysis ?? null) as StarAnalysisJson | null;
 
   return {
-    careerGoal: record?.career_goal ? CAREER_LABEL[record.career_goal] ?? "" : "",
+    careerGoal: record?.career_goal ?? "",
     activities,
     analysis: {
       isAnalyzed: record?.is_ai_analyzed ?? false,
@@ -188,7 +178,7 @@ async function handleJsonPatch(req: NextRequest, userId: string, processYear: nu
 
   const updateData: Record<string, unknown> = {};
   if (body.careerGoal !== undefined) {
-    updateData.career_goal = body.careerGoal ? CAREER_ENUM[body.careerGoal] ?? null : null;
+    updateData.career_goal = body.careerGoal || null;
   }
   if (body.activities !== undefined) {
     updateData.qualitative_activities = body.activities;
@@ -318,7 +308,7 @@ async function handleMultipartPatch(req: NextRequest, userId: string, processYea
     qualitative_activities: mergedActivities,
   };
   if (payload.careerGoal !== undefined) {
-    updateData.career_goal = payload.careerGoal ? CAREER_ENUM[payload.careerGoal] ?? null : null;
+    updateData.career_goal = payload.careerGoal || null;
   }
 
   await prisma.menteeRecord.upsert({

--- a/apps/web/src/app/mentee/dashboard/qualitative/QualitativeClient.tsx
+++ b/apps/web/src/app/mentee/dashboard/qualitative/QualitativeClient.tsx
@@ -14,7 +14,8 @@ type CategoryTab = Exclude<Tab, '대시보드'>;
 const DEFAULT_CATEGORY: ActivityCategory = '교내';
 
 const CAREER_OPTIONS = ['변호사', '검사', '판사'] as const;
-type CareerGoal = typeof CAREER_OPTIONS[number] | '';
+type PresetOption = typeof CAREER_OPTIONS[number];
+type CareerGoal = string;
 
 type ActivityForm = QualitativeActivity;
 
@@ -526,15 +527,33 @@ function CareerGoalCard({
   value: CareerGoal;
   onSave: (value: CareerGoal) => Promise<void>;
 }) {
+  const isPreset = (v: string): v is PresetOption => (CAREER_OPTIONS as readonly string[]).includes(v);
+
   const [isEditing, setIsEditing] = useState(false);
-  const [draft, setDraft] = useState<CareerGoal>(value);
+  const [draftOption, setDraftOption] = useState<PresetOption | '기타' | ''>(() =>
+    isPreset(value) ? value : value ? '기타' : ''
+  );
+  const [draftCustom, setDraftCustom] = useState(() => (isPreset(value) || !value ? '' : value));
   const [saving, setSaving] = useState(false);
 
-  function startEdit() { setDraft(value); setIsEditing(true); }
-  function handleCancel() { setDraft(value); setIsEditing(false); }
+  function startEdit() {
+    setDraftOption(isPreset(value) ? value : value ? '기타' : '');
+    setDraftCustom(isPreset(value) || !value ? '' : value);
+    setIsEditing(true);
+  }
+  function handleCancel() { setIsEditing(false); }
   async function handleSave() {
+    const toSave = draftOption === '기타' ? draftCustom : draftOption;
     setSaving(true);
-    try { await onSave(draft); setIsEditing(false); } finally { setSaving(false); }
+    try { await onSave(toSave); setIsEditing(false); } finally { setSaving(false); }
+  }
+
+  function handleOptionClick(option: PresetOption | '기타') {
+    if (option === '기타') {
+      setDraftOption(draftOption === '기타' ? '' : '기타');
+    } else {
+      setDraftOption(draftOption === option ? '' : option);
+    }
   }
 
   return (
@@ -545,21 +564,32 @@ function CareerGoalCard({
           ? <EditButtons onCancel={handleCancel} onSave={handleSave} disabled={saving} />
           : <EditButton onClick={startEdit} />}
       </div>
-      <div className="min-h-[40px] flex items-center">
+      <div className="min-h-[40px] flex flex-col gap-3">
         {isEditing ? (
-          <div className="flex gap-2">
-            {CAREER_OPTIONS.map((option) => {
-              const selected = draft === option;
-              return (
-                <button key={option} type="button" onClick={() => setDraft(selected ? '' : option)}
-                  className={`px-5 py-2 text-sm font-medium rounded-md border transition-colors ${
-                    selected ? 'bg-brand text-white border-brand' : 'bg-transparent text-text-secondary border-border hover:border-brand hover:text-text-primary'
-                  }`}>
-                  {option}
-                </button>
-              );
-            })}
-          </div>
+          <>
+            <div className="flex gap-2">
+              {([...CAREER_OPTIONS, '기타'] as const).map((option) => {
+                const selected = draftOption === option;
+                return (
+                  <button key={option} type="button" onClick={() => handleOptionClick(option)}
+                    className={`px-5 py-2 text-sm font-medium rounded-md border transition-colors ${
+                      selected ? 'bg-brand text-white border-brand' : 'bg-transparent text-text-secondary border-border hover:border-brand hover:text-text-primary'
+                    }`}>
+                    {option}
+                  </button>
+                );
+              })}
+            </div>
+            {draftOption === '기타' && (
+              <input
+                type="text"
+                value={draftCustom}
+                onChange={(e) => setDraftCustom(e.target.value)}
+                placeholder="희망 진로를 입력하세요"
+                className="w-full max-w-sm px-4 py-2 text-sm border border-border rounded-md focus:outline-none focus:border-brand"
+              />
+            )}
+          </>
         ) : (
           <p className={`text-base ${value ? 'text-text-primary' : 'text-text-placeholder'}`}>
             {value || '선택되지 않음'}
@@ -963,7 +993,7 @@ function EmptyDashboard({ onAdd }: { onAdd: () => void }) {
 export default function QualitativeClient({ initialData }: { initialData?: QualitativeData }) {
   const didInitRef = useRef(false);
   const [activeTab, setActiveTab] = useState<Tab>('대시보드');
-  const [careerGoal, setCareerGoal] = useState<CareerGoal>((initialData?.careerGoal as CareerGoal) || '');
+  const [careerGoal, setCareerGoal] = useState<CareerGoal>(initialData?.careerGoal || '');
   const [serverActivities, setServerActivities] = useState<ActivityForm[]>(
     (initialData?.activities ?? []).map((a) => ({ ...a, category: a.category ?? DEFAULT_CATEGORY }))
   );

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -337,7 +337,7 @@ export type StoryOutline = {
 };
 
 export type QualitativeData = {
-  careerGoal: "변호사" | "검사" | "판사" | "";
+  careerGoal: string;
   activities: QualitativeActivity[];
   analysis: {
     isAnalyzed: boolean;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -43,12 +43,6 @@ enum MilitaryStatus {
   not_applicable // 해당없음 (여성 등)
 }
 
-enum CareerGoal {
-  lawyer // 변호사
-  prosecutor // 검사
-  judge // 판사
-}
-
 enum AccountStatus {
   active
   inactive
@@ -183,7 +177,7 @@ model MenteeRecord {
   qualitative_activities Json? // { volunteer, conference, thesis, club, external }
   core_keywords          String?     @db.VarChar(500)
   story_summary          String?     @db.Text
-  career_goal            CareerGoal? // 변호사 / 검사 / 판사 (정성 대시보드 선택)
+  career_goal            String?     @db.Text
 
   // AI 분석 결과 (LLM Output)
   star_analysis     Json? // STAR 구조화 결과 — 단일 활동 분석 결과 누적


### PR DESCRIPTION
## Summary
- `CareerGoal` enum 제거, `career_goal` 컬럼을 `String`으로 전환
- 변호사/검사/판사는 버튼 선택, 기타는 직접 텍스트 입력
- BE에서 enum 변환 로직(CAREER_LABEL/CAREER_ENUM) 제거 — 값 그대로 저장

## DB 작업 필요 (별도 실행)
```sql
ALTER TABLE "mentee_records"
  ALTER COLUMN "career_goal" TYPE TEXT USING
    CASE career_goal::TEXT
      WHEN 'lawyer'     THEN '변호사'
      WHEN 'prosecutor' THEN '검사'
      WHEN 'judge'      THEN '판사'
      ELSE NULL
    END;

DROP TYPE "CareerGoal";
```
이후 `pnpm db:generate` 실행

## Test plan
- [ ] 변호사/검사/판사 버튼 선택 후 저장 확인
- [ ] 기타 버튼 클릭 시 텍스트 입력창 등장 확인
- [ ] 기타 입력 후 저장 확인
- [ ] 저장된 값이 다음 방문 시 올바르게 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)