### PR TITLE
feat(security): API 라우트 인증 "기본 막힘" 구조 — requireAuth 헬퍼 + 전 라우트 401 테스트 (#212)

### DIFF
--- a/apps/api/scripts/verify-route-auth.ts
+++ b/apps/api/scripts/verify-route-auth.ts
@@ -1,0 +1,144 @@
+// 전 라우트 미인증 401 테스트.
+//
+// apps/api 에는 글로벌 미들웨어가 없으므로, /api 아래 모든 라우트는 핸들러 첫머리에서
+// requireAuth / requireAdmin / 멘티·멘토 역할 가드를 호출해야 한다. 무인증 공개
+// 라우트는 아래 PUBLIC_PATHS 에 명시적으로 등록한다 — "기본 막힘(deny by default)".
+//
+// 이 스크립트는 src/app/api 의 모든 route.ts 를 열거하고, export 된 각 HTTP 메서드에
+// 대해 쿠키 없이 요청을 보내 — PUBLIC_PATHS 가 아니면 401 이어야 하고, PUBLIC_PATHS 면
+// 401 이 아니어야 한다 — 를 검증한다. 하나라도 어긋나면 실패(exit 1).
+//
+// 실행:
+//   터미널 1:  pnpm --filter api dev          # http://localhost:3001
+//   터미널 2:  node --experimental-strip-types apps/api/scripts/verify-route-auth.ts
+//   (대상 변경: BASE_URL=http://... node --experimental-strip-types ...)
+//
+// 새 라우트를 추가할 때:
+//   - 인증 필요  → 핸들러에서 requireAuth/requireAdmin 등을 호출 (이 테스트가 401 확인)
+//   - 무인증 공개 → 아래 PUBLIC_PATHS 에 경로 추가
+import { readdir, readFile } from "node:fs/promises";
+import { join, dirname, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const API_DIR = join(__dirname, "..", "src", "app", "api");
+const BASE_URL = (process.env.BASE_URL ?? "http://localhost:3001").replace(/\/$/, "");
+
+// 세션 쿠키가 필요 없는 공개 라우트 (정확한 경로). 동적 세그먼트를 가진 공개 라우트는
+// 현재 없으므로 모두 리터럴 경로다.
+const PUBLIC_PATHS = new Set<string>([
+  "/api/health",
+  "/api/auth/login",
+  "/api/auth/signup",
+  "/api/auth/logout",
+  "/api/auth/find-id",
+  "/api/auth/reset-password",
+  "/api/auth/check-login-id",
+  "/api/auth/email/send-verification",
+  "/api/auth/email/verify-code",
+]);
+
+const HTTP_METHODS = ["GET", "POST", "PATCH", "PUT", "DELETE"] as const;
+type HttpMethod = (typeof HTTP_METHODS)[number];
+
+// 동적 세그먼트([id], [...slug])를 더미값으로 치환 — 가드가 param 파싱 전에 401 을
+// 반환하므로 더미값으로 충분하다.
+function toUrlPath(routeFileAbs: string): string {
+  const rel = relative(API_DIR, dirname(routeFileAbs)).split(sep).join("/");
+  const segments = rel.length === 0 ? [] : rel.split("/");
+  const subst = segments.map((s) =>
+    /^\[\.\.\..+\]$/.test(s) ? "__test__/__test__" : /^\[.+\]$/.test(s) ? "__test__" : s,
+  );
+  return "/api" + (subst.length ? "/" + subst.join("/") : "");
+}
+
+function exportedMethods(src: string): HttpMethod[] {
+  const found = new Set<HttpMethod>();
+  for (const m of HTTP_METHODS) {
+    const fnRe = new RegExp(`export\\s+(?:async\\s+)?function\\s+${m}\\b`);
+    const constRe = new RegExp(`export\\s+const\\s+${m}\\s*[:=]`);
+    if (fnRe.test(src) || constRe.test(src)) found.add(m);
+  }
+  return [...found];
+}
+
+async function findRouteFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const out: string[] = [];
+  for (const e of entries) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) out.push(...(await findRouteFiles(full)));
+    else if (e.name === "route.ts" || e.name === "route.tsx") out.push(full);
+  }
+  return out;
+}
+
+type Check = { path: string; method: HttpMethod; isPublic: boolean };
+
+async function main() {
+  const routeFiles = (await findRouteFiles(API_DIR)).sort();
+  if (routeFiles.length === 0) {
+    console.error(`route.ts 를 찾지 못했습니다: ${API_DIR}`);
+    process.exit(1);
+  }
+
+  const checks: Check[] = [];
+  const seenPaths = new Set<string>();
+  for (const f of routeFiles) {
+    const path = toUrlPath(f);
+    seenPaths.add(path);
+    const methods = exportedMethods(await readFile(f, "utf8"));
+    if (methods.length === 0) {
+      console.warn(`경고: export 된 HTTP 메서드를 찾지 못함 — ${relative(API_DIR, f)}`);
+      continue;
+    }
+    for (const method of methods) checks.push({ path, method, isPublic: PUBLIC_PATHS.has(path) });
+  }
+
+  // PUBLIC_PATHS 일관성 — stale 항목 검출
+  let staleFail = false;
+  for (const p of PUBLIC_PATHS) {
+    if (!seenPaths.has(p)) {
+      console.error(`FAIL  PUBLIC_PATHS 에 있으나 대응하는 route 파일이 없음: ${p}`);
+      staleFail = true;
+    }
+  }
+
+  // 서버 도달 확인
+  try {
+    await fetch(`${BASE_URL}/api/health`, { method: "GET" });
+  } catch (e) {
+    console.error(`서버에 연결할 수 없습니다: ${BASE_URL} — pnpm --filter api dev 로 띄웠는지 확인하세요.`);
+    console.error(String(e));
+    process.exit(1);
+  }
+
+  let pass = 0;
+  let fail = 0;
+  for (const c of checks) {
+    let status: number | string;
+    try {
+      const res = await fetch(`${BASE_URL}${c.path}`, { method: c.method, redirect: "manual" });
+      status = res.status;
+    } catch (e) {
+      status = `ERR(${e instanceof Error ? e.message : String(e)})`;
+    }
+    const ok =
+      typeof status === "number" && (c.isPublic ? status !== 401 : status === 401);
+    if (ok) pass++;
+    else fail++;
+    const tag = c.isPublic ? "[public]" : "[guarded]";
+    console.log(
+      `${ok ? "PASS" : "FAIL"}  ${c.method.padEnd(6)} ${c.path}  ${tag}  → ${status}` +
+        (ok ? "" : c.isPublic ? "  (expected ≠ 401)" : "  (expected 401)"),
+    );
+  }
+
+  console.log(`\n${pass} passed, ${fail} failed, ${checks.length} checks across ${routeFiles.length} route files.`);
+  if (fail > 0 || staleFail) process.exit(1);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/apps/api/src/app/api/announcements/[id]/route.ts
+++ b/apps/api/src/app/api/announcements/[id]/route.ts
@@ -1,15 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@plawcess/database";
-import { getTokenFromCookie } from "@/lib/auth";
+import { requireAuth } from "@/lib/auth-guard";
 
 export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const payload = getTokenFromCookie(req);
-  if (!payload) {
-    return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
-  }
+  const auth = requireAuth(req);
+  if (auth.error) return auth.error;
 
   const { id } = await params;
 

--- a/apps/api/src/app/api/announcements/route.ts
+++ b/apps/api/src/app/api/announcements/route.ts
@@ -1,13 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@plawcess/database";
-import { getTokenFromCookie } from "@/lib/auth";
+import { requireAuth } from "@/lib/auth-guard";
 import { parsePagination } from "@/lib/pagination";
 
 export async function GET(req: NextRequest) {
-  const payload = getTokenFromCookie(req);
-  if (!payload) {
-    return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
-  }
+  const auth = requireAuth(req);
+  if (auth.error) return auth.error;
 
   const pg = parsePagination(req);
   if (pg.error) return pg.error;

--- a/apps/api/src/app/api/auth/change-email/route.ts
+++ b/apps/api/src/app/api/auth/change-email/route.ts
@@ -1,13 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
 import { prisma } from "@plawcess/database";
-import { getTokenFromCookie } from "@/lib/auth";
+import { requireAuth } from "@/lib/auth-guard";
 
 export async function POST(req: NextRequest) {
-  const tokenPayload = getTokenFromCookie(req);
-  if (!tokenPayload) {
-    return NextResponse.json({ error: "인증이 필요합니다." }, { status: 401 });
-  }
+  const auth = requireAuth(req);
+  if (auth.error) return auth.error;
+  const tokenPayload = auth.payload;
 
   let body: { newEmail?: string; password?: string };
   try {

--- a/apps/api/src/app/api/auth/change-password/route.ts
+++ b/apps/api/src/app/api/auth/change-password/route.ts
@@ -1,13 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
 import { prisma } from "@plawcess/database";
-import { getTokenFromCookie } from "@/lib/auth";
+import { requireAuth } from "@/lib/auth-guard";
 
 export async function POST(req: NextRequest) {
-  const tokenPayload = getTokenFromCookie(req);
-  if (!tokenPayload) {
-    return NextResponse.json({ error: "인증이 필요합니다." }, { status: 401 });
-  }
+  const auth = requireAuth(req);
+  if (auth.error) return auth.error;
+  const tokenPayload = auth.payload;
 
   let body: { currentPassword?: string; newPassword?: string };
   try {

--- a/apps/api/src/app/api/auth/delete-account/route.ts
+++ b/apps/api/src/app/api/auth/delete-account/route.ts
@@ -1,16 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
 import { prisma } from "@plawcess/database";
-import { getTokenFromCookie, makeClearCookie } from "@/lib/auth";
+import { makeClearCookie } from "@/lib/auth";
+import { requireAuth } from "@/lib/auth-guard";
 
 export async function DELETE(req: NextRequest) {
   // 1. 인증: 토큰에서 user_id 추출
-  const tokenPayload = getTokenFromCookie(req);
-  if (!tokenPayload) {
-    return NextResponse.json({ error: "인증이 필요합니다." }, { status: 401 });
-  }
+  const auth = requireAuth(req);
+  if (auth.error) return auth.error;
 
-  const userId = tokenPayload.user_id;
+  const userId = auth.payload.user_id;
 
   // 2. 요청 본체에서 password 추출
   let body: { password?: string };

--- a/apps/api/src/app/api/auth/dismiss-password-reminder/route.ts
+++ b/apps/api/src/app/api/auth/dismiss-password-reminder/route.ts
@@ -1,12 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@plawcess/database";
-import { getTokenFromCookie } from "@/lib/auth";
+import { requireAuth } from "@/lib/auth-guard";
 
 export async function POST(req: NextRequest) {
-  const tokenPayload = getTokenFromCookie(req);
-  if (!tokenPayload) {
-    return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
-  }
+  const auth = requireAuth(req);
+  if (auth.error) return auth.error;
+  const tokenPayload = auth.payload;
 
   const user = await prisma.user.findUnique({
     where: { user_id: tokenPayload.user_id },

--- a/apps/api/src/app/api/auth/me/route.ts
+++ b/apps/api/src/app/api/auth/me/route.ts
@@ -1,12 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@plawcess/database";
-import { getTokenFromCookie } from "@/lib/auth";
+import { requireAuth } from "@/lib/auth-guard";
 
 export async function GET(req: NextRequest) {
-  const payload = getTokenFromCookie(req);
-  if (!payload) {
-    return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
-  }
+  const auth = requireAuth(req);
+  if (auth.error) return auth.error;
+  const payload = auth.payload;
 
   const user = await prisma.user.findUnique({
     where: { user_id: payload.user_id, is_deleted: false },

--- a/apps/api/src/app/api/auth/password-reminder-status/route.ts
+++ b/apps/api/src/app/api/auth/password-reminder-status/route.ts
@@ -1,14 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@plawcess/database";
-import { getTokenFromCookie } from "@/lib/auth";
+import { requireAuth } from "@/lib/auth-guard";
 
 const REMINDER_THRESHOLD_MS = 180 * 24 * 60 * 60 * 1000;
 
 export async function GET(req: NextRequest) {
-  const tokenPayload = getTokenFromCookie(req);
-  if (!tokenPayload) {
-    return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
-  }
+  const auth = requireAuth(req);
+  if (auth.error) return auth.error;
+  const tokenPayload = auth.payload;
 
   const user = await prisma.user.findUnique({
     where: { user_id: tokenPayload.user_id },

--- a/apps/api/src/app/api/cycle-schedules/active/route.ts
+++ b/apps/api/src/app/api/cycle-schedules/active/route.ts
@@ -1,12 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@plawcess/database";
-import { getTokenFromCookie } from "@/lib/auth";
+import { requireAuth } from "@/lib/auth-guard";
 
 export async function GET(req: NextRequest) {
-  const payload = getTokenFromCookie(req);
-  if (!payload) {
-    return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
-  }
+  const auth = requireAuth(req);
+  if (auth.error) return auth.error;
 
   const active = await prisma.cycleSchedule.findFirst({
     where: { is_active: true },

--- a/apps/api/src/lib/auth-guard.ts
+++ b/apps/api/src/lib/auth-guard.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getTokenFromCookie, type TokenPayload } from "./auth";
+
+/**
+ * 라우트 핸들러 첫머리에서 호출하는 인증 가드. apps/api 에는 글로벌 미들웨어가 없으므로
+ * 인증이 필요한 모든 /api 라우트는 이 헬퍼(또는 requireAdmin / 멘티·멘토 역할 가드)를
+ * 직접 호출해야 한다. 공개 라우트는 apps/api/scripts/verify-route-auth.ts 의
+ * PUBLIC_PATHS 에 등록한다. (verify-route-auth.ts 가 이 규약을 검증한다.)
+ *
+ * 사용:
+ *   const auth = requireAuth(req);
+ *   if (auth.error) return auth.error;
+ *   const payload = auth.payload;
+ */
+export type AuthGuardResult =
+  | { error: NextResponse; payload?: undefined }
+  | { error?: undefined; payload: TokenPayload };
+
+/** 유효한 세션이 있는지만 검사한다. 역할은 보지 않는다. */
+export function requireAuth(req: NextRequest): AuthGuardResult {
+  const payload = getTokenFromCookie(req);
+  if (!payload) {
+    return {
+      error: NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 }),
+    };
+  }
+  return { payload };
+}

--- a/docs/api/api-spec.md
+++ b/docs/api/api-spec.md
@@ -5,10 +5,16 @@
 ## 인증
 
 모든 보호 엔드포인트는 `plawcess_token` HttpOnly 쿠키(JWT)로 인증한다.
-- `/api/auth/*`, `/api/health`: 공개
+
+**기본 막힘(deny by default)** — `/api` 아래 모든 라우트는 인증이 필요하다. 무인증 공개 라우트는 명시적으로 허용 목록에 등록되며, 그 목록은 `apps/api/scripts/verify-route-auth.ts` 의 `PUBLIC_PATHS` 가 단일 출처다 (이 스크립트가 "비공개 라우트는 쿠키 없이 호출 시 401" 을 검증한다).
+
+- **무인증 공개**: `/api/health`, `/api/auth/login`, `/api/auth/signup`, `/api/auth/logout`, `/api/auth/find-id`, `/api/auth/reset-password`, `/api/auth/check-login-id`, `/api/auth/email/send-verification`, `/api/auth/email/verify-code`
+- **인증 필요·역할 무관** (예: `/api/auth/me`, `/api/auth/change-password`, `/api/announcements*`, `/api/cycle-schedules/active` 등): 핸들러가 `requireAuth(req)` 호출
 - `/api/mentee/*`: `mentee` 또는 `admin`
 - `/api/mentor/*`: `mentor` 또는 `admin`
-- `/api/admin/*`: `admin`
+- `/api/admin/*`: `admin` — 핸들러가 `requireAdmin(req)` 호출
+
+새 라우트를 추가할 때: 인증이 필요하면 핸들러 첫머리에서 `requireAuth`/`requireAdmin`(또는 멘티·멘토 역할 가드)를 호출하고, 무인증 공개라면 `verify-route-auth.ts` 의 `PUBLIC_PATHS` 에 경로를 추가한다.
 
 ## 라벨 변환 컨벤션
 


### PR DESCRIPTION
## 배경
  `apps/api` 에는 글로벌 미들웨어가 없다 (`proxy.ts` 는 #184 에서 "안 도는 죽은 코드"라 제거됨; `admin-guard.ts` 주석도 "전역 미들웨어가 없으므로 핸들러가 직접 가드"라고 명시). 따라서 `/api/*` 의 모든 인증·인가는 핸들러 책임인데:

  - `getTokenFromCookie(req)` + `if (!payload) return 401` 이 ~25곳에 복붙 (메시지가 `"로그인이 필요합니다."` / `"Unauthorized"` / `"인증이 필요합니다."` 로 제각각)
  - 새 라우트에서 가드 한 줄 빼먹으면 그대로 공개 엔드포인트 — fail-open
  - "쿠키 없이 호출 → 401" 회귀 테스트 없음

  → "기본 막힘(deny by default)"으로: public 으로 열려면 *명시적으로* 허용 목록에 등록해야 하고, 그 외 모든 라우트가 인증을 강제함을 **테스트가 검증**. (미들웨어를 새로 만드는 안도 검토했으나, #184 가 방금 미들웨어-형태 파일을 의도적으로 제거하고 "라우트별 가드가 실질 방어" 방향을 명시했으므로 핸들러 레벨 + 강제 테스트 안으로 진행.)

  ## 변경
  - **신규 `apps/api/src/lib/auth-guard.ts`** — `requireAuth(req)`: 유효한 세션이 있는지만 검사 (`requireAdmin` 의 형제). 사용:
    ```ts const auth = requireAuth(req);
    if (auth.error) return auth.error;
    const payload = auth.payload;
  - 9개 "인증 필요·역할 무관" 라우트를 requireAuth 로 마이그레이션 — 복붙된 토큰 체크 블록 제거, 401 메시지를 "로그인이 필요합니다." 로 통일  
  (일부가 "인증이 필요합니다."였음 — 의도된 표준화). 응답 모양·상태는 동일:
  /api/auth/me, change-password, change-email, delete-account, dismiss-password-reminder, password-reminder-status, /api/announcements,       
  /api/announcements/[id], /api/cycle-schedules/active
  - 신규 apps/api/scripts/verify-route-auth.ts — src/app/api/**/route.ts 전부 열거 → export 된 각 HTTP 메서드를 쿠키 없이 호출:
    - PUBLIC_PATHS(무인증 공개 9개: /api/health,
  /api/auth/login·signup·logout·find-id·reset-password·check-login-id·email/send-verification·email/verify-code) → status !== 401 단언        
    - 그 외 → status === 401 단언
    - PUBLIC_PATHS ↔ route 파일 일관성도 확인 (stale 항목 검출)
    - 실행: pnpm --filter api dev 후 node --experimental-strip-types apps/api/scripts/verify-route-auth.ts (대상: BASE_URL 환경변수)
  - docs/api/api-spec.md 인증 섹션 갱신 (deny-by-default 명시, PUBLIC_PATHS 가 공개 라우트 단일 출처).

  FE 변경 없음. 스키마/마이그레이션 없음.

  의도된 한계 / 후속

  - "기본 막힘"이 프레임워크(미들웨어)가 아니라 테스트 차원 강제 — 로컬에선 가드 빠진 라우트를 만들 수 있고 verify-route-auth.ts(궁극적으로 CI)가 잡는다.
  - requireRole 헬퍼 + requireAdmin 통합 + 멘티/멘토 라우트(getUserId)의 requireRole 마이그레이션 — 후속 PR
  - ci.yml 에 verify-route-auth.ts 통합 (서버 부팅 + 실행) — 후속
  - 403(잘못된 역할) 검증 — 이번 테스트는 "쿠키 없음 → 401" 만 본다. 역할별 토큰 403 검증은 후속

  검증

  - node --experimental-strip-types apps/api/scripts/verify-route-auth.ts (dev server 대상) — 53/53 통과 (39 route files; guarded → 401, public → 200/400)
  - pnpm --filter api build (prisma generate + next build + tsc) 통과
  - pnpm --filter api lint 통과 (기존 warning 2건 외 신규 0)
  - 9개 마이그레이션 라우트 diff 가 기계적임 — 응답 모양·상태 불변

  Closes #212