### PR TITLE
feat(security): JWT 세션 토큰 audience·issuer 검증 강제 (#182)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,7 +15,6 @@
     "@prisma/client": "^7.6.0",
     "@supabase/supabase-js": "^2.105.4",
     "bcryptjs": "^3.0.3",
-    "jose": "^6.2.2",
     "jsonwebtoken": "^9.0.3",
     "mammoth": "^1.12.0",
     "next": "16.2.2",

--- a/apps/api/scripts/verify-jwt-audience.ts
+++ b/apps/api/scripts/verify-jwt-audience.ts
@@ -1,0 +1,77 @@
+// JWT 세션 토큰 audience/issuer 강제 검증.
+// 실행: node --env-file=apps/api/.env --experimental-strip-types apps/api/scripts/verify-jwt-audience.ts
+//
+// verifyToken 은 세션 audience("session")·issuer("pLAWcess")인 토큰만 인정해야 한다.
+// 그 외(aud 없음, 다른 aud, 다른 iss, 다른 secret, 만료) → null.
+import jwt from "jsonwebtoken";
+import { signToken, verifyToken } from "../src/lib/auth.ts";
+
+const SECRET = process.env.JWT_SECRET as string;
+if (!SECRET) {
+  console.error("JWT_SECRET 가 없습니다. node --env-file=apps/api/.env ... 로 실행하세요.");
+  process.exit(1);
+}
+
+const payload = { user_id: "00000000-0000-0000-0000-000000000001", current_role: "mentee" };
+
+type Case = { name: string; token: string; expect: "ok" | "null" };
+
+const cases: Case[] = [
+  {
+    name: "signToken 산출물 (aud=session, iss=pLAWcess)",
+    token: signToken(payload),
+    expect: "ok",
+  },
+  {
+    name: "aud/iss 없음 (jwt.sign(payload, SECRET))",
+    token: jwt.sign(payload, SECRET),
+    expect: "null",
+  },
+  {
+    name: "aud=password-reset, iss=pLAWcess",
+    token: jwt.sign(payload, SECRET, { audience: "password-reset", issuer: "pLAWcess" }),
+    expect: "null",
+  },
+  {
+    name: "aud=email-verification:signup, iss=pLAWcess",
+    token: jwt.sign(payload, SECRET, { audience: "email-verification:signup", issuer: "pLAWcess" }),
+    expect: "null",
+  },
+  {
+    name: "aud=session, iss=evil",
+    token: jwt.sign(payload, SECRET, { audience: "session", issuer: "evil" }),
+    expect: "null",
+  },
+  {
+    name: "aud=session, iss=pLAWcess, 다른 secret 으로 서명",
+    token: jwt.sign(payload, SECRET + "-wrong", { audience: "session", issuer: "pLAWcess" }),
+    expect: "null",
+  },
+  {
+    name: "aud=session, iss=pLAWcess, 만료됨",
+    token: jwt.sign(payload, SECRET, { audience: "session", issuer: "pLAWcess", expiresIn: "-1s" }),
+    expect: "null",
+  },
+];
+
+let failed = 0;
+for (const c of cases) {
+  const r = verifyToken(c.token);
+  const got = r === null ? "null" : "ok";
+  let pass = got === c.expect;
+  // ok 케이스는 payload 보존도 확인
+  if (pass && c.expect === "ok" && (r?.user_id !== payload.user_id || r?.current_role !== payload.current_role)) {
+    pass = false;
+  }
+  if (!pass) failed++;
+  console.log(
+    `${pass ? "PASS" : "FAIL"}  ${c.name}  →  expected ${c.expect}, got ${got}` +
+      (c.expect === "ok" && r ? ` (user_id=${r.user_id}, role=${r.current_role})` : ""),
+  );
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} case(s) failed.`);
+  process.exit(1);
+}
+console.log(`\nAll ${cases.length} cases passed.`);

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -1,5 +1,5 @@
 import jwt from "jsonwebtoken";
-import { NextRequest } from "next/server";
+import type { NextRequest } from "next/server";
 
 const JWT_SECRET = process.env.JWT_SECRET!;
 const COOKIE_NAME = "plawcess_token";
@@ -25,9 +25,13 @@ export function signToken(payload: TokenPayload): string {
 
 export function verifyToken(token: string): TokenPayload | null {
   try {
-    // audience 미강제: 기존 세션 토큰(audience 없음) 호환을 위해.
-    // 토큰 종류 변환 공격은 verification·reset 토큰의 verify 함수가 자체 audience 강제로 차단.
-    return jwt.verify(token, JWT_SECRET) as TokenPayload;
+    // 세션 audience(`session`)·issuer(`pLAWcess`)만 인정한다. password-reset / email-verification
+    // 등 다른 종류 토큰(같은 JWT_SECRET 으로 서명됨)이 세션 토큰으로 오용되는 것을 차단.
+    // auth-tokens.ts 의 verify 함수들과 대칭.
+    return jwt.verify(token, JWT_SECRET, {
+      issuer: ISSUER,
+      audience: SESSION_AUDIENCE,
+    }) as TokenPayload;
   } catch {
     return null;
   }

--- a/docs/api/api-spec.md
+++ b/docs/api/api-spec.md
@@ -4,7 +4,7 @@
 
 ## 인증
 
-모든 보호 엔드포인트는 `plawcess_token` HttpOnly 쿠키(JWT)로 인증한다.
+모든 보호 엔드포인트는 `plawcess_token` HttpOnly 쿠키(JWT)로 인증한다. 세션 토큰은 `iss: pLAWcess`, `aud: session` 으로 발급·검증된다 — 다른 audience 의 토큰(`password-reset` 등)은 세션으로 인정되지 않는다.
 
 **기본 막힘(deny by default)** — `/api` 아래 모든 라우트는 인증이 필요하다. 무인증 공개 라우트는 명시적으로 허용 목록에 등록되며, 그 목록은 `apps/api/scripts/verify-route-auth.ts` 의 `PUBLIC_PATHS` 가 단일 출처다 (이 스크립트가 "비공개 라우트는 쿠키 없이 호출 시 401" 을 검증한다).
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,9 +28,6 @@ importers:
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
-      jose:
-        specifier: ^6.2.2
-        version: 6.2.2
       jsonwebtoken:
         specifier: ^9.0.3
         version: 9.0.3
@@ -568,89 +565,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -720,24 +733,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.2':
     resolution: {integrity: sha512-VKLuscm0P/mIfzt+SDdn2+8TNNJ7f0qfEkA+az7OqQbjzKdBxAHs0UvuiVoCtbwX+dqMEL9U54b5wQ/aN3dHeg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.2':
     resolution: {integrity: sha512-kU3OPHJq6sBUjOk7wc5zJ7/lipn8yGldMoAv4z67j6ov6Xo/JvzA7L7LCsyzzsXmgLEhk3Qkpwqaq/1+XpNR3g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.2':
     resolution: {integrity: sha512-CKXRILyErMtUftp+coGcZ38ZwE/Aqq45VMCcRLr2I4OXKrgxIBDXHnBgeX/UMil0S09i2JXaDL3Q+TN8D/cKmg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.2':
     resolution: {integrity: sha512-sS/jSk5VUoShUqINJFvNjVT7JfR5ORYj/+/ZpOYbbIohv/lQfduWnGAycq2wlknbOql2xOR0DoV0s6Xfcy49+g==}
@@ -1014,24 +1031,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -1204,41 +1225,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2337,24 +2366,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}


### PR DESCRIPTION
## 배경
  `apps/api/src/lib/auth.ts` 의 `verifyToken` 이 `jwt.verify(token, JWT_SECRET)` 만 호출 — `{ issuer, audience }` 옵션 없이 — 검증해서, `JWT_SECRET` 으로 서명되기만 하면 `aud`/`iss` 가 무엇이든 세션 토큰으로 통과시켰다.

  - `signToken` 은 이미 세션 토큰을 `iss: "pLAWcess"`, `aud: "session"`, `exp: 7d` 로 발급 중이었으나, 검증 측에서 이를 강제하지 않았음.      
  - `auth-tokens.ts` 가 발급하는 다른 종류 토큰(`aud: "password-reset"`, `aud: "email-verification:signup"`)을 `plawcess_token` 쿠키에 넣으면 세션 토큰으로 인정됨 = **토큰 종류 혼동(type confusion)**. 현재 실익은 제한적(그 페이로드엔 `user_id`/`current_role` 없음)이지만 정석 하드닝이고, `auth-tokens.ts` 의 verify 들은 이미 `issuer`+`audience` 를 강제하는데 세션만 비대칭.

  remediation 문서 §3.2 H3 / 이슈 #182.

  ## 변경
  - **`verifyToken` 에 `{ issuer: "pLAWcess", audience: "session" }` 강제** (`apps/api/src/lib/auth.ts`). 코드 변경은 verify 한 곳뿐
  (`signToken` 은 이미 올바름). 주석을 "세션 audience·issuer 만 인정 — 다른 종류 토큰 오용 차단, `auth-tokens.ts` 와 대칭" 으로 교체.
  - **마이그레이션·유예 없음**: `JWT_SECRET` 이 최근 rotate 되어 옛 secret 으로 서명된 토큰은 전부 이미 서명 불일치로 무효 → 떠다니는 유효 토큰은 모두 현 `signToken` 산출물(= `aud:"session"` 포함). 추가로 로그아웃되는 사용자 없음.
  - `auth.ts` 의 `import { NextRequest } from "next/server"` → `import type ...` (`NextRequest` 는 타입으로만 사용).
  - **안 쓰이는 `jose` 의존성 제거** (`apps/api/package.json` + `pnpm-lock.yaml`): `proxy.ts` 가 삭제된 #184 이후 `apps/api` 어디서도 `jose`를 import 안 함 (`apps/web/src/lib/jwt.ts` 만 사용 — BE 무관). → remediation H3 의 "jose 로 통일" 도 자동 달성 (apps/api 는 `jsonwebtoken` 단일; Edge 런타임도 없으니 jose 불필요).
  - **신규 `apps/api/scripts/verify-jwt-audience.ts`** — `verifyToken` 을 7가지 토큰으로 검증: 정상 `session` 토큰 / `aud` 없음 /
  `aud:password-reset` / `aud:email-verification:signup` / 다른 `iss` / 다른 secret / 만료. 실행: `node --env-file=apps/api/.env
  --experimental-strip-types apps/api/scripts/verify-jwt-audience.ts`
  - `docs/api/api-spec.md` 인증 섹션에 토큰 `iss: pLAWcess`/`aud: session` 명시.

  FE 변경 없음. 스키마/마이그레이션 없음.

  ## 후속
  - FE(`apps/web/src/lib/jwt.ts` / `middleware.ts`)가 세션 쿠키를 검증한다면 거기도 `aud: "session"` 체크 추가 권장 — 핸드오프 메모.
  - `User.token_version` 기반 revocation (remediation M1) — 별개.

  ## 검증
  - [x] `node --env-file=apps/api/.env --experimental-strip-types apps/api/scripts/verify-jwt-audience.ts` — **7/7 통과**
  - [x] `pnpm install` 클린 (jose 없이)
  - [x] `pnpm --filter api build` (prisma generate + next build + tsc) 통과
  - [x] `pnpm --filter api lint` 통과 (기존 warning 2건 외 신규 0)

  Closes #182