### PR TITLE
feat: 멘티/멘토 지난기록 페이지 구현

### DIFF
--- a/apps/api/src/app/api/mentee/history/years/route.ts
+++ b/apps/api/src/app/api/mentee/history/years/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@plawcess/database";
+import { getTokenFromCookie } from "@/lib/auth";
+
+export async function GET(req: NextRequest) {
+  const userId = getTokenFromCookie(req)?.user_id;
+  if (!userId) {
+    return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
+  }
+
+  const records = await prisma.menteeRecord.findMany({
+    where: { user_id: userId },
+    select: { process_year: true },
+    orderBy: { process_year: "desc" },
+  });
+
+  return NextResponse.json({ years: records.map((r) => r.process_year) });
+}

--- a/apps/api/src/app/api/mentee/history/years/route.ts
+++ b/apps/api/src/app/api/mentee/history/years/route.ts
@@ -11,6 +11,7 @@ export async function GET(req: NextRequest) {
   const records = await prisma.menteeRecord.findMany({
     where: { user_id: userId },
     select: { process_year: true },
+    distinct: ["process_year"],
     orderBy: { process_year: "desc" },
   });
 

--- a/apps/web/src/app/mentee/dashboard/personal-statement/PersonalStatementClient.tsx
+++ b/apps/web/src/app/mentee/dashboard/personal-statement/PersonalStatementClient.tsx
@@ -27,9 +27,11 @@ type Mode = 'hwp' | 'text';
 export default function PersonalStatementClient({
   initialData,
   year,
+  readOnly,
 }: {
   initialData: PersonalStatementData;
   year: string;
+  readOnly?: boolean;
 }) {
   const [activeTab, setActiveTab] = useState<Group>(() =>
     initialData.ga.school ? 'ga' : 'na',
@@ -67,6 +69,7 @@ export default function PersonalStatementClient({
   useEffect(() => {
     const id = setInterval(async () => {
       if (isSavingRef.current) return;
+      if (readOnly) return;
       isSavingRef.current = true;
       setAutoSaving(true);
       try {
@@ -220,8 +223,8 @@ export default function PersonalStatementClient({
           <p className="text-sm text-text-secondary mt-1">지망 로스쿨 자기소개서를 편집하고 저장하세요</p>
         </div>
         <div className="flex items-center gap-3">
-          {statusText && <span className="text-xs text-text-placeholder">{statusText}</span>}
-          {mode === 'hwp' && activeGroup.hwp && (
+          {!readOnly && statusText && <span className="text-xs text-text-placeholder">{statusText}</span>}
+          {!readOnly && mode === 'hwp' && activeGroup.hwp && (
             <button
               onClick={handleDownload}
               className="px-4 py-2 text-sm font-medium text-text-secondary bg-page-bg rounded-lg hover:bg-gray-200 transition-colors"
@@ -229,13 +232,15 @@ export default function PersonalStatementClient({
               다운로드
             </button>
           )}
-          <button
-            onClick={handleSave}
-            disabled={saving || autoSaving}
-            className="px-4 py-2 text-sm font-medium text-white bg-brand rounded-lg hover:bg-brand-dark transition-colors disabled:opacity-50"
-          >
-            {saving ? '저장 중...' : '저장'}
-          </button>
+          {!readOnly && (
+            <button
+              onClick={handleSave}
+              disabled={saving || autoSaving}
+              className="px-4 py-2 text-sm font-medium text-white bg-brand rounded-lg hover:bg-brand-dark transition-colors disabled:opacity-50"
+            >
+              {saving ? '저장 중...' : '저장'}
+            </button>
+          )}
         </div>
       </div>
 
@@ -259,20 +264,22 @@ export default function PersonalStatementClient({
       )}
 
       {/* 모드 토글 */}
-      <div className="flex items-center gap-1 self-start p-1 bg-gray-100 rounded-lg border border-border">
-        <ModeButton active={mode === 'hwp'} onClick={() => setMode('hwp')}>
-          HWP 에디터
-        </ModeButton>
-        <ModeButton active={mode === 'text'} onClick={() => setMode('text')}>
-          문항별 작성
-        </ModeButton>
-      </div>
+      {!readOnly && (
+        <div className="flex items-center gap-1 self-start p-1 bg-gray-100 rounded-lg border border-border">
+          <ModeButton active={mode === 'hwp'} onClick={() => setMode('hwp')}>
+            HWP 에디터
+          </ModeButton>
+          <ModeButton active={mode === 'text'} onClick={() => setMode('text')}>
+            문항별 작성
+          </ModeButton>
+        </div>
+      )}
 
       {/* 콘텐츠 */}
       {tabs.map(({ group }) =>
         activeTab === group && (
           <div key={group}>
-            {mode === 'hwp' ? (
+            {!readOnly && mode === 'hwp' ? (
               activeGroup.hwp ? (
                 <>
                   <div className="sm:hidden bg-amber-50 border border-amber-200 rounded-xl px-5 py-4 text-sm text-amber-800">
@@ -316,13 +323,19 @@ export default function PersonalStatementClient({
                         )}
                       </div>
 
-                      <textarea
-                        value={text}
-                        onChange={(e) => handleTextChange(group, q.id, e.target.value)}
-                        rows={6}
-                        className="w-full px-3 py-2 text-sm border border-border rounded-lg resize-y focus:outline-none focus:border-brand placeholder:text-text-placeholder"
-                        placeholder="내용을 입력하세요"
-                      />
+                      {readOnly ? (
+                        <p className="text-sm text-text-primary whitespace-pre-wrap leading-relaxed min-h-[80px] py-2">
+                          {text || <span className="text-text-placeholder">작성된 내용이 없습니다.</span>}
+                        </p>
+                      ) : (
+                        <textarea
+                          value={text}
+                          onChange={(e) => handleTextChange(group, q.id, e.target.value)}
+                          rows={6}
+                          className="w-full px-3 py-2 text-sm border border-border rounded-lg resize-y focus:outline-none focus:border-brand placeholder:text-text-placeholder"
+                          placeholder="내용을 입력하세요"
+                        />
+                      )}
 
                       {/* 글자수 진행바 + 카운터 */}
                       <div className="mt-2 flex flex-col gap-1">

--- a/apps/web/src/app/mentee/dashboard/qualitative/QualitativeClient.tsx
+++ b/apps/web/src/app/mentee/dashboard/qualitative/QualitativeClient.tsx
@@ -1507,7 +1507,7 @@ export default function QualitativeClient({ initialData, year, readOnly }: { ini
             </div>
           </SortableContext>
         </DndContext>
-        {draftList.map((form, i) => (
+        {!readOnly && draftList.map((form, i) => (
           <ActivityFormCard
             key={`draft-${i}`}
             form={form}

--- a/apps/web/src/app/mentee/dashboard/qualitative/QualitativeClient.tsx
+++ b/apps/web/src/app/mentee/dashboard/qualitative/QualitativeClient.tsx
@@ -544,9 +544,11 @@ function AddItemPlaceholder({ onClick }: { onClick: () => void }) {
 function CareerGoalCard({
   value,
   onSave,
+  readOnly,
 }: {
   value: CareerGoal;
   onSave: (value: CareerGoal) => Promise<void>;
+  readOnly?: boolean;
 }) {
   const isPreset = (v: string): v is PresetOption => (CAREER_OPTIONS as readonly string[]).includes(v);
 
@@ -581,9 +583,9 @@ function CareerGoalCard({
     <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-base font-semibold text-text-primary">희망 진로</h2>
-        {isEditing
+        {!readOnly && (isEditing
           ? <EditButtons onCancel={handleCancel} onSave={handleSave} disabled={saving} />
-          : <EditButton onClick={startEdit} />}
+          : <EditButton onClick={startEdit} />)}
       </div>
       <div className="min-h-[40px] flex flex-col gap-3">
         {isEditing ? (
@@ -672,8 +674,8 @@ function ActivityCard({
   star?: StarItem;
   expanded: boolean;
   onToggle: () => void;
-  onEdit: () => void;
-  onDelete: () => void;
+  onEdit?: () => void;
+  onDelete?: () => void;
   deleting: boolean;
   isAnalyzing?: boolean;
 }) {
@@ -690,15 +692,17 @@ function ActivityCard({
       <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
         <div className="flex items-start justify-between gap-3">
           <h2 className="text-lg font-semibold text-text-primary">{activity.name}</h2>
-          <button
-            onClick={onDelete}
-            disabled={deleting}
-            aria-label="활동 삭제"
-            title="활동 삭제"
-            className="shrink-0 p-2 -mr-2 -mt-1 rounded-md text-text-placeholder hover:text-red-500 hover:bg-red-50 transition-colors disabled:opacity-40"
-          >
-            <IconTrash />
-          </button>
+          {onDelete && (
+            <button
+              onClick={onDelete}
+              disabled={deleting}
+              aria-label="활동 삭제"
+              title="활동 삭제"
+              className="shrink-0 p-2 -mr-2 -mt-1 rounded-md text-text-placeholder hover:text-red-500 hover:bg-red-50 transition-colors disabled:opacity-40"
+            >
+              <IconTrash />
+            </button>
+          )}
         </div>
         <div className="flex items-center gap-4 mt-2 text-sm text-text-secondary">
           <span className="flex items-center gap-1.5"><IconBuilding /> {activity.organization || '-'}</span>
@@ -736,11 +740,13 @@ function ActivityCard({
           </div>
         )}
         <hr className="border-border my-5" />
-        <div className="grid grid-cols-2 gap-3">
-          <button onClick={onEdit}
-            className="flex items-center justify-center gap-2 py-2.5 text-sm text-text-secondary bg-page-bg rounded-md hover:bg-gray-200 transition-colors">
-            <IconPencil /> 수정
-          </button>
+        <div className={`grid gap-3 ${onEdit ? 'grid-cols-2' : 'grid-cols-1'}`}>
+          {onEdit && (
+            <button onClick={onEdit}
+              className="flex items-center justify-center gap-2 py-2.5 text-sm text-text-secondary bg-page-bg rounded-md hover:bg-gray-200 transition-colors">
+              <IconPencil /> 수정
+            </button>
+          )}
           <button onClick={onToggle} disabled={!star}
             className="flex items-center justify-center gap-2 py-2.5 text-sm text-text-secondary bg-page-bg rounded-md hover:bg-gray-200 transition-colors disabled:opacity-40">
             <IconClipboard /> STAR 분석 {expanded ? '접기' : '펼치기'} <IconChevron open={expanded} />
@@ -1040,7 +1046,7 @@ function EmptyDashboard({ onAdd }: { onAdd: () => void }) {
 // ================================================================
 // 페이지
 // ================================================================
-export default function QualitativeClient({ initialData, year }: { initialData?: QualitativeData; year: string }) {
+export default function QualitativeClient({ initialData, year, readOnly }: { initialData?: QualitativeData; year: string; readOnly?: boolean }) {
   const didInitRef = useRef(false);
   const [activeTab, setActiveTab] = useState<Tab>('대시보드');
   const [careerGoal, setCareerGoal] = useState<CareerGoal>(initialData?.careerGoal || '');
@@ -1395,8 +1401,14 @@ export default function QualitativeClient({ initialData, year }: { initialData?:
     if (serverActivities.length === 0) {
       return (
         <div className="flex flex-col gap-6 page-container">
-          <CareerGoalCard value={careerGoal} onSave={handleCareerGoalSave} />
-          <EmptyDashboard onAdd={() => setActiveTab('교내')} />
+          <CareerGoalCard value={careerGoal} onSave={handleCareerGoalSave} readOnly={readOnly} />
+          {readOnly ? (
+            <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-16 flex items-center justify-center">
+              <p className="text-text-secondary text-sm">이 연도에 작성한 활동 내역이 없습니다.</p>
+            </div>
+          ) : (
+            <EmptyDashboard onAdd={() => setActiveTab('교내')} />
+          )}
         </div>
       );
     }
@@ -1409,15 +1421,17 @@ export default function QualitativeClient({ initialData, year }: { initialData?:
 
     return (
       <div className="flex flex-col gap-6">
-        <SummaryAnalysisCard
-          state={summaryState}
-          analyzedAt={analysis?.analyzedAt ?? null}
-          onAnalyze={handleSummarize}
-          loading={summarizing}
-        />
+        {!readOnly && (
+          <SummaryAnalysisCard
+            state={summaryState}
+            analyzedAt={analysis?.analyzedAt ?? null}
+            onAnalyze={handleSummarize}
+            loading={summarizing}
+          />
+        )}
         <div className="grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-6 relative">
           <div className="flex flex-col gap-6 min-w-0">
-            <CareerGoalCard value={careerGoal} onSave={handleCareerGoalSave} />
+            <CareerGoalCard value={careerGoal} onSave={handleCareerGoalSave} readOnly={readOnly} />
             <ActivityListTable
               activities={serverActivities}
               starByIdx={findStar}
@@ -1478,13 +1492,13 @@ export default function QualitativeClient({ initialData, year }: { initialData?:
                   <SortableActivityCard
                     key={`saved-${x.idx}`}
                     id={String(x.idx)}
-                    sortDisabled={sortDisabled}
+                    sortDisabled={sortDisabled || !!readOnly}
                     activity={x.activity}
                     star={findStar(x.idx)}
                     expanded={expandedSet.has(x.idx)}
                     onToggle={() => toggleExpand(x.idx)}
-                    onEdit={() => startEdit(x.idx)}
-                    onDelete={() => deleteActivity(x.idx)}
+                    onEdit={readOnly ? undefined : () => startEdit(x.idx)}
+                    onDelete={readOnly ? undefined : () => deleteActivity(x.idx)}
                     deleting={deletingIdx === x.idx}
                     isAnalyzing={analyzingIdx === x.idx}
                   />
@@ -1517,7 +1531,7 @@ export default function QualitativeClient({ initialData, year }: { initialData?:
             submitting={submitting}
           />
         ))}
-        <AddItemPlaceholder onClick={() => addDraft(category)} />
+        {!readOnly && <AddItemPlaceholder onClick={() => addDraft(category)} />}
       </div>
     );
   }

--- a/apps/web/src/app/mentee/dashboard/quantitative/QuantitativeClient.tsx
+++ b/apps/web/src/app/mentee/dashboard/quantitative/QuantitativeClient.tsx
@@ -7,9 +7,9 @@ import GpaCard from '@/components/quantitative/GpaCard';
 import { patchQuantitative } from '@/lib/api';
 import type { QuantitativeData, LeetSection, GpaSection, LanguageSection } from '@/lib/api';
 
-type Props = { initialData: QuantitativeData; year: string };
+type Props = { initialData: QuantitativeData; year: string; readOnly?: boolean };
 
-export default function QuantitativeClient({ initialData, year }: Props) {
+export default function QuantitativeClient({ initialData, year, readOnly }: Props) {
   const [data, setData] = useState<QuantitativeData>(initialData);
 
   async function handleSaveLeet(leet: LeetSection) {
@@ -29,9 +29,9 @@ export default function QuantitativeClient({ initialData, year }: Props) {
 
   return (
     <>
-      <LeetCard initialData={data.leet} onSave={handleSaveLeet} />
-      <LanguageCard initialData={data.language} onSave={handleSaveLanguage} />
-      <GpaCard initialData={data.gpa} onSave={handleSaveGpa} />
+      <LeetCard initialData={data.leet} onSave={readOnly ? undefined : handleSaveLeet} readOnly={readOnly} />
+      <LanguageCard initialData={data.language} onSave={readOnly ? undefined : handleSaveLanguage} readOnly={readOnly} />
+      <GpaCard initialData={data.gpa} onSave={readOnly ? undefined : handleSaveGpa} readOnly={readOnly} />
     </>
   );
 }

--- a/apps/web/src/app/mentee/history/page.tsx
+++ b/apps/web/src/app/mentee/history/page.tsx
@@ -1,15 +1,22 @@
-'use client';
+import { cookies } from 'next/headers';
+import { serverFetch, getActiveProcessYear } from '@/lib/server-fetch';
+import HistoryClient from '@/components/history/HistoryClient';
 
-export default function MenteeHistoryPage() {
+export default async function MenteeHistoryPage() {
+  const token = (await cookies()).get('plawcess_token')?.value ?? '';
+  const activeYear = await getActiveProcessYear(token);
+  const activeYearNum = parseInt(activeYear.replace('학년도', '')) || new Date().getFullYear();
+
+  const response = await serverFetch<{ years: number[] }>('/api/mentee/history/years', token);
+  const historyYears = (response?.years ?? []).filter((y) => y !== activeYearNum);
+
   return (
     <div className="flex flex-col gap-6 page-container w-full">
       <div>
         <h1 className="text-2xl font-bold text-text-primary">지난 기록</h1>
         <p className="text-sm text-text-secondary mt-1">이전 연도에 작성한 나의 데이터를 확인할 수 있습니다.</p>
       </div>
-      <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-16 flex items-center justify-center">
-        <p className="text-text-secondary text-sm">준비 중입니다.</p>
-      </div>
+      <HistoryClient years={historyYears} />
     </div>
   );
 }

--- a/apps/web/src/app/mentor/history/page.tsx
+++ b/apps/web/src/app/mentor/history/page.tsx
@@ -1,15 +1,22 @@
-'use client';
+import { cookies } from 'next/headers';
+import { serverFetch, getActiveProcessYear } from '@/lib/server-fetch';
+import HistoryClient from '@/components/history/HistoryClient';
 
-export default function MentorHistoryPage() {
+export default async function MentorHistoryPage() {
+  const token = (await cookies()).get('plawcess_token')?.value ?? '';
+  const activeYear = await getActiveProcessYear(token);
+  const activeYearNum = parseInt(activeYear.replace('학년도', '')) || new Date().getFullYear();
+
+  const response = await serverFetch<{ years: number[] }>('/api/mentee/history/years', token);
+  const historyYears = (response?.years ?? []).filter((y) => y !== activeYearNum);
+
   return (
     <div className="flex flex-col gap-6 page-container w-full">
       <div>
         <h1 className="text-2xl font-bold text-text-primary">지난 기록</h1>
         <p className="text-sm text-text-secondary mt-1">이전 연도에 작성한 나의 데이터를 확인할 수 있습니다.</p>
       </div>
-      <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-16 flex items-center justify-center">
-        <p className="text-text-secondary text-sm">준비 중입니다.</p>
-      </div>
+      <HistoryClient years={historyYears} />
     </div>
   );
 }

--- a/apps/web/src/components/history/HistoryClient.tsx
+++ b/apps/web/src/components/history/HistoryClient.tsx
@@ -58,6 +58,7 @@ export default function HistoryClient({ years }: { years: number[] }) {
   useEffect(() => {
     if (!selectedYear) return;
     const yearStr = `${selectedYear}학년도`;
+    let cancelled = false;
     setLoading(true);
     setData(null);
     Promise.all([
@@ -66,9 +67,11 @@ export default function HistoryClient({ years }: { years: number[] }) {
       getQualitative(yearStr).catch(() => null),
       getPersonalStatement(yearStr).catch(() => null),
     ]).then(([basicInfo, quantitative, qualitative, personalStatement]) => {
+      if (cancelled) return;
       setData({ basicInfo, quantitative, qualitative, personalStatement });
       setLoading(false);
     });
+    return () => { cancelled = true; };
   }, [selectedYear]);
 
   if (years.length === 0) {

--- a/apps/web/src/components/history/HistoryClient.tsx
+++ b/apps/web/src/components/history/HistoryClient.tsx
@@ -57,20 +57,22 @@ export default function HistoryClient({ years }: { years: number[] }) {
 
   useEffect(() => {
     if (!selectedYear) return;
-    const yearStr = `${selectedYear}학년도`;
     let cancelled = false;
-    setLoading(true);
-    setData(null);
-    Promise.all([
-      getBasicInfo(yearStr).catch(() => null),
-      getQuantitative(yearStr).catch(() => null),
-      getQualitative(yearStr).catch(() => null),
-      getPersonalStatement(yearStr).catch(() => null),
-    ]).then(([basicInfo, quantitative, qualitative, personalStatement]) => {
+    async function fetchAll() {
+      const yearStr = `${selectedYear}학년도`;
+      setLoading(true);
+      setData(null);
+      const [basicInfo, quantitative, qualitative, personalStatement] = await Promise.all([
+        getBasicInfo(yearStr).catch(() => null),
+        getQuantitative(yearStr).catch(() => null),
+        getQualitative(yearStr).catch(() => null),
+        getPersonalStatement(yearStr).catch(() => null),
+      ]);
       if (cancelled) return;
       setData({ basicInfo, quantitative, qualitative, personalStatement });
       setLoading(false);
-    });
+    }
+    fetchAll();
     return () => { cancelled = true; };
   }, [selectedYear]);
 

--- a/apps/web/src/components/history/HistoryClient.tsx
+++ b/apps/web/src/components/history/HistoryClient.tsx
@@ -123,24 +123,18 @@ export default function HistoryClient({ years }: { years: number[] }) {
           </div>
 
           {/* 정성 데이터 */}
-          <div className="flex flex-col gap-3">
-            <h2 className="text-lg font-semibold text-text-primary">정성 데이터</h2>
-            <QualitativeClient
-              initialData={data.qualitative ?? EMPTY_QUALITATIVE}
-              year={`${selectedYear}학년도`}
-              readOnly
-            />
-          </div>
+          <QualitativeClient
+            initialData={data.qualitative ?? EMPTY_QUALITATIVE}
+            year={`${selectedYear}학년도`}
+            readOnly
+          />
 
           {/* 자기소개서 */}
-          <div className="flex flex-col gap-3">
-            <h2 className="text-lg font-semibold text-text-primary">자기소개서</h2>
-            <PersonalStatementClient
-              initialData={data.personalStatement ?? EMPTY_PERSONAL}
-              year={`${selectedYear}학년도`}
-              readOnly
-            />
-          </div>
+          <PersonalStatementClient
+            initialData={data.personalStatement ?? EMPTY_PERSONAL}
+            year={`${selectedYear}학년도`}
+            readOnly
+          />
         </div>
       )}
     </div>

--- a/apps/web/src/components/history/HistoryClient.tsx
+++ b/apps/web/src/components/history/HistoryClient.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import QuantitativeClient from '@/app/mentee/dashboard/quantitative/QuantitativeClient';
+import QualitativeClient from '@/app/mentee/dashboard/qualitative/QualitativeClient';
+import PersonalStatementClient from '@/app/mentee/dashboard/personal-statement/PersonalStatementClient';
+import {
+  getBasicInfo,
+  getQuantitative,
+  getQualitative,
+  getPersonalStatement,
+  type BasicInfoData,
+  type QuantitativeData,
+  type QualitativeData,
+  type PersonalStatementData,
+} from '@/lib/api';
+
+type HistoryData = {
+  basicInfo: BasicInfoData | null;
+  quantitative: QuantitativeData | null;
+  qualitative: QualitativeData | null;
+  personalStatement: PersonalStatementData | null;
+};
+
+const EMPTY_QUANTITATIVE: QuantitativeData = {
+  leet: {
+    verbal: { raw: null, standard: null, percentile: null },
+    reasoning: { raw: null, standard: null, percentile: null },
+  },
+  gpa: { overall: null, major: null, converted: null },
+  language: { toeic: null, toefl: null, teps: null },
+};
+
+const EMPTY_QUALITATIVE: QualitativeData = {
+  careerGoal: '',
+  activities: [],
+  analysis: {
+    isAnalyzed: false,
+    analyzedAt: null,
+    starAnalysis: null,
+    aiKeywords: null,
+    storyOutline: null,
+    summaryOutdated: false,
+    activitiesAnalyzed: [],
+  },
+};
+
+const EMPTY_PERSONAL: PersonalStatementData = {
+  ga: { school: null, hwp: null, questions: null, textAnswers: null, templateExists: false },
+  na: { school: null, hwp: null, questions: null, textAnswers: null, templateExists: false },
+};
+
+export default function HistoryClient({ years }: { years: number[] }) {
+  const [selectedYear, setSelectedYear] = useState<number | null>(years[0] ?? null);
+  const [loading, setLoading] = useState(false);
+  const [data, setData] = useState<HistoryData | null>(null);
+
+  useEffect(() => {
+    if (!selectedYear) return;
+    const yearStr = `${selectedYear}학년도`;
+    setLoading(true);
+    setData(null);
+    Promise.all([
+      getBasicInfo(yearStr).catch(() => null),
+      getQuantitative(yearStr).catch(() => null),
+      getQualitative(yearStr).catch(() => null),
+      getPersonalStatement(yearStr).catch(() => null),
+    ]).then(([basicInfo, quantitative, qualitative, personalStatement]) => {
+      setData({ basicInfo, quantitative, qualitative, personalStatement });
+      setLoading(false);
+    });
+  }, [selectedYear]);
+
+  if (years.length === 0) {
+    return (
+      <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-16 flex items-center justify-center">
+        <p className="text-text-secondary text-sm">이전 연도의 기록이 없습니다.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* 연도 드롭다운 */}
+      <div className="flex items-center gap-3">
+        <label htmlFor="history-year" className="text-sm font-medium text-text-secondary">
+          연도 선택
+        </label>
+        <select
+          id="history-year"
+          value={selectedYear ?? ''}
+          onChange={(e) => setSelectedYear(Number(e.target.value))}
+          className="px-3 py-2 text-sm border border-border rounded-lg bg-white text-text-primary focus:outline-none focus:ring-2 focus:ring-brand focus:border-transparent"
+        >
+          {years.map((y) => (
+            <option key={y} value={y}>{y}학년도</option>
+          ))}
+        </select>
+      </div>
+
+      {loading && (
+        <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-16 flex items-center justify-center">
+          <div className="w-6 h-6 rounded-full border-2 border-brand border-t-transparent animate-spin" />
+        </div>
+      )}
+
+      {!loading && data && (
+        <div className="flex flex-col gap-6">
+          {/* 지망학교 */}
+          <TargetSchoolCard basicInfo={data.basicInfo} />
+
+          {/* 정량 데이터 */}
+          <div className="flex flex-col gap-3">
+            <h2 className="text-lg font-semibold text-text-primary">정량 데이터</h2>
+            <QuantitativeClient
+              initialData={data.quantitative ?? EMPTY_QUANTITATIVE}
+              year={`${selectedYear}학년도`}
+              readOnly
+            />
+          </div>
+
+          {/* 정성 데이터 */}
+          <div className="flex flex-col gap-3">
+            <h2 className="text-lg font-semibold text-text-primary">정성 데이터</h2>
+            <QualitativeClient
+              initialData={data.qualitative ?? EMPTY_QUALITATIVE}
+              year={`${selectedYear}학년도`}
+              readOnly
+            />
+          </div>
+
+          {/* 자기소개서 */}
+          <div className="flex flex-col gap-3">
+            <h2 className="text-lg font-semibold text-text-primary">자기소개서</h2>
+            <PersonalStatementClient
+              initialData={data.personalStatement ?? EMPTY_PERSONAL}
+              year={`${selectedYear}학년도`}
+              readOnly
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TargetSchoolCard({ basicInfo }: { basicInfo: BasicInfoData | null }) {
+  const admission = basicInfo?.admission;
+
+  return (
+    <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-6">
+      <h2 className="text-base font-semibold text-text-primary mb-4">지망 학교</h2>
+      {!admission || (!admission['가'].school && !admission['나'].school) ? (
+        <p className="text-sm text-text-secondary">지망 학교 정보가 없습니다.</p>
+      ) : (
+        <div className="flex flex-col gap-3 text-sm">
+          {admission['가'].school && (
+            <div className="flex items-center gap-3">
+              <span className="px-2 py-0.5 text-xs font-medium bg-brand-light text-brand rounded">가군</span>
+              <span className="text-text-primary font-medium">{admission['가'].school}</span>
+              {admission['가'].isSpecial && (
+                <span className="px-2 py-0.5 text-xs bg-amber-50 text-amber-700 rounded border border-amber-200">특별전형</span>
+              )}
+            </div>
+          )}
+          {admission['나'].school && (
+            <div className="flex items-center gap-3">
+              <span className="px-2 py-0.5 text-xs font-medium bg-brand-light text-brand rounded">나군</span>
+              <span className="text-text-primary font-medium">{admission['나'].school}</span>
+              {admission['나'].isSpecial && (
+                <span className="px-2 py-0.5 text-xs bg-amber-50 text-amber-700 rounded border border-amber-200">특별전형</span>
+              )}
+            </div>
+          )}
+          {admission.preferredGroup && (
+            <p className="text-text-secondary text-xs mt-1">1순위: {admission.preferredGroup}군</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -19,6 +19,7 @@ const menteeNavItems: NavItem[] = [
   { label: '자기소개서', href: '/mentee/dashboard/personal-statement' },
   { label: '프로세스 신청', href: '/mentee/applications' },
   { label: '합격 아카이브', href: '/mentee/archive' },
+  { label: '지난기록', href: '/mentee/history' },
   { label: '공지사항', href: '/mentee/announcements', dividerBefore: true },
   { label: '설정', href: '/settings', exact: true },
 ];
@@ -29,6 +30,7 @@ const mentorNavItems: NavItem[] = [
   { label: '정량 데이터', href: '/mentor/dashboard/quantitative' },
   { label: '정성 데이터', href: '/mentor/dashboard/qualitative' },
   { label: '합격 아카이브', href: '/mentor/archive' },
+  { label: '지난기록', href: '/mentor/history' },
   { label: '공지사항', href: '/mentor/announcements', dividerBefore: true },
   { label: '설정', href: '/settings', exact: true },
 ];

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -19,7 +19,7 @@ const menteeNavItems: NavItem[] = [
   { label: '자기소개서', href: '/mentee/dashboard/personal-statement' },
   { label: '프로세스 신청', href: '/mentee/applications' },
   { label: '합격 아카이브', href: '/mentee/archive' },
-  { label: '지난기록', href: '/mentee/history' },
+  { label: '지난 기록', href: '/mentee/history' },
   { label: '공지사항', href: '/mentee/announcements', dividerBefore: true },
   { label: '설정', href: '/settings', exact: true },
 ];
@@ -30,7 +30,7 @@ const mentorNavItems: NavItem[] = [
   { label: '정량 데이터', href: '/mentor/dashboard/quantitative' },
   { label: '정성 데이터', href: '/mentor/dashboard/qualitative' },
   { label: '합격 아카이브', href: '/mentor/archive' },
-  { label: '지난기록', href: '/mentor/history' },
+  { label: '지난 기록', href: '/mentor/history' },
   { label: '공지사항', href: '/mentor/announcements', dividerBefore: true },
   { label: '설정', href: '/settings', exact: true },
 ];

--- a/apps/web/src/components/quantitative/GpaCard.tsx
+++ b/apps/web/src/components/quantitative/GpaCard.tsx
@@ -9,6 +9,7 @@ export type GpaData = GpaSection;
 type Props = {
   initialData: GpaData;
   onSave?: (data: GpaData) => Promise<void>;
+  readOnly?: boolean;
 };
 
 const GPA_MAX = 4.5;
@@ -27,7 +28,7 @@ function toStr(val: number | null): string {
   return val == null ? '' : String(val);
 }
 
-export default function GpaCard({ initialData, onSave }: Props) {
+export default function GpaCard({ initialData, onSave, readOnly }: Props) {
   const [data, setData] = useState<GpaData>(initialData);
   const [draft, setDraft] = useState<GpaData>(initialData);
   const [draftStr, setDraftStr] = useState({
@@ -65,10 +66,10 @@ export default function GpaCard({ initialData, onSave }: Props) {
     <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-base font-semibold text-text-primary">GPA</h2>
-        {isEditing
+        {!readOnly && (isEditing
           ? <EditButtons onCancel={handleCancel} onSave={handleSave} disabled={isSaving} />
           : <EditButton onClick={() => { setDraft(data); setDraftStr({ overall: toStr(data.overall), major: toStr(data.major) }); setIsEditing(true); }} />
-        }
+        )}
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-5 sm:gap-8">
@@ -76,7 +77,7 @@ export default function GpaCard({ initialData, onSave }: Props) {
         <div className="flex flex-col gap-2">
           <span className="text-sm text-text-secondary">전체 평점 평균</span>
           <div className="h-7 flex items-center">
-            {isEditing ? (
+            {isEditing && !readOnly ? (
               <input
                 type="text"
                 value={draftStr.overall}
@@ -102,7 +103,7 @@ export default function GpaCard({ initialData, onSave }: Props) {
         <div className="flex flex-col gap-2">
           <span className="text-sm text-text-secondary">전공 평점 평균</span>
           <div className="h-7 flex items-center">
-            {isEditing ? (
+            {isEditing && !readOnly ? (
               <input
                 type="text"
                 value={draftStr.major}

--- a/apps/web/src/components/quantitative/LanguageCard.tsx
+++ b/apps/web/src/components/quantitative/LanguageCard.tsx
@@ -9,6 +9,7 @@ export type LanguageData = LanguageSection;
 type Props = {
   initialData: LanguageData;
   onSave?: (data: LanguageData) => Promise<void>;
+  readOnly?: boolean;
 };
 
 const fields: { label: string; key: keyof LanguageData }[] = [
@@ -21,7 +22,7 @@ function toDisplay(val: number | null): string {
   return val == null ? '-' : String(val);
 }
 
-export default function LanguageCard({ initialData, onSave }: Props) {
+export default function LanguageCard({ initialData, onSave, readOnly }: Props) {
   const [data, setData] = useState<LanguageData>(initialData);
   const [draft, setDraft] = useState<LanguageData>(initialData);
   const [isEditing, setIsEditing] = useState(false);
@@ -42,17 +43,17 @@ export default function LanguageCard({ initialData, onSave }: Props) {
     <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-base font-semibold text-text-primary">어학 성적</h2>
-        {isEditing
+        {!readOnly && (isEditing
           ? <EditButtons onCancel={() => { setDraft(data); setIsEditing(false); }} onSave={handleSave} disabled={isSaving} />
           : <EditButton onClick={() => { setDraft(data); setIsEditing(true); }} />
-        }
+        )}
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-5 sm:gap-8">
         {fields.map(({ label, key }) => (
           <div key={key} className="flex flex-col gap-2">
             <span className="text-sm text-text-secondary">{label}</span>
             <div className="h-7 flex items-center">
-              {isEditing ? (
+              {isEditing && !readOnly ? (
                 <input
                   type="text"
                   value={draft[key] ?? ''}

--- a/apps/web/src/components/quantitative/LeetCard.tsx
+++ b/apps/web/src/components/quantitative/LeetCard.tsx
@@ -9,6 +9,7 @@ export type LeetData = LeetSection;
 type Props = {
   initialData: LeetData;
   onSave?: (data: LeetData) => Promise<void>;
+  readOnly?: boolean;
 };
 
 function toDisplay(val: number | null): string {
@@ -20,7 +21,7 @@ function fromInput(val: string): number | null {
   return isNaN(n) ? null : n;
 }
 
-export default function LeetCard({ initialData, onSave }: Props) {
+export default function LeetCard({ initialData, onSave, readOnly }: Props) {
   const [data, setData] = useState<LeetData>(initialData);
   const [draft, setDraft] = useState<LeetData>(initialData);
   const [isEditing, setIsEditing] = useState(false);
@@ -53,10 +54,10 @@ export default function LeetCard({ initialData, onSave }: Props) {
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-base font-semibold text-text-primary">LEET 성적</h2>
         <div className="flex items-center gap-3">
-          {isEditing
+          {!readOnly && (isEditing
             ? <EditButtons onCancel={() => { setDraft(data); setIsEditing(false); }} onSave={handleSave} disabled={isSaving} />
             : <EditButton onClick={() => { setDraft(data); setIsEditing(true); }} />
-          }
+          )}
         </div>
       </div>
       <table className="w-full text-sm table-fixed">
@@ -75,7 +76,7 @@ export default function LeetCard({ initialData, onSave }: Props) {
               {fields.map((f) => (
                 <td key={f.key} className="py-4 text-base font-semibold text-text-primary">
                   <div className="h-5">
-                    {isEditing ? (
+                    {isEditing && !readOnly ? (
                       <input
                         type="number"
                         value={draft[s.key][f.key] ?? ''}


### PR DESCRIPTION
## Summary

- `GET /api/mentee/history/years` 엔드포인트 추가 — 현재 활성 연도를 제외한 과거 MenteeRecord 연도 목록 반환 (멘티·멘토 공통)
- `/mentee/history`, `/mentor/history` 페이지 추가 — 연도 드롭다운으로 과거 연도 선택 시 정량/정성/자소서/지망학교 데이터를 읽기 전용으로 표시
- `QuantitativeClient`, `QualitativeClient`, `PersonalStatementClient`에 `readOnly?: boolean` prop 추가 — 편집 버튼·드래프트 폼 숨김, 자소서 textarea를 `<p>`로 대체
- 사이드바 menteeNavItems·mentorNavItems에 "지난 기록" 링크 추가

## Test Plan

- [ ] 멘티 계정으로 `/mentee/history` 접근 → 과거 연도 드롭다운 확인
- [ ] 연도 선택 시 정량/정성/자소서/지망학교 4개 섹션 읽기 전용 표시 확인
- [ ] 멘토 계정으로 `/mentor/history` 접근 → 멘티 시절 데이터 동일하게 표시 확인
- [ ] 편집 버튼·저장 버튼·드래프트 폼이 모두 숨겨져 있는지 확인
- [ ] 과거 기록 없는 유저 → "이전 연도의 기록이 없습니다." 메시지 표시 확인
- [ ] 기존 대시보드 페이지(정량/정성/자소서)가 정상 동작하는지 회귀 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)