### PR TITLE
feat(#34): KUPID 성적 스크래핑 연동 + GPA 자동 계산

### DIFF
--- a/apps/api/next.config.ts
+++ b/apps/api/next.config.ts
@@ -12,7 +12,7 @@ const nextConfig: NextConfig = {
   transpilePackages: ["@plawcess/database"],
   // mammoth는 동적 require로 인코딩 테이블을 읽어 webpack 번들과 충돌 →
   // node_modules에서 직접 resolve하도록 external 처리.
-  serverExternalPackages: ["mammoth"],
+  serverExternalPackages: ["mammoth", "playwright-core", "@sparticuz/chromium"],
   async headers() {
     return [{ source: "/:path*", headers: securityHeaders }];
   },

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,6 +13,7 @@
     "@plawcess/database": "workspace:*",
     "@prisma/adapter-pg": "^7.6.0",
     "@prisma/client": "^7.6.0",
+    "@sparticuz/chromium": "^148.0.0",
     "@supabase/supabase-js": "^2.105.4",
     "bcryptjs": "^3.0.3",
     "jose": "^6.2.2",
@@ -20,6 +21,7 @@
     "mammoth": "^1.12.0",
     "next": "16.2.2",
     "pg": "^8.20.0",
+    "playwright-core": "^1.60.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "resend": "^6.12.3"

--- a/apps/api/src/app/api/mentee/grades/route.ts
+++ b/apps/api/src/app/api/mentee/grades/route.ts
@@ -56,20 +56,20 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const rows = await scrapeGrades(body.id as string, body.pw as string);
-    if (rows === null) {
+    const result = await scrapeGrades(body.id as string, body.pw as string);
+    if (result === null) {
       return NextResponse.json(
         { error: "로그인에 실패했습니다. ID/PW를 확인해주세요." },
         { status: 401 },
       );
     }
-    if (rows.length === 0) {
+    if (result.rows.length === 0) {
       return NextResponse.json(
-        { error: "성적을 불러올 수 없습니다." },
+        { error: "성적을 불러올 수 없습니다.", debug: result.debugText, summary: result.summary },
         { status: 422 },
       );
     }
-    return NextResponse.json({ rows });
+    return NextResponse.json({ rows: result.rows, summary: result.summary, debug: result.debugText });
   } catch (e) {
     console.error("scrapeGrades error:", e);
     return NextResponse.json(

--- a/apps/api/src/app/api/mentee/grades/route.ts
+++ b/apps/api/src/app/api/mentee/grades/route.ts
@@ -1,9 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import { spawn } from "child_process";
-import { readFileSync, unlinkSync, existsSync } from "fs";
-import { join } from "path";
-import { tmpdir } from "os";
 import { getTokenFromCookie } from "@/lib/auth";
+import { scrapeGrades } from "@/lib/scrapeGrades";
+
+export const maxDuration = 300; // Vercel Pro: 최대 300초
 
 const ID_PATTERN = /^[A-Za-z0-9._@-]{1,32}$/;
 const PW_MAX_LEN = 128;
@@ -21,13 +20,8 @@ function validateCredentials(id: unknown, pw: unknown): { ok: true } | { ok: fal
   if (pw.length < 1 || pw.length > PW_MAX_LEN) {
     return { ok: false, error: "비밀번호 길이가 올바르지 않습니다." };
   }
-  // 제어문자 차단
   if (/[\x00-\x1f]/.test(pw)) {
     return { ok: false, error: "비밀번호에 허용되지 않은 문자가 포함되어 있습니다." };
-  }
-  // argparse 옵션 인젝션 차단 (`--`-prefix)
-  if (id.startsWith("--") || pw.startsWith("--")) {
-    return { ok: false, error: "허용되지 않은 형식입니다." };
   }
   return { ok: true };
 }
@@ -60,51 +54,27 @@ export async function POST(req: NextRequest) {
   if (!validation.ok) {
     return NextResponse.json({ error: validation.error }, { status: 400 });
   }
-  const id = body.id as string;
-  const pw = body.pw as string;
 
-  const outputFile = join(tmpdir(), `grades_${Date.now()}.csv`);
-  const scriptPath = join(process.cwd(), "../../tools/scrape_grades.py");
-
-  const rows = await new Promise<Record<string, string>[] | null>((resolve) => {
-    const proc = spawn("python3", [scriptPath, outputFile, "--id", id, "--pw", pw]);
-
-    let stderr = "";
-    proc.stderr.on("data", (d: Buffer) => { stderr += d.toString(); });
-
-    proc.on("close", (code) => {
-      if (code !== 0 || !existsSync(outputFile)) {
-        console.error("scrape_grades stderr:", stderr);
-        resolve(null);
-        return;
-      }
-      try {
-        const csv = readFileSync(outputFile, "utf-8");
-        unlinkSync(outputFile);
-        resolve(parseCSV(csv));
-      } catch {
-        resolve(null);
-      }
-    });
-  });
-
-  if (!rows) {
+  try {
+    const rows = await scrapeGrades(body.id as string, body.pw as string);
+    if (rows === null) {
+      return NextResponse.json(
+        { error: "로그인에 실패했습니다. ID/PW를 확인해주세요." },
+        { status: 401 },
+      );
+    }
+    if (rows.length === 0) {
+      return NextResponse.json(
+        { error: "성적을 불러올 수 없습니다." },
+        { status: 422 },
+      );
+    }
+    return NextResponse.json({ rows });
+  } catch (e) {
+    console.error("scrapeGrades error:", e);
     return NextResponse.json(
-      { error: "로그인에 실패했거나 성적을 불러올 수 없습니다." },
-      { status: 401 },
+      { error: "성적 조회 중 오류가 발생했습니다." },
+      { status: 500 },
     );
   }
-
-  return NextResponse.json({ rows });
-}
-
-function parseCSV(csv: string): Record<string, string>[] {
-  const lines = csv.replace(/\r/g, "").split("\n").filter(Boolean);
-  if (lines.length < 2) return [];
-
-  const headers = lines[0].split(",");
-  return lines.slice(1).map((line) => {
-    const values = line.split(",");
-    return Object.fromEntries(headers.map((h, i) => [h.trim(), (values[i] ?? "").trim()]));
-  });
 }

--- a/apps/api/src/app/api/mentee/grades/route.ts
+++ b/apps/api/src/app/api/mentee/grades/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+import { prisma, Prisma } from "@plawcess/database";
 import { getTokenFromCookie } from "@/lib/auth";
-import { scrapeGrades } from "@/lib/scrapeGrades";
+import { scrapeGrades, type GradeRow } from "@/lib/scrapeGrades";
 
 export const maxDuration = 300; // Vercel Pro: 최대 300초
 
@@ -9,6 +10,12 @@ const PW_MAX_LEN = 128;
 const RATE_LIMIT_WINDOW_MS = 60_000;
 
 const lastCallByUser = new Map<string, number>();
+
+function getProcessYear(req: NextRequest): number {
+  const raw = req.nextUrl.searchParams.get("year");
+  const match = raw?.match(/\d{4}/);
+  return match ? parseInt(match[0]) : new Date().getFullYear();
+}
 
 function validateCredentials(id: unknown, pw: unknown): { ok: true } | { ok: false; error: string } {
   if (typeof id !== "string" || typeof pw !== "string") {
@@ -26,6 +33,42 @@ function validateCredentials(id: unknown, pw: unknown): { ok: true } | { ok: fal
   return { ok: true };
 }
 
+// ----------------------------------------------------------------
+// GET — 저장된 수강 과목 조회
+// ----------------------------------------------------------------
+export async function GET(req: NextRequest) {
+  const token = getTokenFromCookie(req);
+  if (!token) {
+    return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
+  }
+  const processYear = getProcessYear(req);
+  const record = await prisma.menteeRecord.findUnique({
+    where: { user_id_process_year: { user_id: token.user_id, process_year: processYear } },
+    select: { kupid_grades: true },
+  });
+  const rows = (record?.kupid_grades as GradeRow[] | null) ?? [];
+  return NextResponse.json({ rows });
+}
+
+// ----------------------------------------------------------------
+// DELETE — 저장된 수강 과목 삭제
+// ----------------------------------------------------------------
+export async function DELETE(req: NextRequest) {
+  const token = getTokenFromCookie(req);
+  if (!token) {
+    return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
+  }
+  const processYear = getProcessYear(req);
+  await prisma.menteeRecord.updateMany({
+    where: { user_id: token.user_id, process_year: processYear },
+    data: { kupid_grades: Prisma.JsonNull },
+  });
+  return NextResponse.json({ ok: true });
+}
+
+// ----------------------------------------------------------------
+// POST — KUPID 스크래핑 후 저장
+// ----------------------------------------------------------------
 export async function POST(req: NextRequest) {
   const token = getTokenFromCookie(req);
   if (!token) {
@@ -69,6 +112,15 @@ export async function POST(req: NextRequest) {
         { status: 422 },
       );
     }
+
+    // DB에 저장 (현재 cycle의 멘티 레코드 upsert)
+    const processYear = getProcessYear(req);
+    await prisma.menteeRecord.upsert({
+      where: { user_id_process_year: { user_id: token.user_id, process_year: processYear } },
+      create: { user_id: token.user_id, process_year: processYear, kupid_grades: result.rows },
+      update: { kupid_grades: result.rows },
+    });
+
     return NextResponse.json({ rows: result.rows, summary: result.summary, debug: result.debugText });
   } catch (e) {
     console.error("scrapeGrades error:", e);

--- a/apps/api/src/app/api/mentee/grades/route.ts
+++ b/apps/api/src/app/api/mentee/grades/route.ts
@@ -75,16 +75,19 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
   }
 
-  const now = Date.now();
-  const last = lastCallByUser.get(token.user_id) ?? 0;
-  if (now - last < RATE_LIMIT_WINDOW_MS) {
-    const retryAfter = Math.ceil((RATE_LIMIT_WINDOW_MS - (now - last)) / 1000);
-    return NextResponse.json(
-      { error: `잠시 후 다시 시도해주세요. (${retryAfter}초)` },
-      { status: 429, headers: { "Retry-After": String(retryAfter) } },
-    );
+  // 프로덕션에서만 rate limit 적용 (스크래핑 비용 보호 / KUPID 로그인 제한 회피)
+  if (process.env.NODE_ENV === "production") {
+    const now = Date.now();
+    const last = lastCallByUser.get(token.user_id) ?? 0;
+    if (now - last < RATE_LIMIT_WINDOW_MS) {
+      const retryAfter = Math.ceil((RATE_LIMIT_WINDOW_MS - (now - last)) / 1000);
+      return NextResponse.json(
+        { error: `잠시 후 다시 시도해주세요. (${retryAfter}초)` },
+        { status: 429, headers: { "Retry-After": String(retryAfter) } },
+      );
+    }
+    lastCallByUser.set(token.user_id, now);
   }
-  lastCallByUser.set(token.user_id, now);
 
   let body: { id?: unknown; pw?: unknown };
   try {

--- a/apps/api/src/lib/scrapeGrades.ts
+++ b/apps/api/src/lib/scrapeGrades.ts
@@ -24,7 +24,6 @@ async function getBrowser() {
     const chromium = (await import('@sparticuz/chromium')).default;
     return playwrightChromium.launch({
       args: chromium.args,
-      defaultViewport: chromium.defaultViewport,
       executablePath: await chromium.executablePath(),
       headless: true,
     });

--- a/apps/api/src/lib/scrapeGrades.ts
+++ b/apps/api/src/lib/scrapeGrades.ts
@@ -1,0 +1,98 @@
+import { chromium as playwrightChromium } from 'playwright-core';
+
+const PORTAL_URL = 'https://portal.korea.ac.kr';
+const INFODEPOT_BASE = 'https://infodepot.korea.ac.kr';
+const INFODEPOT_GRADE_PATH = '/grade/SearchGradeAll.jsp';
+
+export type GradeRow = Record<string, string>;
+
+const COLUMNS = ['년도', '학기', '학수번호', '과목명', '이수구분', '교양영역', '과목유형', '학점', '점수', '등급', '평점', '재수강년도', '재수강학기', '재수강과목', '삭제구분'];
+
+async function getBrowser() {
+  if (process.env.NODE_ENV === 'production' || process.env.VERCEL) {
+    const chromium = (await import('@sparticuz/chromium')).default;
+    return playwrightChromium.launch({
+      args: chromium.args,
+      defaultViewport: chromium.defaultViewport,
+      executablePath: await chromium.executablePath(),
+      headless: true,
+    });
+  }
+  return playwrightChromium.launch({ headless: true });
+}
+
+function parseGradeTable(html: string): GradeRow[] {
+  // 간단한 HTML 테이블 파서 (cheerio 없이)
+  const tableMatch = html.match(/<table[\s\S]*?<\/table>/gi) ?? [];
+  for (const tableHtml of tableMatch) {
+    if (!tableHtml.includes('학수번호') || !tableHtml.includes('과목명') || !tableHtml.includes('학점')) continue;
+
+    const rows: GradeRow[] = [];
+    const trMatches = tableHtml.match(/<tr[\s\S]*?<\/tr>/gi) ?? [];
+    for (const tr of trMatches) {
+      // th만 있는 헤더 행 스킵
+      if (/<th/i.test(tr) && !/<td/i.test(tr)) continue;
+      const cellMatches = tr.match(/<t[dh][^>]*>([\s\S]*?)<\/t[dh]>/gi) ?? [];
+      const texts = cellMatches.map(cell =>
+        cell.replace(/<[^>]+>/g, ' ').replace(/&nbsp;/g, ' ').replace(/\s+/g, ' ').trim()
+      );
+      if (texts.length === 0 || texts.every(t => !t)) continue;
+      while (texts.length < COLUMNS.length) texts.push('');
+      const row = Object.fromEntries(COLUMNS.map((col, i) => [col, texts[i] ?? '']));
+      if (!row['학수번호'] && !row['과목명']) continue;
+      rows.push(row);
+    }
+    if (rows.length > 0) return rows;
+  }
+  return [];
+}
+
+export async function scrapeGrades(id: string, pw: string): Promise<GradeRow[] | null> {
+  const browser = await getBrowser();
+  try {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    // 1. 포털 로그인
+    await page.goto(PORTAL_URL, { waitUntil: 'networkidle', timeout: 20000 });
+    await page.fill('#oneid', id);
+    await page.fill('#_pw', pw);
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: 'networkidle', timeout: 20000 }),
+      page.click('#loginsubmit'),
+    ]);
+
+    if (page.url().includes('LoginDeny')) return null;
+
+    // 2. moveComponent로 infodepot SSO 세션 수립
+    try {
+      await page.evaluate(
+        `moveComponent('${INFODEPOT_BASE}', '3', '${INFODEPOT_GRADE_PATH}', '84', '280', 'S')`
+      );
+      await page.waitForTimeout(2000);
+    } catch {
+      // moveComponent 없어도 계속 시도
+    }
+
+    // 3. 새 탭으로 성적 페이지 접근
+    const gradePage = await context.newPage();
+    await gradePage.goto(`${INFODEPOT_BASE}${INFODEPOT_GRADE_PATH}`, { waitUntil: 'networkidle', timeout: 30000 });
+
+    // 4. 메인 페이지에서 파싱 시도
+    let rows = parseGradeTable(await gradePage.content());
+    if (rows.length > 0) return rows;
+
+    // 5. iframe 탐색
+    for (const frame of gradePage.frames()) {
+      if (frame === gradePage.mainFrame()) continue;
+      try {
+        rows = parseGradeTable(await frame.content());
+        if (rows.length > 0) return rows;
+      } catch { /* 접근 불가 iframe 무시 */ }
+    }
+
+    return [];
+  } finally {
+    await browser.close();
+  }
+}

--- a/apps/api/src/lib/scrapeGrades.ts
+++ b/apps/api/src/lib/scrapeGrades.ts
@@ -8,6 +8,13 @@ export type GradeRow = Record<string, string>;
 
 const COLUMNS = ['년도', '학기', '학수번호', '과목명', '이수구분', '교양영역', '과목유형', '학점', '점수', '등급', '평점', '재수강년도', '재수강학기', '재수강과목', '삭제구분'];
 
+const LOCAL_CHROME_PATHS = [
+  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  '/Applications/Chromium.app/Contents/MacOS/Chromium',
+  '/usr/bin/google-chrome',
+  '/usr/bin/chromium-browser',
+];
+
 async function getBrowser() {
   if (process.env.NODE_ENV === 'production' || process.env.VERCEL) {
     const chromium = (await import('@sparticuz/chromium')).default;
@@ -18,7 +25,10 @@ async function getBrowser() {
       headless: true,
     });
   }
-  return playwrightChromium.launch({ headless: true });
+  // 로컬 개발: 시스템 Chrome 사용
+  const { existsSync } = await import('fs');
+  const executablePath = LOCAL_CHROME_PATHS.find(p => existsSync(p));
+  return playwrightChromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
 }
 
 function parseGradeTable(html: string): GradeRow[] {

--- a/apps/api/src/lib/scrapeGrades.ts
+++ b/apps/api/src/lib/scrapeGrades.ts
@@ -1,12 +1,16 @@
 import { chromium as playwrightChromium } from 'playwright-core';
+import type { Page, Frame } from 'playwright-core';
 
 const PORTAL_URL = 'https://portal.korea.ac.kr';
 const INFODEPOT_BASE = 'https://infodepot.korea.ac.kr';
 const INFODEPOT_GRADE_PATH = '/grade/SearchGradeAll.jsp';
 
 export type GradeRow = Record<string, string>;
-
-const COLUMNS = ['년도', '학기', '학수번호', '과목명', '이수구분', '교양영역', '과목유형', '학점', '점수', '등급', '평점', '재수강년도', '재수강학기', '재수강과목', '삭제구분'];
+export type ScrapeResult = {
+  rows: GradeRow[];
+  summary: Record<string, string>;
+  debugText?: string;
+};
 
 const LOCAL_CHROME_PATHS = [
   '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
@@ -25,39 +29,97 @@ async function getBrowser() {
       headless: true,
     });
   }
-  // 로컬 개발: 시스템 Chrome 사용
   const { existsSync } = await import('fs');
   const executablePath = LOCAL_CHROME_PATHS.find(p => existsSync(p));
   return playwrightChromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
 }
 
-function parseGradeTable(html: string): GradeRow[] {
-  // 간단한 HTML 테이블 파서 (cheerio 없이)
-  const tableMatch = html.match(/<table[\s\S]*?<\/table>/gi) ?? [];
-  for (const tableHtml of tableMatch) {
-    if (!tableHtml.includes('학수번호') || !tableHtml.includes('과목명') || !tableHtml.includes('학점')) continue;
+// 브라우저 컨텍스트에서 실행 — 성적 테이블 + 요약값(평점평균 등) 추출
+function extractGradeData(): ScrapeResult {
+  const norm = (s: string | null | undefined) => (s ?? '').replace(/\s+/g, ' ').trim();
 
-    const rows: GradeRow[] = [];
-    const trMatches = tableHtml.match(/<tr[\s\S]*?<\/tr>/gi) ?? [];
-    for (const tr of trMatches) {
-      // th만 있는 헤더 행 스킵
-      if (/<th/i.test(tr) && !/<td/i.test(tr)) continue;
-      const cellMatches = tr.match(/<t[dh][^>]*>([\s\S]*?)<\/t[dh]>/gi) ?? [];
-      const texts = cellMatches.map(cell =>
-        cell.replace(/<[^>]+>/g, ' ').replace(/&nbsp;/g, ' ').replace(/\s+/g, ' ').trim()
-      );
-      if (texts.length === 0 || texts.every(t => !t)) continue;
-      while (texts.length < COLUMNS.length) texts.push('');
-      const row = Object.fromEntries(COLUMNS.map((col, i) => [col, texts[i] ?? '']));
-      if (!row['학수번호'] && !row['과목명']) continue;
-      rows.push(row);
+  // --- 1. 성적 테이블 ---
+  const tables = Array.from(document.querySelectorAll('table'));
+  const gradeTable = tables.find(t =>
+    (t.textContent ?? '').includes('학수번호') &&
+    (t.textContent ?? '').includes('과목명') &&
+    (t.textContent ?? '').includes('학점'),
+  );
+
+  const rows: GradeRow[] = [];
+  if (gradeTable) {
+    const allRows = Array.from(gradeTable.querySelectorAll('tr'));
+    let headers: string[] = [];
+    for (const row of allRows) {
+      const ths = Array.from(row.querySelectorAll('th'));
+      if (ths.length >= 8) { headers = ths.map(c => norm(c.textContent)); break; }
     }
-    if (rows.length > 0) return rows;
+    if (headers.length === 0) {
+      for (const row of allRows) {
+        const tds = Array.from(row.querySelectorAll('td'));
+        if (tds.length >= 8) { headers = tds.map(c => norm(c.textContent)); break; }
+      }
+    }
+    if (headers.length > 0) {
+      const codeIdx = headers.findIndex(h => h.includes('학수번호'));
+      for (const row of allRows) {
+        const tds = Array.from(row.querySelectorAll('td'));
+        if (tds.length < Math.floor(headers.length / 2)) continue; // 섹션헤더 행 스킵
+        const texts = tds.map(c => norm(c.textContent));
+        if (codeIdx >= 0 && !texts[codeIdx]) continue;
+        const obj: GradeRow = {};
+        headers.forEach((h, i) => { obj[h] = texts[i] ?? ''; });
+        rows.push(obj);
+      }
+    }
   }
-  return [];
+
+  // --- 2. 요약값: "평점/학점/백분율/증명" 라벨 + 옆 셀 숫자 ---
+  const summary: Record<string, string> = {};
+  const KEYWORDS = ['평점', '학점', '백분율', '증명', '평균', '취득', '신청'];
+  for (const table of tables) {
+    for (const tr of Array.from(table.querySelectorAll('tr'))) {
+      const cells = Array.from(tr.querySelectorAll('th, td')).map(c => norm(c.textContent));
+      for (let i = 0; i < cells.length - 1; i++) {
+        const label = cells[i];
+        const next = cells[i + 1];
+        if (!label || !next) continue;
+        if (KEYWORDS.some(k => label.includes(k)) && /^[\d.]+$/.test(next)) {
+          summary[label] = next;
+        }
+      }
+    }
+  }
+  // 본문 텍스트에서도 "라벨: 숫자" / "라벨 숫자" 패턴 추출 (테이블이 아닐 경우 대비)
+  const bodyText = norm(document.body.textContent);
+  const patterns = [
+    /평점평균[^\d]{0,10}([\d]\.[\d]{1,3})/g,
+    /백분율[^\d]{0,10}([\d]{1,3}\.[\d]{1,3})/g,
+    /증명[^\d]{0,15}([\d]\.[\d]{1,3})/g,
+    /전공[^\d]{0,10}평점[^\d]{0,10}([\d]\.[\d]{1,3})/g,
+  ];
+  for (const re of patterns) {
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(bodyText)) !== null) {
+      const key = m[0].replace(m[1], '').trim() || `pattern_${Object.keys(summary).length}`;
+      if (!summary[key]) summary[key] = m[1];
+    }
+  }
+
+  return { rows, summary, debugText: bodyText.slice(0, 2000) };
 }
 
-export async function scrapeGrades(id: string, pw: string): Promise<GradeRow[] | null> {
+async function tryExtract(target: Page | Frame): Promise<ScrapeResult | null> {
+  try {
+    const result = await target.evaluate(extractGradeData);
+    if (result.rows.length > 0 || Object.keys(result.summary).length > 0) return result;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function scrapeGrades(id: string, pw: string): Promise<ScrapeResult | null> {
   const browser = await getBrowser();
   try {
     const context = await browser.newContext();
@@ -71,7 +133,6 @@ export async function scrapeGrades(id: string, pw: string): Promise<GradeRow[] |
       page.waitForNavigation({ waitUntil: 'networkidle', timeout: 20000 }),
       page.click('#loginsubmit'),
     ]);
-
     if (page.url().includes('LoginDeny')) return null;
 
     // 2. moveComponent로 infodepot SSO 세션 수립
@@ -80,28 +141,23 @@ export async function scrapeGrades(id: string, pw: string): Promise<GradeRow[] |
         `moveComponent('${INFODEPOT_BASE}', '3', '${INFODEPOT_GRADE_PATH}', '84', '280', 'S')`
       );
       await page.waitForTimeout(2000);
-    } catch {
-      // moveComponent 없어도 계속 시도
-    }
+    } catch { /* 없으면 직접 접근 */ }
 
     // 3. 새 탭으로 성적 페이지 접근
     const gradePage = await context.newPage();
     await gradePage.goto(`${INFODEPOT_BASE}${INFODEPOT_GRADE_PATH}`, { waitUntil: 'networkidle', timeout: 30000 });
+    try { await gradePage.waitForSelector('table', { timeout: 8000 }); } catch { /* 없을 수도 */ }
 
-    // 4. 메인 페이지에서 파싱 시도
-    let rows = parseGradeTable(await gradePage.content());
-    if (rows.length > 0) return rows;
-
-    // 5. iframe 탐색
-    for (const frame of gradePage.frames()) {
-      if (frame === gradePage.mainFrame()) continue;
-      try {
-        rows = parseGradeTable(await frame.content());
-        if (rows.length > 0) return rows;
-      } catch { /* 접근 불가 iframe 무시 */ }
+    // 4. 메인 프레임 + iframe 전부 시도해서 가장 많은 데이터 가진 것 선택
+    let best: ScrapeResult | null = null;
+    const candidates: (Page | Frame)[] = [gradePage, ...gradePage.frames().filter(f => f !== gradePage.mainFrame())];
+    for (const c of candidates) {
+      const r = await tryExtract(c);
+      if (r && (!best || r.rows.length > best.rows.length || Object.keys(r.summary).length > Object.keys(best.summary).length)) {
+        best = r;
+      }
     }
-
-    return [];
+    return best ?? { rows: [], summary: {} };
   } finally {
     await browser.close();
   }

--- a/apps/web/src/components/quantitative/GpaCard.tsx
+++ b/apps/web/src/components/quantitative/GpaCard.tsx
@@ -174,9 +174,9 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
           </div>
         </div>
 
-        {/* 전공 평점 평균 */}
+        {/* 법학 과목 평점 평균 (학수번호 JURA) */}
         <div className="flex flex-col gap-2">
-          <span className="text-sm text-text-secondary">전공 평점 평균</span>
+          <span className="text-sm text-text-secondary">법학 과목 평점 평균</span>
           <div className="h-7 flex items-center">
             {isEditing && !readOnly ? (
               <input

--- a/apps/web/src/components/quantitative/GpaCard.tsx
+++ b/apps/web/src/components/quantitative/GpaCard.tsx
@@ -74,6 +74,7 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
   const [kupidLoading, setKupidLoading] = useState(false);
   const [kupidError, setKupidError] = useState<string | null>(null);
   const [gradeRows, setGradeRows] = useState<GradeRow[] | null>(null);
+  const [gradeListOpen, setGradeListOpen] = useState(true);
 
   async function handleKupidLogin() {
     setKupidLoading(true);
@@ -105,6 +106,7 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
       setDraft(newData);
       setDraftStr({ overall: toStr(overall), major: toStr(major) });
       setGradeRows(rows);
+      setGradeListOpen(true);
       if (onSave) await onSave(newData);
 
       setShowKupid(false);
@@ -223,46 +225,59 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
         const totalCredits = validRows.reduce((s, r) => s + (parseFloat(r['학점'] ?? '') || 0), 0);
         return (
           <div className="mt-6 border-t border-border pt-6">
-            <div className="flex items-center justify-between mb-3">
-              <h3 className="text-sm font-semibold text-text-primary">수강 과목</h3>
+            <button
+              onClick={() => setGradeListOpen(o => !o)}
+              className="w-full flex items-center justify-between mb-3 group"
+            >
+              <h3 className="flex items-center gap-1.5 text-sm font-semibold text-text-primary">
+                <svg
+                  width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
+                  className={`text-text-secondary transition-transform ${gradeListOpen ? 'rotate-90' : ''}`}
+                >
+                  <polyline points="9 18 15 12 9 6" />
+                </svg>
+                수강 과목
+              </h3>
               <div className="flex items-center gap-4 text-xs text-text-secondary">
                 <span>총 <span className="font-semibold text-text-primary">{validRows.length}</span>과목</span>
                 <span>총 <span className="font-semibold text-text-primary">{totalCredits}</span>학점</span>
               </div>
-            </div>
-            <div className="overflow-auto max-h-72">
-              <table className="w-full text-xs table-fixed">
-                <thead>
-                  <tr className="border-b border-border">
-                    <th className="pb-2 text-left text-text-secondary font-normal w-16">년도</th>
-                    <th className="pb-2 text-left text-text-secondary font-normal w-14">학기</th>
-                    <th className="pb-2 text-left text-text-secondary font-normal">과목명</th>
-                    <th className="pb-2 text-left text-text-secondary font-normal w-20">이수구분</th>
-                    <th className="pb-2 text-right text-text-secondary font-normal w-10">학점</th>
-                    <th className="pb-2 text-right text-text-secondary font-normal w-10">등급</th>
-                    <th className="pb-2 text-right text-text-secondary font-normal w-10">평점</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {gradeRows.map((row, i) => {
-                    const isRetaken = (row['삭제구분'] ?? '') !== '';
-                    const cls = isRetaken ? 'line-through text-text-placeholder' : 'text-text-primary';
-                    const subCls = isRetaken ? 'text-text-placeholder' : 'text-text-secondary';
-                    return (
-                      <tr key={i} className={`border-b border-border last:border-0 ${isRetaken ? 'opacity-50' : ''}`}>
-                        <td className={`py-2 whitespace-nowrap ${subCls}`}>{row['년도']}</td>
-                        <td className={`py-2 whitespace-nowrap ${subCls}`}>{row['학기']}</td>
-                        <td className={`py-2 truncate pr-2 ${cls}`}>{row['과목명']}</td>
-                        <td className={`py-2 whitespace-nowrap ${subCls}`}>{row['이수구분']}</td>
-                        <td className={`py-2 text-right whitespace-nowrap ${cls}`}>{row['학점']}</td>
-                        <td className={`py-2 text-right whitespace-nowrap ${cls}`}>{row['등급']}</td>
-                        <td className={`py-2 text-right whitespace-nowrap font-semibold ${cls}`}>{row['평점']}</td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
+            </button>
+            {gradeListOpen && (
+              <div className="overflow-auto max-h-72">
+                <table className="w-full text-xs table-fixed">
+                  <thead>
+                    <tr className="border-b border-border">
+                      <th className="pb-2 text-left text-text-secondary font-normal w-16">년도</th>
+                      <th className="pb-2 text-left text-text-secondary font-normal w-14">학기</th>
+                      <th className="pb-2 text-left text-text-secondary font-normal">과목명</th>
+                      <th className="pb-2 text-left text-text-secondary font-normal w-20">이수구분</th>
+                      <th className="pb-2 text-right text-text-secondary font-normal w-10">학점</th>
+                      <th className="pb-2 text-right text-text-secondary font-normal w-10">등급</th>
+                      <th className="pb-2 text-right text-text-secondary font-normal w-10">평점</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {gradeRows.map((row, i) => {
+                      const isRetaken = (row['삭제구분'] ?? '') !== '';
+                      const cls = isRetaken ? 'line-through text-text-placeholder' : 'text-text-primary';
+                      const subCls = isRetaken ? 'text-text-placeholder' : 'text-text-secondary';
+                      return (
+                        <tr key={i} className={`border-b border-border last:border-0 ${isRetaken ? 'opacity-50' : ''}`}>
+                          <td className={`py-2 whitespace-nowrap ${subCls}`}>{row['년도']}</td>
+                          <td className={`py-2 whitespace-nowrap ${subCls}`}>{row['학기']}</td>
+                          <td className={`py-2 truncate pr-2 ${cls}`}>{row['과목명']}</td>
+                          <td className={`py-2 whitespace-nowrap ${subCls}`}>{row['이수구분']}</td>
+                          <td className={`py-2 text-right whitespace-nowrap ${cls}`}>{row['학점']}</td>
+                          <td className={`py-2 text-right whitespace-nowrap ${cls}`}>{row['등급']}</td>
+                          <td className={`py-2 text-right whitespace-nowrap font-semibold ${cls}`}>{row['평점']}</td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
           </div>
         );
       })()}

--- a/apps/web/src/components/quantitative/GpaCard.tsx
+++ b/apps/web/src/components/quantitative/GpaCard.tsx
@@ -1,11 +1,26 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { EditButton, EditButtons } from '@/components/ui/EditButton';
-import type { GpaSection } from '@/lib/api';
+import { getUser, type GpaSection } from '@/lib/api';
 
 export type GpaData = GpaSection;
 type GradeRow = Record<string, string>;
+
+const GRADES_STORAGE_PREFIX = 'plawcess:kupid-grades:';
+function gradesStorageKey(): string {
+  return GRADES_STORAGE_PREFIX + (getUser()?.user_id ?? 'anon');
+}
+function loadStoredGrades(): GradeRow[] | null {
+  try {
+    const raw = localStorage.getItem(gradesStorageKey());
+    const parsed = raw ? JSON.parse(raw) : null;
+    return Array.isArray(parsed) && parsed.length > 0 ? parsed : null;
+  } catch { return null; }
+}
+function storeGrades(rows: GradeRow[]) {
+  try { localStorage.setItem(gradesStorageKey(), JSON.stringify(rows)); } catch { /* 용량 초과 등 무시 */ }
+}
 
 type Props = {
   initialData: GpaData;
@@ -27,6 +42,16 @@ function toDisplay(val: number | null): string {
 
 function toStr(val: number | null): string {
   return val == null ? '' : String(val);
+}
+
+// 저장 시점 검증. 빈 값은 허용(미입력), 그 외엔 0~4.5 + 소수점 둘째 자리까지(예: 4.5, 3.42)
+const GPA_INPUT_HINT = '학점을 알맞게 입력해주세요 (0 ~ 4.5, 예: 4.5 또는 3.42)';
+function validateGpaStr(s: string): string | null {
+  if (s.trim() === '') return null;
+  if (!/^[0-4](\.\d{1,2})?$/.test(s.trim())) return GPA_INPUT_HINT;
+  const n = parseFloat(s);
+  if (isNaN(n) || n > GPA_MAX) return GPA_INPUT_HINT;
+  return null;
 }
 
 // 학점 가중 평점 평균. 재수강 대체 과목(삭제구분 != '')과 P/F 제외.
@@ -74,7 +99,15 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
   const [kupidLoading, setKupidLoading] = useState(false);
   const [kupidError, setKupidError] = useState<string | null>(null);
   const [gradeRows, setGradeRows] = useState<GradeRow[] | null>(null);
-  const [gradeListOpen, setGradeListOpen] = useState(true);
+  const [gradeListOpen, setGradeListOpen] = useState(false);
+  const [gpaInputError, setGpaInputError] = useState<string | null>(null);
+
+  // 마운트 시 저장된 수강 과목 복원
+  useEffect(() => {
+    if (readOnly) return;
+    const stored = loadStoredGrades();
+    if (stored) setGradeRows(stored);
+  }, [readOnly]);
 
   async function handleKupidLogin() {
     setKupidLoading(true);
@@ -106,6 +139,7 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
       setDraft(newData);
       setDraftStr({ overall: toStr(overall), major: toStr(major) });
       setGradeRows(rows);
+      storeGrades(rows);
       setGradeListOpen(true);
       if (onSave) await onSave(newData);
 
@@ -122,6 +156,9 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
   const draftConverted = calcConverted(draft.overall);
 
   async function handleSave() {
+    const err = validateGpaStr(draftStr.overall) ?? validateGpaStr(draftStr.major);
+    if (err) { setGpaInputError(err); return; }
+    setGpaInputError(null);
     setIsSaving(true);
     try {
       const saveData: GpaData = { ...draft, converted: draftConverted };
@@ -136,6 +173,7 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
   function handleCancel() {
     setDraft(data);
     setDraftStr({ overall: toStr(data.overall), major: toStr(data.major) });
+    setGpaInputError(null);
     setIsEditing(false);
   }
 
@@ -144,8 +182,8 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-base font-semibold text-text-primary">GPA</h2>
         {!readOnly && (isEditing
-          ? <EditButtons onCancel={handleCancel} onSave={handleSave} disabled={isSaving} />
-          : <EditButton onClick={() => { setDraft(data); setDraftStr({ overall: toStr(data.overall), major: toStr(data.major) }); setIsEditing(true); }} />
+          ? <EditButtons onCancel={handleCancel} onSave={handleSave} disabled={isSaving || gpaInputError != null} />
+          : <EditButton onClick={() => { setDraft(data); setDraftStr({ overall: toStr(data.overall), major: toStr(data.major) }); setGpaInputError(null); setIsEditing(true); }} />
         )}
       </div>
 
@@ -157,10 +195,12 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
             {isEditing && !readOnly ? (
               <input
                 type="text"
+                inputMode="decimal"
                 value={draftStr.overall}
                 onChange={(e) => {
                   const val = e.target.value;
-                  if (/^-?\d*\.?\d*$/.test(val) || val === '') {
+                  if (/^\d*\.?\d*$/.test(val)) {
+                    if (gpaInputError) setGpaInputError(null);
                     setDraftStr(prev => ({ ...prev, overall: val }));
                     setDraft(prev => ({ ...prev, overall: val === '' || val === '.' ? null : Number(val) }));
                   }
@@ -183,10 +223,12 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
             {isEditing && !readOnly ? (
               <input
                 type="text"
+                inputMode="decimal"
                 value={draftStr.major}
                 onChange={(e) => {
                   const val = e.target.value;
-                  if (/^-?\d*\.?\d*$/.test(val) || val === '') {
+                  if (/^\d*\.?\d*$/.test(val)) {
+                    if (gpaInputError) setGpaInputError(null);
                     setDraftStr(prev => ({ ...prev, major: val }));
                     setDraft(prev => ({ ...prev, major: val === '' || val === '.' ? null : Number(val) }));
                   }
@@ -218,6 +260,10 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
           </div>
         </div>
       </div>
+
+      {isEditing && gpaInputError && (
+        <p className="text-xs text-red-500 mt-3">{gpaInputError}</p>
+      )}
 
       {/* 수강 과목 목록 */}
       {gradeRows && gradeRows.length > 0 && (() => {
@@ -282,17 +328,29 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
         );
       })()}
 
-      {!showKupid && !gradeRows && !readOnly && (
+      {!showKupid && !readOnly && (
         <div className="flex justify-center mt-8">
-          <button
-            onClick={() => setShowKupid(true)}
-            className="flex items-center gap-2 text-sm text-text-secondary border border-border px-4 py-2 rounded-md hover:bg-gray-50 transition-colors"
-          >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" /><polyline points="17 21 17 13 7 13 7 21" /><polyline points="7 3 7 8 15 8" />
-            </svg>
-            학업 정보 불러오기 (선택)
-          </button>
+          {gradeRows ? (
+            <button
+              onClick={() => setShowKupid(true)}
+              className="flex items-center gap-2 text-xs text-text-secondary hover:text-brand transition-colors"
+            >
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8" /><path d="M21 3v5h-5" />
+              </svg>
+              KUPID에서 다시 불러오기
+            </button>
+          ) : (
+            <button
+              onClick={() => setShowKupid(true)}
+              className="flex items-center gap-2 text-sm text-text-secondary border border-border px-4 py-2 rounded-md hover:bg-gray-50 transition-colors"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" /><polyline points="17 21 17 13 7 13 7 21" /><polyline points="7 3 7 8 15 8" />
+              </svg>
+              학업 정보 불러오기 (선택)
+            </button>
+          )}
         </div>
       )}
 

--- a/apps/web/src/components/quantitative/GpaCard.tsx
+++ b/apps/web/src/components/quantitative/GpaCard.tsx
@@ -41,6 +41,45 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
   const [showKupid, setShowKupid] = useState(false);
   const [kupidId, setKupidId] = useState('');
   const [kupidPw, setKupidPw] = useState('');
+  const [kupidLoading, setKupidLoading] = useState(false);
+  const [kupidError, setKupidError] = useState<string | null>(null);
+
+  async function handleKupidLogin() {
+    setKupidLoading(true);
+    setKupidError(null);
+    try {
+      const res = await fetch('/api/mentee/grades', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ id: kupidId, pw: kupidPw }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setKupidError(json.error ?? '오류가 발생했습니다.');
+        return;
+      }
+      // rows: [{ 학점, 평점, ... }] → overall GPA 자동 계산
+      const rows: Record<string, string>[] = json.rows ?? [];
+      const credits = rows.map(r => ({ credit: parseFloat(r['학점'] ?? '0'), grade: parseFloat(r['평점'] ?? '0') })).filter(r => !isNaN(r.credit) && !isNaN(r.grade) && r.credit > 0);
+      if (credits.length > 0) {
+        const totalCredits = credits.reduce((s, r) => s + r.credit, 0);
+        const overall = Math.round((credits.reduce((s, r) => s + r.credit * r.grade, 0) / totalCredits) * 100) / 100;
+        const newData: GpaData = { ...data, overall, converted: calcConverted(overall) };
+        setData(newData);
+        setDraft(newData);
+        setDraftStr({ overall: String(overall), major: toStr(newData.major) });
+        if (onSave) await onSave(newData);
+      }
+      setShowKupid(false);
+      setKupidId('');
+      setKupidPw('');
+    } catch {
+      setKupidError('네트워크 오류가 발생했습니다.');
+    } finally {
+      setKupidLoading(false);
+    }
+  }
 
   const draftConverted = calcConverted(draft.overall);
 
@@ -189,15 +228,23 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
               />
             </div>
           </div>
+          {kupidError && (
+            <p className="text-xs text-red-500 mb-3">{kupidError}</p>
+          )}
           <div className="flex justify-end gap-2">
             <button
-              onClick={() => { setShowKupid(false); setKupidId(''); setKupidPw(''); }}
-              className="px-4 py-2 text-sm text-text-secondary border border-border rounded-md hover:bg-gray-50 transition-colors"
+              onClick={() => { setShowKupid(false); setKupidId(''); setKupidPw(''); setKupidError(null); }}
+              disabled={kupidLoading}
+              className="px-4 py-2 text-sm text-text-secondary border border-border rounded-md hover:bg-gray-50 transition-colors disabled:opacity-40"
             >
               취소
             </button>
-            <button className="px-4 py-2 text-sm text-white bg-brand rounded-md hover:bg-brand-dark transition-colors">
-              로그인
+            <button
+              onClick={handleKupidLogin}
+              disabled={kupidLoading || !kupidId || !kupidPw}
+              className="px-4 py-2 text-sm text-white bg-brand rounded-md hover:bg-brand-dark transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {kupidLoading ? '불러오는 중...' : '로그인'}
             </button>
           </div>
         </div>

--- a/apps/web/src/components/quantitative/GpaCard.tsx
+++ b/apps/web/src/components/quantitative/GpaCard.tsx
@@ -2,25 +2,11 @@
 
 import { useEffect, useState } from 'react';
 import { EditButton, EditButtons } from '@/components/ui/EditButton';
-import { getUser, type GpaSection } from '@/lib/api';
+import type { GpaSection } from '@/lib/api';
+import KupidLoginModal, { type GradesResult } from './KupidLoginModal';
 
 export type GpaData = GpaSection;
 type GradeRow = Record<string, string>;
-
-const GRADES_STORAGE_PREFIX = 'plawcess:kupid-grades:';
-function gradesStorageKey(): string {
-  return GRADES_STORAGE_PREFIX + (getUser()?.user_id ?? 'anon');
-}
-function loadStoredGrades(): GradeRow[] | null {
-  try {
-    const raw = localStorage.getItem(gradesStorageKey());
-    const parsed = raw ? JSON.parse(raw) : null;
-    return Array.isArray(parsed) && parsed.length > 0 ? parsed : null;
-  } catch { return null; }
-}
-function storeGrades(rows: GradeRow[]) {
-  try { localStorage.setItem(gradesStorageKey(), JSON.stringify(rows)); } catch { /* 용량 초과 등 무시 */ }
-}
 
 type Props = {
   initialData: GpaData;
@@ -93,63 +79,56 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
   const [isEditing, setIsEditing] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
 
-  const [showKupid, setShowKupid] = useState(false);
-  const [kupidId, setKupidId] = useState('');
-  const [kupidPw, setKupidPw] = useState('');
-  const [kupidLoading, setKupidLoading] = useState(false);
-  const [kupidError, setKupidError] = useState<string | null>(null);
+  const [showKupidModal, setShowKupidModal] = useState(false);
   const [gradeRows, setGradeRows] = useState<GradeRow[] | null>(null);
   const [gradeListOpen, setGradeListOpen] = useState(false);
+  const [deletingGrades, setDeletingGrades] = useState(false);
   const [gpaInputError, setGpaInputError] = useState<string | null>(null);
 
-  // 마운트 시 저장된 수강 과목 복원
+  // 마운트 시 DB에 저장된 수강 과목 복원
   useEffect(() => {
     if (readOnly) return;
-    const stored = loadStoredGrades();
-    if (stored) setGradeRows(stored);
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/mentee/grades', { credentials: 'include' });
+        if (!res.ok) return;
+        const json = await res.json();
+        const rows: GradeRow[] = json.rows ?? [];
+        if (!cancelled && rows.length > 0) setGradeRows(rows);
+      } catch { /* 무시 */ }
+    })();
+    return () => { cancelled = true; };
   }, [readOnly]);
 
-  async function handleKupidLogin() {
-    setKupidLoading(true);
-    setKupidError(null);
+  async function handleGradesLoaded(result: GradesResult) {
+    const rows = result.rows;
+    const summary = result.summary;
+    console.log('[KUPID] summary:', summary);
+    console.log('[KUPID] rows sample:', rows.slice(0, 3));
+
+    // 전체 평점 평균 = KUPID 증명용 평점평균 (없으면 가중 계산으로 폴백)
+    const overall = pickCertifiedGpa(summary) ?? calcWeightedGpa(rows);
+    // 법학 과목 평점 평균 = 학수번호가 JURA로 시작하는 과목들의 가중 평균
+    const major = calcWeightedGpa(rows.filter(r => (r['학수번호'] ?? '').startsWith('JURA')));
+
+    const newData: GpaData = { ...data, overall, major, converted: calcConverted(overall) };
+    setData(newData);
+    setDraft(newData);
+    setDraftStr({ overall: toStr(overall), major: toStr(major) });
+    setGradeRows(rows);          // 저장은 API(POST)에서 이미 처리됨
+    setGradeListOpen(true);
+    if (onSave) await onSave(newData);
+  }
+
+  async function handleDeleteGrades() {
+    if (!window.confirm('불러온 수강 과목을 삭제할까요? GPA 값은 그대로 유지됩니다.')) return;
+    setDeletingGrades(true);
     try {
-      const res = await fetch('/api/mentee/grades', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ id: kupidId, pw: kupidPw }),
-      });
-      const json = await res.json();
-      if (!res.ok) {
-        setKupidError(json.error ?? '오류가 발생했습니다.');
-        return;
-      }
-      const rows: GradeRow[] = json.rows ?? [];
-      const summary: Record<string, string> = json.summary ?? {};
-      console.log('[KUPID] summary:', summary);
-      console.log('[KUPID] rows sample:', rows.slice(0, 3));
-
-      // 전체 평점 평균 = KUPID 증명용 평점평균 (없으면 가중 계산으로 폴백)
-      const overall = pickCertifiedGpa(summary) ?? calcWeightedGpa(rows);
-      // 전공 평점 평균 = 학수번호가 JURA로 시작하는 과목들의 가중 평균
-      const major = calcWeightedGpa(rows.filter(r => (r['학수번호'] ?? '').startsWith('JURA')));
-
-      const newData: GpaData = { ...data, overall, major, converted: calcConverted(overall) };
-      setData(newData);
-      setDraft(newData);
-      setDraftStr({ overall: toStr(overall), major: toStr(major) });
-      setGradeRows(rows);
-      storeGrades(rows);
-      setGradeListOpen(true);
-      if (onSave) await onSave(newData);
-
-      setShowKupid(false);
-      setKupidId('');
-      setKupidPw('');
-    } catch {
-      setKupidError('네트워크 오류가 발생했습니다.');
+      const res = await fetch('/api/mentee/grades', { method: 'DELETE', credentials: 'include' });
+      if (res.ok) setGradeRows(null);
     } finally {
-      setKupidLoading(false);
+      setDeletingGrades(false);
     }
   }
 
@@ -271,11 +250,11 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
         const totalCredits = validRows.reduce((s, r) => s + (parseFloat(r['학점'] ?? '') || 0), 0);
         return (
           <div className="mt-6 border-t border-border pt-6">
-            <button
-              onClick={() => setGradeListOpen(o => !o)}
-              className="w-full flex items-center justify-between mb-3 group"
-            >
-              <h3 className="flex items-center gap-1.5 text-sm font-semibold text-text-primary">
+            <div className="flex items-center justify-between mb-3 gap-2">
+              <button
+                onClick={() => setGradeListOpen(o => !o)}
+                className="flex items-center gap-1.5 text-sm font-semibold text-text-primary"
+              >
                 <svg
                   width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
                   className={`text-text-secondary transition-transform ${gradeListOpen ? 'rotate-90' : ''}`}
@@ -283,12 +262,25 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
                   <polyline points="9 18 15 12 9 6" />
                 </svg>
                 수강 과목
-              </h3>
-              <div className="flex items-center gap-4 text-xs text-text-secondary">
+              </button>
+              <div className="flex items-center gap-3 text-xs text-text-secondary">
                 <span>총 <span className="font-semibold text-text-primary">{validRows.length}</span>과목</span>
                 <span>총 <span className="font-semibold text-text-primary">{totalCredits}</span>학점</span>
+                {!readOnly && (
+                  <button
+                    onClick={handleDeleteGrades}
+                    disabled={deletingGrades}
+                    className="text-text-placeholder hover:text-red-500 transition-colors disabled:opacity-40"
+                    aria-label="수강 과목 삭제"
+                    title="수강 과목 삭제"
+                  >
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <polyline points="3 6 5 6 21 6" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+                    </svg>
+                  </button>
+                )}
               </div>
-            </button>
+            </div>
             {gradeListOpen && (
               <div className="overflow-auto max-h-72">
                 <table className="w-full text-xs table-fixed">
@@ -328,11 +320,11 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
         );
       })()}
 
-      {!showKupid && !readOnly && (
+      {!readOnly && (
         <div className="flex justify-center mt-8">
           {gradeRows ? (
             <button
-              onClick={() => setShowKupid(true)}
+              onClick={() => setShowKupidModal(true)}
               className="flex items-center gap-2 text-xs text-text-secondary hover:text-brand transition-colors"
             >
               <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -342,7 +334,7 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
             </button>
           ) : (
             <button
-              onClick={() => setShowKupid(true)}
+              onClick={() => setShowKupidModal(true)}
               className="flex items-center gap-2 text-sm text-text-secondary border border-border px-4 py-2 rounded-md hover:bg-gray-50 transition-colors"
             >
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -354,67 +346,11 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
         </div>
       )}
 
-      {showKupid && (
-        <div className="mt-6 border-t border-border pt-6">
-          <div className="flex flex-col gap-1.5 mb-4">
-            <div className="flex items-center gap-2">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-brand">
-                <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" /><polyline points="17 21 17 13 7 13 7 21" /><polyline points="7 3 7 8 15 8" />
-              </svg>
-              <span className="text-sm font-semibold text-text-primary">KUPID 로그인</span>
-            </div>
-            <p className="text-xs text-text-secondary">학업 성적표를 불러오기 위해 KUPID 계정으로 로그인해주세요.</p>
-          </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6 mb-4">
-            <div className="flex flex-col gap-1.5">
-              <label className="text-sm text-text-secondary">ID</label>
-              <input
-                type="text"
-                value={kupidId}
-                onChange={(e: { target: { value: string } }) => setKupidId(e.target.value)}
-                placeholder="ID를 입력하세요"
-                className="border border-border rounded-md px-3 py-2 text-sm text-text-primary placeholder:text-text-placeholder focus:outline-none focus:ring-2 focus:ring-brand"
-              />
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <label className="text-sm text-text-secondary">비밀번호</label>
-              <input
-                type="password"
-                value={kupidPw}
-                onChange={(e: { target: { value: string } }) => setKupidPw(e.target.value)}
-                onKeyDown={(e) => { if (e.key === 'Enter' && kupidId && kupidPw && !kupidLoading) handleKupidLogin(); }}
-                placeholder="비밀번호를 입력하세요"
-                className="border border-border rounded-md px-3 py-2 text-sm text-text-primary placeholder:text-text-placeholder focus:outline-none focus:ring-2 focus:ring-brand"
-              />
-            </div>
-          </div>
-          {kupidError && (
-            <p className="text-xs text-red-500 mb-3">{kupidError}</p>
-          )}
-          <div className="flex justify-end gap-2">
-            <button
-              onClick={() => { setShowKupid(false); setKupidId(''); setKupidPw(''); setKupidError(null); }}
-              disabled={kupidLoading}
-              className="px-4 py-2 text-sm text-text-secondary border border-border rounded-md hover:bg-gray-50 transition-colors disabled:opacity-40"
-            >
-              취소
-            </button>
-            <button
-              onClick={handleKupidLogin}
-              disabled={kupidLoading || !kupidId || !kupidPw}
-              className="px-4 py-2 text-sm text-white bg-brand rounded-md hover:bg-brand-dark transition-colors disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-2"
-            >
-              {kupidLoading && (
-                <svg className="animate-spin w-3.5 h-3.5" viewBox="0 0 24 24" fill="none">
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
-                </svg>
-              )}
-              {kupidLoading ? '불러오는 중...' : '로그인'}
-            </button>
-          </div>
-        </div>
-      )}
+      <KupidLoginModal
+        open={showKupidModal}
+        onClose={() => setShowKupidModal(false)}
+        onLoaded={handleGradesLoaded}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/quantitative/GpaCard.tsx
+++ b/apps/web/src/components/quantitative/GpaCard.tsx
@@ -5,6 +5,7 @@ import { EditButton, EditButtons } from '@/components/ui/EditButton';
 import type { GpaSection } from '@/lib/api';
 
 export type GpaData = GpaSection;
+type GradeRow = Record<string, string>;
 
 type Props = {
   initialData: GpaData;
@@ -28,6 +29,35 @@ function toStr(val: number | null): string {
   return val == null ? '' : String(val);
 }
 
+// 학점 가중 평점 평균. 재수강 대체 과목(삭제구분 != '')과 P/F 제외.
+function calcWeightedGpa(rows: GradeRow[]): number | null {
+  let sumCredits = 0;
+  let sumPoints = 0;
+  for (const r of rows) {
+    if ((r['삭제구분'] ?? '') !== '') continue;
+    const grade = r['등급'] ?? '';
+    if (grade === 'P' || grade === 'F') continue;
+    const credit = parseFloat(r['학점'] ?? '');
+    const point = parseFloat(r['평점'] ?? '');
+    if (isNaN(credit) || credit <= 0 || isNaN(point)) continue;
+    sumCredits += credit;
+    sumPoints += point * credit;
+  }
+  if (sumCredits === 0) return null;
+  return Math.round((sumPoints / sumCredits) * 100) / 100;
+}
+
+// KUPID 요약에서 증명용 평점평균 추출
+function pickCertifiedGpa(summary: Record<string, string>): number | null {
+  const keys = Object.keys(summary);
+  const certKey =
+    keys.find(k => k.includes('증명')) ??
+    keys.find(k => k.includes('평점평균') && !k.includes('전공') && !k.includes('백분율'));
+  if (!certKey) return null;
+  const v = parseFloat(summary[certKey]);
+  return isNaN(v) ? null : v;
+}
+
 export default function GpaCard({ initialData, onSave, readOnly }: Props) {
   const [data, setData] = useState<GpaData>(initialData);
   const [draft, setDraft] = useState<GpaData>(initialData);
@@ -43,6 +73,7 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
   const [kupidPw, setKupidPw] = useState('');
   const [kupidLoading, setKupidLoading] = useState(false);
   const [kupidError, setKupidError] = useState<string | null>(null);
+  const [gradeRows, setGradeRows] = useState<GradeRow[] | null>(null);
 
   async function handleKupidLogin() {
     setKupidLoading(true);
@@ -59,18 +90,23 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
         setKupidError(json.error ?? '오류가 발생했습니다.');
         return;
       }
-      // rows: [{ 학점, 평점, ... }] → overall GPA 자동 계산
-      const rows: Record<string, string>[] = json.rows ?? [];
-      const credits = rows.map(r => ({ credit: parseFloat(r['학점'] ?? '0'), grade: parseFloat(r['평점'] ?? '0') })).filter(r => !isNaN(r.credit) && !isNaN(r.grade) && r.credit > 0);
-      if (credits.length > 0) {
-        const totalCredits = credits.reduce((s, r) => s + r.credit, 0);
-        const overall = Math.round((credits.reduce((s, r) => s + r.credit * r.grade, 0) / totalCredits) * 100) / 100;
-        const newData: GpaData = { ...data, overall, converted: calcConverted(overall) };
-        setData(newData);
-        setDraft(newData);
-        setDraftStr({ overall: String(overall), major: toStr(newData.major) });
-        if (onSave) await onSave(newData);
-      }
+      const rows: GradeRow[] = json.rows ?? [];
+      const summary: Record<string, string> = json.summary ?? {};
+      console.log('[KUPID] summary:', summary);
+      console.log('[KUPID] rows sample:', rows.slice(0, 3));
+
+      // 전체 평점 평균 = KUPID 증명용 평점평균 (없으면 가중 계산으로 폴백)
+      const overall = pickCertifiedGpa(summary) ?? calcWeightedGpa(rows);
+      // 전공 평점 평균 = 학수번호가 JURA로 시작하는 과목들의 가중 평균
+      const major = calcWeightedGpa(rows.filter(r => (r['학수번호'] ?? '').startsWith('JURA')));
+
+      const newData: GpaData = { ...data, overall, major, converted: calcConverted(overall) };
+      setData(newData);
+      setDraft(newData);
+      setDraftStr({ overall: toStr(overall), major: toStr(major) });
+      setGradeRows(rows);
+      if (onSave) await onSave(newData);
+
       setShowKupid(false);
       setKupidId('');
       setKupidPw('');
@@ -181,7 +217,57 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
         </div>
       </div>
 
-      {!showKupid && (
+      {/* 수강 과목 목록 */}
+      {gradeRows && gradeRows.length > 0 && (() => {
+        const validRows = gradeRows.filter(r => (r['삭제구분'] ?? '') === '' && r['등급'] !== 'F');
+        const totalCredits = validRows.reduce((s, r) => s + (parseFloat(r['학점'] ?? '') || 0), 0);
+        return (
+          <div className="mt-6 border-t border-border pt-6">
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-sm font-semibold text-text-primary">수강 과목</h3>
+              <div className="flex items-center gap-4 text-xs text-text-secondary">
+                <span>총 <span className="font-semibold text-text-primary">{validRows.length}</span>과목</span>
+                <span>총 <span className="font-semibold text-text-primary">{totalCredits}</span>학점</span>
+              </div>
+            </div>
+            <div className="overflow-auto max-h-72">
+              <table className="w-full text-xs table-fixed">
+                <thead>
+                  <tr className="border-b border-border">
+                    <th className="pb-2 text-left text-text-secondary font-normal w-16">년도</th>
+                    <th className="pb-2 text-left text-text-secondary font-normal w-14">학기</th>
+                    <th className="pb-2 text-left text-text-secondary font-normal">과목명</th>
+                    <th className="pb-2 text-left text-text-secondary font-normal w-20">이수구분</th>
+                    <th className="pb-2 text-right text-text-secondary font-normal w-10">학점</th>
+                    <th className="pb-2 text-right text-text-secondary font-normal w-10">등급</th>
+                    <th className="pb-2 text-right text-text-secondary font-normal w-10">평점</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {gradeRows.map((row, i) => {
+                    const isRetaken = (row['삭제구분'] ?? '') !== '';
+                    const cls = isRetaken ? 'line-through text-text-placeholder' : 'text-text-primary';
+                    const subCls = isRetaken ? 'text-text-placeholder' : 'text-text-secondary';
+                    return (
+                      <tr key={i} className={`border-b border-border last:border-0 ${isRetaken ? 'opacity-50' : ''}`}>
+                        <td className={`py-2 whitespace-nowrap ${subCls}`}>{row['년도']}</td>
+                        <td className={`py-2 whitespace-nowrap ${subCls}`}>{row['학기']}</td>
+                        <td className={`py-2 truncate pr-2 ${cls}`}>{row['과목명']}</td>
+                        <td className={`py-2 whitespace-nowrap ${subCls}`}>{row['이수구분']}</td>
+                        <td className={`py-2 text-right whitespace-nowrap ${cls}`}>{row['학점']}</td>
+                        <td className={`py-2 text-right whitespace-nowrap ${cls}`}>{row['등급']}</td>
+                        <td className={`py-2 text-right whitespace-nowrap font-semibold ${cls}`}>{row['평점']}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        );
+      })()}
+
+      {!showKupid && !gradeRows && !readOnly && (
         <div className="flex justify-center mt-8">
           <button
             onClick={() => setShowKupid(true)}
@@ -206,7 +292,7 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
             </div>
             <p className="text-xs text-text-secondary">학업 성적표를 불러오기 위해 KUPID 계정으로 로그인해주세요.</p>
           </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6 mb-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6 mb-4">
             <div className="flex flex-col gap-1.5">
               <label className="text-sm text-text-secondary">ID</label>
               <input
@@ -223,6 +309,7 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
                 type="password"
                 value={kupidPw}
                 onChange={(e: { target: { value: string } }) => setKupidPw(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter' && kupidId && kupidPw && !kupidLoading) handleKupidLogin(); }}
                 placeholder="비밀번호를 입력하세요"
                 className="border border-border rounded-md px-3 py-2 text-sm text-text-primary placeholder:text-text-placeholder focus:outline-none focus:ring-2 focus:ring-brand"
               />
@@ -242,8 +329,14 @@ export default function GpaCard({ initialData, onSave, readOnly }: Props) {
             <button
               onClick={handleKupidLogin}
               disabled={kupidLoading || !kupidId || !kupidPw}
-              className="px-4 py-2 text-sm text-white bg-brand rounded-md hover:bg-brand-dark transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              className="px-4 py-2 text-sm text-white bg-brand rounded-md hover:bg-brand-dark transition-colors disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-2"
             >
+              {kupidLoading && (
+                <svg className="animate-spin w-3.5 h-3.5" viewBox="0 0 24 24" fill="none">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+                </svg>
+              )}
               {kupidLoading ? '불러오는 중...' : '로그인'}
             </button>
           </div>

--- a/apps/web/src/components/quantitative/KupidLoginModal.tsx
+++ b/apps/web/src/components/quantitative/KupidLoginModal.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+export type GradeRow = Record<string, string>;
+export type GradesResult = { rows: GradeRow[]; summary: Record<string, string> };
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onLoaded: (result: GradesResult) => void | Promise<void>;
+}
+
+export default function KupidLoginModal({ open, onClose, onLoaded }: Props) {
+  if (!open) return null;
+  return <KupidLoginModalInner onClose={onClose} onLoaded={onLoaded} />;
+}
+
+function KupidLoginModalInner({ onClose, onLoaded }: Omit<Props, 'open'>) {
+  const [kupidId, setKupidId] = useState('');
+  const [kupidPw, setKupidPw] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const idRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const id = window.setTimeout(() => idRef.current?.focus(), 0);
+    return () => window.clearTimeout(id);
+  }, []);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) { if (e.key === 'Escape' && !loading) onClose(); }
+    document.addEventListener('keydown', onKey);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.body.style.overflow = prev;
+    };
+  }, [onClose, loading]);
+
+  async function handleSubmit() {
+    if (!kupidId || !kupidPw || loading) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/mentee/grades', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ id: kupidId, pw: kupidPw }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setError(json.error ?? '오류가 발생했습니다.');
+        return;
+      }
+      await onLoaded({ rows: json.rows ?? [], summary: json.summary ?? {} });
+      onClose();
+    } catch {
+      setError('네트워크 오류가 발생했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
+      <div className="absolute inset-0 bg-black/40" onClick={() => { if (!loading) onClose(); }} />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="KUPID 로그인"
+        className="relative bg-white rounded-2xl shadow-xl w-full max-w-md"
+      >
+        {/* 헤더 */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-border">
+          <h2 className="flex items-center gap-2 text-base font-semibold text-text-primary">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-brand">
+              <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" /><polyline points="17 21 17 13 7 13 7 21" /><polyline points="7 3 7 8 15 8" />
+            </svg>
+            KUPID 로그인
+          </h2>
+          <button type="button" onClick={() => { if (!loading) onClose(); }} aria-label="닫기" className="text-text-placeholder hover:text-text-primary disabled:opacity-40" disabled={loading}>
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        {/* 본문 */}
+        <div className="px-6 py-5">
+          <p className="text-xs text-text-secondary mb-4">학업 성적표를 불러오기 위해 KUPID 계정으로 로그인해주세요. 입력한 정보는 저장되지 않습니다.</p>
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm text-text-secondary">ID</label>
+              <input
+                ref={idRef}
+                type="text"
+                value={kupidId}
+                onChange={(e) => setKupidId(e.target.value)}
+                placeholder="ID를 입력하세요"
+                disabled={loading}
+                className="border border-border rounded-md px-3 py-2 text-sm text-text-primary placeholder:text-text-placeholder focus:outline-none focus:ring-2 focus:ring-brand disabled:bg-page-bg"
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm text-text-secondary">비밀번호</label>
+              <input
+                type="password"
+                value={kupidPw}
+                onChange={(e) => setKupidPw(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') handleSubmit(); }}
+                placeholder="비밀번호를 입력하세요"
+                disabled={loading}
+                className="border border-border rounded-md px-3 py-2 text-sm text-text-primary placeholder:text-text-placeholder focus:outline-none focus:ring-2 focus:ring-brand disabled:bg-page-bg"
+              />
+            </div>
+          </div>
+          {error && <p className="text-xs text-red-500 mt-3">{error}</p>}
+          {loading && <p className="text-xs text-text-secondary mt-3">KUPID에서 성적을 불러오는 중입니다. 최대 1~2분 걸릴 수 있어요.</p>}
+        </div>
+
+        {/* 푸터 */}
+        <div className="flex items-center justify-end gap-2 px-6 py-4 border-t border-border">
+          <button
+            type="button"
+            onClick={() => { if (!loading) onClose(); }}
+            disabled={loading}
+            className="px-4 py-2 text-sm text-text-secondary hover:text-text-primary disabled:opacity-40"
+          >
+            취소
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={loading || !kupidId || !kupidPw}
+            className="px-4 py-2 text-sm bg-brand text-white rounded-lg hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-2"
+          >
+            {loading && (
+              <svg className="animate-spin w-3.5 h-3.5" viewBox="0 0 24 24" fill="none">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+              </svg>
+            )}
+            {loading ? '불러오는 중...' : '로그인'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/quantitative/KupidLoginModal.tsx
+++ b/apps/web/src/components/quantitative/KupidLoginModal.tsx
@@ -90,7 +90,7 @@ function KupidLoginModalInner({ onClose, onLoaded }: Omit<Props, 'open'>) {
 
         {/* 본문 */}
         <div className="px-6 py-5">
-          <p className="text-xs text-text-secondary mb-4">학업 성적표를 불러오기 위해 KUPID 계정으로 로그인해주세요. 입력한 정보는 저장되지 않습니다.</p>
+          <p className="text-xs text-text-secondary mb-4">학업 성적표를 불러오기 위해 KUPID 계정으로 로그인해주세요.<br />입력한 정보는 저장되지 않습니다.</p>
           <div className="flex flex-col gap-4">
             <div className="flex flex-col gap-1.5">
               <label className="text-sm text-text-secondary">ID</label>

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -168,6 +168,9 @@ model MenteeRecord {
   toefl_score Int?
   teps_score  Int?
 
+  // KUPID에서 불러온 수강 과목 원본 (표시용) — GradeRow[]
+  kupid_grades Json?
+
   // 희망 로스쿨 — 가/나군 단일 슬롯, 슬롯별 학교 + 특별전형 여부
   target_school_ga String? @db.VarChar(100) // 가군
   is_special_ga    Boolean @default(false)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       '@prisma/client':
         specifier: ^7.6.0
         version: 7.6.0(prisma@7.6.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
+      '@sparticuz/chromium':
+        specifier: ^148.0.0
+        version: 148.0.0
       '@supabase/supabase-js':
         specifier: ^2.105.4
         version: 2.105.4
@@ -43,6 +46,9 @@ importers:
       pg:
         specifier: ^8.20.0
         version: 8.20.0
+      playwright-core:
+        specifier: ^1.60.0
+        version: 1.60.0
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -568,105 +574,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -736,28 +726,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.2':
     resolution: {integrity: sha512-VKLuscm0P/mIfzt+SDdn2+8TNNJ7f0qfEkA+az7OqQbjzKdBxAHs0UvuiVoCtbwX+dqMEL9U54b5wQ/aN3dHeg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.2':
     resolution: {integrity: sha512-kU3OPHJq6sBUjOk7wc5zJ7/lipn8yGldMoAv4z67j6ov6Xo/JvzA7L7LCsyzzsXmgLEhk3Qkpwqaq/1+XpNR3g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.2':
     resolution: {integrity: sha512-CKXRILyErMtUftp+coGcZ38ZwE/Aqq45VMCcRLr2I4OXKrgxIBDXHnBgeX/UMil0S09i2JXaDL3Q+TN8D/cKmg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.2':
     resolution: {integrity: sha512-sS/jSk5VUoShUqINJFvNjVT7JfR5ORYj/+/ZpOYbbIohv/lQfduWnGAycq2wlknbOql2xOR0DoV0s6Xfcy49+g==}
@@ -960,6 +946,10 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
+  '@sparticuz/chromium@148.0.0':
+    resolution: {integrity: sha512-na5beDSZkrlcEWEMt+eHu4Xe+MLUgCtHBjHaXGsNaQu5tJWwXE+McxAcMtyumEM/JzXrxGpkO5vAPD9TWhil3g==}
+    engines: {node: '>=22.17.0'}
+
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
@@ -1034,28 +1024,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -1228,49 +1214,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -1400,12 +1378,61 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  bare-events@2.8.2:
+    resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.7.1:
+    resolution: {integrity: sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.9.1:
+    resolution: {integrity: sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.0:
+    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
+
+  bare-stream@2.13.1:
+    resolution: {integrity: sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.3:
+    resolution: {integrity: sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -1853,6 +1880,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   exceljs@4.4.0:
     resolution: {integrity: sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==}
     engines: {node: '>=8.3.0'}
@@ -1873,6 +1903,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -2369,28 +2402,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2738,6 +2767,11 @@ packages:
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -2806,6 +2840,9 @@ packages:
   protobufjs@7.5.6:
     resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
     engines: {node: '>=12.0.0'}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3020,6 +3057,9 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  streamx@2.25.0:
+    resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
+
   string.prototype.includes@2.0.1:
     resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
     engines: {node: '>= 0.4'}
@@ -3085,9 +3125,21 @@ packages:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
+  tar-fs@3.1.2:
+    resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
+
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
+
+  tar-stream@3.2.0:
+    resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   tinyexec@1.0.4:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
@@ -3951,6 +4003,14 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
+  '@sparticuz/chromium@148.0.0':
+    dependencies:
+      tar-fs: 3.1.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
   '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -4409,9 +4469,43 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  b4a@1.8.1: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  bare-events@2.8.2: {}
+
+  bare-fs@4.7.1:
+    dependencies:
+      bare-events: 2.8.2
+      bare-path: 3.0.0
+      bare-stream: 2.13.1(bare-events@2.8.2)
+      bare-url: 2.4.3
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-os@3.9.1: {}
+
+  bare-path@3.0.0:
+    dependencies:
+      bare-os: 3.9.1
+
+  bare-stream@2.13.1(bare-events@2.8.2):
+    dependencies:
+      streamx: 2.25.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.4.3:
+    dependencies:
+      bare-path: 3.0.0
 
   base64-js@1.5.1: {}
 
@@ -5068,6 +5162,12 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   exceljs@4.4.0:
     dependencies:
       archiver: 5.3.2
@@ -5094,6 +5194,8 @@ snapshots:
       '@fast-csv/parse': 4.3.6
 
   fast-deep-equal@3.1.3: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.1:
     dependencies:
@@ -5960,6 +6062,8 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
+  playwright-core@1.60.0: {}
+
   possible-typed-array-names@1.1.0: {}
 
   postal-mime@2.7.4: {}
@@ -6037,6 +6141,11 @@ snapshots:
       '@protobufjs/utf8': 1.1.1
       '@types/node': 20.19.39
       long: 5.3.2
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
 
   punycode@2.3.1: {}
 
@@ -6289,6 +6398,15 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
+  streamx@2.25.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   string.prototype.includes@2.0.1:
     dependencies:
       call-bind: 1.0.8
@@ -6368,6 +6486,18 @@ snapshots:
 
   tapable@2.3.2: {}
 
+  tar-fs@3.1.2:
+    dependencies:
+      pump: 3.0.4
+      tar-stream: 3.2.0
+    optionalDependencies:
+      bare-fs: 4.7.1
+      bare-path: 3.0.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
   tar-stream@2.2.0:
     dependencies:
       bl: 4.1.0
@@ -6375,6 +6505,30 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  tar-stream@3.2.0:
+    dependencies:
+      b4a: 1.8.1
+      bare-fs: 4.7.1
+      fast-fifo: 1.3.2
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
 
   tinyexec@1.0.4: {}
 


### PR DESCRIPTION
## 개요
멘티 정량 데이터 페이지에 KUPID 성적 스크래핑을 연동한다. (이슈 #34, 기존 `9425b0d` 구현이 revert됐던 것을 Vercel 호환 형태로 복구·확장)

## 주요 변경
### 스크래핑 (`apps/api`)
- Python 스크립트(`tools/scrape_grades.py`)를 TypeScript로 포팅 (`apps/api/src/lib/scrapeGrades.ts`)
  - `@sparticuz/chromium` + `playwright-core` 사용 → Vercel Pro 함수 제한(250MB / 300초) 안에서 동작
  - 로컬 개발 시 시스템 Chrome 사용
  - `page.evaluate()` DOM 추출 — 섹션 헤더 행 자동 스킵, 전체 수강 과목 + 평점평균 요약값(`summary`) 추출
- `POST /api/mentee/grades`: 스크래핑 후 `MenteeRecord.kupid_grades`(JSONB)에 저장
- `GET /api/mentee/grades`: 저장된 수강 과목 조회
- `DELETE /api/mentee/grades`: 수강 과목 삭제
- rate limit(60초/user)은 프로덕션에서만 적용

### DB 스키마
- `MenteeRecord.kupid_grades` (`Json?` → `jsonb`) 필드 추가
- **마이그레이션**: Supabase에서 아래 SQL 수동 실행 필요
  ```sql
  ALTER TABLE mentee_records ADD COLUMN kupid_grades JSONB;
  ```

### 프론트엔드 (`apps/web`)
- `GpaCard`: KUPID 로그인 → 성적 자동 채우기 연동
  - **전체 평점 평균** = KUPID 증명용 평점평균 (없으면 학점 가중 계산 폴백)
  - **법학 과목 평점 평균** = 학수번호 `JURA` 시작 과목들의 학점 가중평균 (재수강 대체·P/F 제외)
  - 환산점수 자동 계산 유지
- `KupidLoginModal`: KUPID 로그인을 오버레이 모달로 (희망 학교 편집과 동일 패턴)
- 수강 과목 목록 테이블 표시 (재수강 대체 과목 취소선, 과목 수/총 학점, 접기/펼치기, 삭제 버튼)
- 페이지 마운트 시 DB에서 수강 과목 복원, "KUPID에서 다시 불러오기" 버튼
- GPA 입력 검증 — 저장 시점에 `0 ~ 4.5`, 소수점 둘째 자리까지 체크 (어긋나면 빨간 안내 + 저장 차단)

## 배포 전 체크리스트
- [ ] Supabase에 `ALTER TABLE mentee_records ADD COLUMN kupid_grades JSONB;` 실행
- [ ] (Vercel) `@sparticuz/chromium` 콜드스타트 시 `/tmp`에 Chromium 다운로드 → 첫 호출 30~60초 소요 감안

🤖 Generated with [Claude Code](https://claude.com/claude-code)