### PR TITLE
feat: 멘티 자소서 HWP "양식으로 초기화" 기능

### DIFF
--- a/apps/api/src/app/api/mentee/personal-statement/route.ts
+++ b/apps/api/src/app/api/mentee/personal-statement/route.ts
@@ -116,3 +116,38 @@ export async function PATCH(req: NextRequest) {
 
   return NextResponse.json({ ok: true });
 }
+
+// HWP 초기화 — 멘티 개인 편집본 삭제 후 학교 양식으로 폴백
+export async function DELETE(req: NextRequest) {
+  const userId = getUserId(req);
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const year = getProcessYear(req);
+  const group = req.nextUrl.searchParams.get("group");
+  if (group !== "ga" && group !== "na") {
+    return NextResponse.json({ error: "group 파라미터가 필요합니다 (ga 또는 na)" }, { status: 400 });
+  }
+
+  const record = await prisma.menteeRecord.findUnique({
+    where: { user_id_process_year: { user_id: userId, process_year: year } },
+    select: {
+      target_school_ga: true,
+      target_school_na: true,
+      personal_statement_text_ga: true,
+      personal_statement_text_na: true,
+    },
+  });
+
+  await prisma.menteeRecord.updateMany({
+    where: { user_id: userId, process_year: year },
+    data: group === "ga" ? { personal_statement_hwp_ga: null } : { personal_statement_hwp_na: null },
+  });
+
+  const resolved = await resolveGroup(
+    null,
+    group === "ga" ? record?.personal_statement_text_ga : record?.personal_statement_text_na,
+    group === "ga" ? record?.target_school_ga : record?.target_school_na,
+    year,
+  );
+  return NextResponse.json(resolved);
+}

--- a/apps/web/src/app/mentee/dashboard/personal-statement/PersonalStatementClient.tsx
+++ b/apps/web/src/app/mentee/dashboard/personal-statement/PersonalStatementClient.tsx
@@ -6,6 +6,7 @@ import type { RhwpEditor } from '@rhwp/editor';
 import {
   uploadPersonalStatement,
   saveTextAnswers,
+  resetPersonalStatementHwp,
   type PersonalStatementData,
   type TextAnswer,
 } from '@/lib/api';
@@ -40,6 +41,8 @@ export default function PersonalStatementClient({
   const [data, setData] = useState(initialData);
   const [saving, setSaving] = useState(false);
   const [autoSaving, setAutoSaving] = useState(false);
+  const [resetting, setResetting] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
   const [savedAt, setSavedAt] = useState<Record<Group, Date | null>>({ ga: null, na: null });
   // [group][questionId] → text
   const [textDrafts, setTextDrafts] = useState<Record<Group, Record<string, string>>>(() => {
@@ -144,6 +147,26 @@ export default function PersonalStatementClient({
     }
   }
 
+  async function handleReset() {
+    if (isSavingRef.current || resetting) return;
+    if (!confirm('편집한 내용을 모두 버리고 학교 양식으로 되돌립니다. 계속하시겠습니까?')) return;
+    setResetting(true);
+    try {
+      const resolved = await resetPersonalStatementHwp(year, activeTab);
+      setData((prev) => ({
+        ...prev,
+        [activeTab]: { ...prev[activeTab], hwp: resolved.hwp, templateExists: resolved.templateExists },
+      }));
+      dirtyRef.current[activeTab] = false;
+      setSavedAt((prev) => ({ ...prev, [activeTab]: null }));
+      setReloadKey((k) => k + 1); // HwpEditor 리마운트 → 양식 다시 로드
+    } catch (e) {
+      alert(e instanceof Error ? e.message : '초기화 실패');
+    } finally {
+      setResetting(false);
+    }
+  }
+
   async function handleDownload() {
     const editorRef = activeTab === 'ga' ? editorRefGa : editorRefNa;
     if (!editorRef.current) return;
@@ -226,6 +249,15 @@ export default function PersonalStatementClient({
           {!readOnly && statusText && <span className="text-xs text-text-placeholder">{statusText}</span>}
           {!readOnly && mode === 'hwp' && activeGroup.hwp && (
             <button
+              onClick={handleReset}
+              disabled={resetting || saving || autoSaving}
+              className="px-4 py-2 text-sm font-medium text-text-secondary bg-page-bg rounded-lg hover:bg-gray-200 transition-colors disabled:opacity-50"
+            >
+              {resetting ? '초기화 중...' : '양식으로 초기화'}
+            </button>
+          )}
+          {!readOnly && mode === 'hwp' && activeGroup.hwp && (
+            <button
               onClick={handleDownload}
               className="px-4 py-2 text-sm font-medium text-text-secondary bg-page-bg rounded-lg hover:bg-gray-200 transition-colors"
             >
@@ -290,6 +322,7 @@ export default function PersonalStatementClient({
                     style={{ height: '80vh' }}
                   >
                     <HwpEditor
+                      key={`hwp-${group}-${reloadKey}`}
                       initialHwpBase64={activeGroup.hwp}
                       onEditorReady={(editor) => onEditorReady(group, editor)}
                     />

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -826,6 +826,18 @@ export async function uploadPersonalStatement(
   await jsonOrError(res, "자기소개서 저장 실패");
 }
 
+// HWP 개인 편집본 초기화 → 학교 양식으로 되돌린 그룹 정보 반환
+export async function resetPersonalStatementHwp(
+  year: string,
+  group: "ga" | "na",
+): Promise<PersonalStatementGroupInfo> {
+  const res = await fetch(
+    `${API_BASE}/api/mentee/personal-statement?year=${encodeURIComponent(year)}&group=${group}`,
+    { method: "DELETE", credentials: "include" },
+  );
+  return jsonOrError(res, "자기소개서 초기화 실패");
+}
+
 export async function saveTextAnswers(
   year: string,
   group: "ga" | "na",


### PR DESCRIPTION
## 개요
멘티 자기소개서 페이지(HWP 에디터 모드)에서 본인이 편집·저장한 한글 파일을 **학교 양식 템플릿으로 되돌리는** 기능 추가.

## 변경
- **백엔드** `DELETE /api/mentee/personal-statement?year=&group=ga|na`
  - `MenteeRecord.personal_statement_hwp_ga/na`를 `null`로 → GET이 학교 양식(`SchoolPersonalStatement.hwp_data`)으로 폴백
  - 응답: 다시 resolve한 그룹 정보(양식 HWP base64 등) 반환
  - 문항별 텍스트 답변(`personal_statement_text_*`)은 건드리지 않음
- **`lib/api.ts`** `resetPersonalStatementHwp(year, group)` 추가
- **`PersonalStatementClient.tsx`**
  - HWP 에디터 모드 헤더에 "양식으로 초기화" 버튼 (`!readOnly && mode === 'hwp' && activeGroup.hwp`일 때만)
  - 클릭 → confirm → DELETE → `data[group].hwp` 갱신 + `reloadKey` 증가시켜 `HwpEditor` 리마운트(현 `useEffect([])` 구조상 양식 재로딩에 필요)
  - 학교 양식 HWP가 없으면 초기화 후 "양식 준비 안 됨" 상태로 자연스럽게 떨어짐

🤖 Generated with [Claude Code](https://claude.com/claude-code)