### PR TITLE
fix(security): HWP 업로드 크기·확장자·매직넘버 검증 추가 (#218)

### DIFF
--- a/apps/api/scripts/verify-hwp-upload.ts
+++ b/apps/api/scripts/verify-hwp-upload.ts
@@ -1,0 +1,51 @@
+// HWP 업로드 검증 헬퍼 단독 검사.
+// 실행: node --experimental-strip-types apps/api/scripts/verify-hwp-upload.ts   (Node 24)
+import { validateHwpUpload, MAX_HWP_BYTES } from "../src/lib/hwp-upload.ts";
+
+const CFBF = Buffer.from([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]);
+const ZIP = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
+const PDF = Buffer.from("%PDF-1.4\n%\xe2\xe3\xcf\xd3\nrest of a pdf", "latin1");
+
+// 정상 .hwp: CFBF 매직 + 'HWP Document File' 시그니처(+버전) + 패딩.
+const validHwp = Buffer.concat([
+  CFBF,
+  Buffer.from("HWP Document File", "latin1"),
+  Buffer.alloc(64), // 패딩
+]);
+// 정상 .hwpx: ZIP 매직으로 시작하는 임의 바이트.
+const validHwpx = Buffer.concat([ZIP, Buffer.alloc(128)]);
+
+function file(name: string, data: Buffer): File {
+  return new File([data], name, { type: "" });
+}
+
+type Case = { name: string; input: unknown; expect: "ok" | number };
+
+const cases: Case[] = [
+  { name: "null", input: null, expect: 400 },
+  { name: "문자열", input: "not a file", expect: 400 },
+  { name: "빈 .hwp", input: file("x.hwp", Buffer.alloc(0)), expect: 400 },
+  { name: "초과 크기 .hwp", input: file("big.hwp", Buffer.concat([validHwp, Buffer.alloc(MAX_HWP_BYTES)])), expect: 413 },
+  { name: ".pdf 확장자", input: file("doc.pdf", PDF), expect: 415 },
+  { name: ".hwp 확장자인데 PDF 내용", input: file("fake.hwp", PDF), expect: 415 },
+  { name: ".hwp 확장자인데 CFBF 매직만 (시그니처 없음)", input: file("nosig.hwp", Buffer.concat([CFBF, Buffer.alloc(64)])), expect: 415 },
+  { name: ".hwpx 확장자인데 ZIP 아님", input: file("fake.hwpx", PDF), expect: 415 },
+  { name: "정상 .hwp", input: file("ok.hwp", validHwp), expect: "ok" },
+  { name: "정상 .HWP (대문자 확장자)", input: file("OK.HWP", validHwp), expect: "ok" },
+  { name: "정상 .hwpx", input: file("ok.hwpx", validHwpx), expect: "ok" },
+];
+
+let failed = 0;
+for (const c of cases) {
+  const r = await validateHwpUpload(c.input);
+  const got = r.ok ? "ok" : r.status;
+  const pass = got === c.expect;
+  if (!pass) failed++;
+  console.log(`${pass ? "PASS" : "FAIL"}  ${c.name}  →  expected ${c.expect}, got ${got}${!r.ok ? ` ("${r.error}")` : ""}`);
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} case(s) failed.`);
+  process.exit(1);
+}
+console.log(`\nAll ${cases.length} cases passed.`);

--- a/apps/api/src/app/api/admin/personal-statements/route.ts
+++ b/apps/api/src/app/api/admin/personal-statements/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@plawcess/database";
 import { requireAdmin } from "@/lib/admin-guard";
+import { validateHwpUpload } from "@/lib/hwp-upload";
 
 function getProcessYear(req: NextRequest): number {
   const raw = req.nextUrl.searchParams.get("year");
@@ -49,12 +50,10 @@ export async function PATCH(req: NextRequest) {
   }
 
   const formData = await req.formData();
-  const file = formData.get("hwp");
-  if (!file || !(file instanceof Blob)) {
-    return NextResponse.json({ error: "hwp 파일이 없습니다" }, { status: 400 });
-  }
+  const v = await validateHwpUpload(formData.get("hwp"));
+  if (!v.ok) return NextResponse.json({ error: v.error }, { status: v.status });
+  const bytes = v.bytes;
 
-  const bytes = Buffer.from(await file.arrayBuffer());
   await prisma.schoolPersonalStatement.upsert({
     where: { school_name_process_year: { school_name: school, process_year: year } },
     create: { school_name: school, process_year: year, hwp_data: bytes },

--- a/apps/api/src/app/api/mentee/personal-statement/route.ts
+++ b/apps/api/src/app/api/mentee/personal-statement/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@plawcess/database";
 import { getTokenFromCookie } from "@/lib/auth";
+import { validateHwpUpload } from "@/lib/hwp-upload";
 
 function getUserId(req: NextRequest): string | null {
   return getTokenFromCookie(req)?.user_id ?? null;
@@ -98,12 +99,10 @@ export async function PATCH(req: NextRequest) {
   }
 
   const formData = await req.formData();
-  const file = formData.get("hwp");
-  if (!file || !(file instanceof Blob)) {
-    return NextResponse.json({ error: "hwp 파일이 없습니다" }, { status: 400 });
-  }
+  const v = await validateHwpUpload(formData.get("hwp"));
+  if (!v.ok) return NextResponse.json({ error: v.error }, { status: v.status });
+  const bytes = v.bytes;
 
-  const bytes = Buffer.from(await file.arrayBuffer());
   await prisma.menteeRecord.upsert({
     where: { user_id_process_year: { user_id: userId, process_year: year } },
     create: {

--- a/apps/api/src/lib/hwp-upload.ts
+++ b/apps/api/src/lib/hwp-upload.ts
@@ -1,0 +1,69 @@
+// 한글 문서(.hwp / .hwpx) 업로드 검증 — personal-statement 라우트(멘티·admin) 공용.
+//
+// 막는 것:
+//   1) 과도한 크기 — arrayBuffer()로 통째 메모리에 올리기 전, size 헤더로 1차 거름.
+//   2) 허용 외 확장자 — .hwp / .hwpx 만.
+//   3) 내용 위장 — PDF/exe 등을 .hwp 로 rename 한 경우. 매직넘버 + .hwp 는 시그니처까지.
+//
+// ▼ 한도 변경 지점: 유료 요금제 도입 시 여기만 바꾸면 됨.
+//   환경변수 HWP_MAX_BYTES 로 배포별 오버라이드도 가능. 단 Vercel serverless 의
+//   요청 본문 한계(~4.5MB)를 함께 검토할 것 — 그 이상은 별도 업로드 경로가 필요하다.
+export const MAX_HWP_BYTES = Number(process.env.HWP_MAX_BYTES) || 4 * 1024 * 1024;
+
+// .hwp 5.x = OLE 복합문서(CFBF). 파일 시작 8바이트가 고정 시그니처.
+const CFBF_MAGIC = Buffer.from([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]);
+// .hwpx = ZIP 기반(OPC). 파일 시작 4바이트 "PK\x03\x04".
+const ZIP_MAGIC = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
+// .hwp 의 FileHeader 스트림은 비압축이라 이 ASCII 문자열이 파일 바이트 어딘가에 그대로 존재한다.
+const HWP_SIGNATURE = Buffer.from("HWP Document File", "latin1");
+
+export type HwpValidationResult =
+  // bytes 는 Buffer<ArrayBuffer> — Prisma 의 Bytes 컬럼이 요구하는 Uint8Array<ArrayBuffer> 와 호환되도록.
+  | { ok: true; bytes: Buffer<ArrayBuffer>; filename: string; size: number }
+  | { ok: false; status: 400 | 413 | 415; error: string };
+
+function maxMb(): string {
+  return (MAX_HWP_BYTES / 1024 / 1024).toFixed(1);
+}
+
+export async function validateHwpUpload(file: unknown): Promise<HwpValidationResult> {
+  if (!file || !(file instanceof Blob)) {
+    return { ok: false, status: 400, error: "hwp 파일이 없습니다." };
+  }
+
+  const filename = file instanceof File ? file.name : "upload.hwp";
+  const lower = filename.toLowerCase();
+  const isHwpx = lower.endsWith(".hwpx");
+  const isHwp = !isHwpx && lower.endsWith(".hwp");
+  if (!isHwp && !isHwpx) {
+    return { ok: false, status: 415, error: ".hwp 또는 .hwpx 파일만 업로드할 수 있습니다." };
+  }
+
+  // 1차 거름 — 헤더상 크기로 빠르게 거절 (큰 파일을 메모리에 올리기 전).
+  if (typeof file.size === "number") {
+    if (file.size === 0) return { ok: false, status: 400, error: "빈 파일입니다." };
+    if (file.size > MAX_HWP_BYTES) {
+      return { ok: false, status: 413, error: `파일이 너무 큽니다. 최대 ${maxMb()}MB.` };
+    }
+  }
+
+  const bytes = Buffer.from(await file.arrayBuffer());
+
+  // 2차 — 실측 길이로 재확인 (size 헤더를 못 믿는 경우 대비).
+  if (bytes.length === 0) return { ok: false, status: 400, error: "빈 파일입니다." };
+  if (bytes.length > MAX_HWP_BYTES) {
+    return { ok: false, status: 413, error: `파일이 너무 큽니다. 최대 ${maxMb()}MB.` };
+  }
+
+  if (isHwpx) {
+    if (!bytes.subarray(0, 4).equals(ZIP_MAGIC)) {
+      return { ok: false, status: 415, error: "올바른 HWPX 파일이 아닙니다." };
+    }
+  } else {
+    if (!bytes.subarray(0, 8).equals(CFBF_MAGIC) || !bytes.includes(HWP_SIGNATURE)) {
+      return { ok: false, status: 415, error: "올바른 HWP 파일이 아닙니다." };
+    }
+  }
+
+  return { ok: true, bytes, filename, size: bytes.length };
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "scripts"]
 }


### PR DESCRIPTION
## 배경
  `apps/api` 의 한글 문서(.hwp/.hwpx) 업로드 PATCH 라우트 2곳이 크기·확장자·MIME·매직넘버 검사 없이 `formData` 의 파일을 그대로 DB `bytea`    
  컬럼에 INSERT 하고 있었음.

  - `apps/api/src/app/api/mentee/personal-statement/route.ts` (PATCH) → `MenteeRecord.personal_statement_hwp_{ga,na}`
  - `apps/api/src/app/api/admin/personal-statements/route.ts` (PATCH) → `SchoolPersonalStatement.hwp_data`

  **위험**: ① GB급 파일 → `arrayBuffer()` 전량 메모리 적재 → OOM·DB 폭증 ② PDF·exe 등을 `.hwp` 로 rename 한 위장 파일 저장 → 악성 매크로 hwp / 비-hwp 저장소화.

  ## 변경
  - **신규 `apps/api/src/lib/hwp-upload.ts`** — `validateHwpUpload(file)` 공유 검증 헬퍼 (순수 함수, DB·I/O 없음)
    - 확장자 `.hwp`/`.hwpx` 만 허용 (그 외 `415`)
    - 크기 한도 **4MB** — `file.size` 헤더로 1차 거름 → `arrayBuffer()` 후 실측 길이로 재확인 (초과 `413`, 빈 파일 `400`)
      - 한도는 `MAX_HWP_BYTES` 상수 / `HWP_MAX_BYTES` 환경변수로 조정 (유료 요금제 대비). Vercel serverless 본문 한계(~4.5MB)는 별도 고려 필요
   — 코드 주석에 명시.
    - 매직넘버: `.hwp` → CFBF(`D0 CF 11 E0 A1 B1 1A E1`) + 버퍼 내 `"HWP Document File"` 시그니처 스캔, `.hwpx` → ZIP(`50 4B 03 04`)
  - 위 두 PATCH 라우트가 헬퍼 사용 (기존 `if (!file instanceof Blob) → 400` 분기 흡수, upsert·인증 가드·파라미터 검증은 변경 없음)
  - **신규 `apps/api/scripts/verify-hwp-upload.ts`** — 헬퍼 단독 검증 스크립트 (`node --experimental-strip-types
  apps/api/scripts/verify-hwp-upload.ts`), 11케이스
  - `apps/api/tsconfig.json` — `scripts/` 를 타입체크에서 제외 (Node 러너용 `.ts` 확장자 import 때문)

  스키마/마이그레이션 변경 없음. FE 변경 없음 (FE 는 이미 `.hwp,.hwpx` 만 `accept`).

  ## 의도된 한계 (트레이드오프)
  - HWP 3.x(한글 97 레거시 바이너리)는 CFBF 가 아니라 거부됨 — 현대 한글(2002+)·학교 양식·in-browser 에디터 모두 5.x 라 실무 영향 없음        
  - `.hwpx` 는 ZIP 매직(4바이트)만 확인하고 내부 `mimetype` 엔트리(`application/hwp+zip`)까지는 안 풂 (unzip 비용 회피). 임의 ZIP 은 통과하지만 C2 핵심 목표(임의 바이너리·실행파일·다른 포맷 위장 차단)는 충족

  ## 검증
  - [x] `node --experimental-strip-types apps/api/scripts/verify-hwp-upload.ts` — 11/11 통과 (빈 파일→400, 5MB→413, .pdf→415, 위장 .hwp→415, CFBF만(시그니처 없음)→415, 위장 .hwpx→415, 정상 .hwp/.HWP/.hwpx→통과, null/문자열→400)
  - [x] `pnpm --filter api build` (prisma generate + next build + tsc) 통과
  - [x] `pnpm --filter api lint` 통과 (기존 warning 2건 외 신규 0)