### PR TITLE
feat(security): /api/auth/login brute-force / credential stuffing rate limit (#179)

### DIFF
--- a/apps/api/src/app/api/auth/login/route.ts
+++ b/apps/api/src/app/api/auth/login/route.ts
@@ -2,6 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
 import { prisma } from "@plawcess/database";
 import { signToken, makeAuthCookie } from "@/lib/auth";
+import { getClientIp } from "@/lib/email/code";
+import {
+  assertLoginRateLimit,
+  recordLoginAttempt,
+  normalizeIdentifier,
+  LoginRateLimitError,
+} from "@/lib/login-rate-limit";
 
 export async function POST(req: NextRequest) {
   let body: { loginId?: string; email?: string; password?: string };
@@ -23,23 +30,45 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "아이디와 비밀번호를 입력해주세요." }, { status: 400 });
   }
 
+  const ip = getClientIp(req.headers);
+  const identifier = normalizeIdentifier(loginId, email);
+
+  // brute-force / credential stuffing 방어 — bcrypt·DB 조회 전에 (identifier, IP)별 한도 검사
+  try {
+    await assertLoginRateLimit(identifier, ip);
+  } catch (e) {
+    if (e instanceof LoginRateLimitError) {
+      return NextResponse.json(
+        { error: e.message },
+        { status: 429, headers: { "Retry-After": String(e.retryAfterSeconds) } },
+      );
+    }
+    throw e;
+  }
+
   const user = await prisma.user.findFirst({
     where: queryKey,
     select: { user_id: true, name: true, login_id: true, email: true, current_role: true, account_status: true, military_status: true, password_hash: true },
   });
 
   if (!user || !user.password_hash) {
+    await recordLoginAttempt(identifier, ip, false);
     return NextResponse.json({ error: "아이디 또는 비밀번호가 올바르지 않습니다." }, { status: 401 });
   }
 
   const isValid = await bcrypt.compare(password, user.password_hash);
   if (!isValid) {
+    await recordLoginAttempt(identifier, ip, false);
     return NextResponse.json({ error: "아이디 또는 비밀번호가 올바르지 않습니다." }, { status: 401 });
   }
 
   if (user.account_status === "blocked") {
+    // 비밀번호는 일치 → brute-force 가 아님. 실패 카운트에 넣지 않도록 success 로 기록.
+    await recordLoginAttempt(identifier, ip, true);
     return NextResponse.json({ error: "차단된 계정입니다. 관리자에게 문의하세요." }, { status: 403 });
   }
+
+  await recordLoginAttempt(identifier, ip, true);
 
   const token = signToken({ user_id: user.user_id, current_role: user.current_role, name: user.name, email: user.email });
   const { password_hash: _, ...safeUser } = user;

--- a/apps/api/src/lib/login-rate-limit.ts
+++ b/apps/api/src/lib/login-rate-limit.ts
@@ -1,0 +1,78 @@
+// 로그인 brute-force / credential stuffing 방어 — DB(login_attempts) 기반 sliding-window rate limit.
+//
+// 두 축으로 검사한다:
+//   - identifier(loginId/email 을 소문자·trim 정규화한 값)별 최근 15분 실패 횟수
+//   - IP별 최근 15분 실패 횟수 (한 IP 에서 여러 계정을 찔러보는 credential stuffing 합산)
+// 어느 한쪽이 한도를 넘으면 429 + Retry-After. identifier 는 계정이 실제로 존재하든 안 하든
+// 동일하게 기록 — rate-limit 동작 차이로 계정 존재 여부가 새지 않게.
+//
+// 레이트 리미터 자체(DB 조회/insert)가 실패하면 fail-open 한다(로그인 허용). 인프라 장애로
+// 정상 사용자를 self-DoS 시키지 않기 위함 — rate limiter 의 관용적 선택.
+import { prisma } from "@plawcess/database";
+
+export const LOGIN_WINDOW_MS = 15 * 60 * 1000; // 15분
+export const MAX_FAILS_PER_IDENTIFIER = 5; // 식별자당 15분 5회 실패 → 429
+export const MAX_FAILS_PER_IP = 30; // IP당 15분 30회 실패 → 429
+
+export class LoginRateLimitError extends Error {
+  constructor(public readonly retryAfterSeconds: number) {
+    super("너무 많은 로그인 시도가 있었습니다. 잠시 후 다시 시도해주세요.");
+    this.name = "LoginRateLimitError";
+  }
+}
+
+export function normalizeIdentifier(loginId?: string, email?: string): string {
+  return (loginId ?? email ?? "").trim().toLowerCase();
+}
+
+/**
+ * 로그인 시도 *전에* (bcrypt·DB 조회 전에) 호출한다. 한도 초과 시 LoginRateLimitError throw.
+ * DB 장애 시 조용히 통과한다(fail-open).
+ */
+export async function assertLoginRateLimit(identifier: string, ip: string): Promise<void> {
+  try {
+    const windowStart = new Date(Date.now() - LOGIN_WINDOW_MS);
+
+    const [failsByIdentifier, failsByIp] = await Promise.all([
+      prisma.loginAttempt.count({
+        where: { identifier, success: false, created_at: { gte: windowStart } },
+      }),
+      prisma.loginAttempt.count({
+        where: { ip_address: ip, success: false, created_at: { gte: windowStart } },
+      }),
+    ]);
+
+    const overByIdentifier = failsByIdentifier >= MAX_FAILS_PER_IDENTIFIER;
+    const overByIp = failsByIp >= MAX_FAILS_PER_IP;
+    if (!overByIdentifier && !overByIp) return;
+
+    // 어느 버킷이 초과인지에 따라 그 버킷의 가장 오래된 실패가 창에서 빠질 때까지를 Retry-After 로.
+    const oldest = await prisma.loginAttempt.findFirst({
+      where: overByIdentifier
+        ? { identifier, success: false, created_at: { gte: windowStart } }
+        : { ip_address: ip, success: false, created_at: { gte: windowStart } },
+      orderBy: { created_at: "asc" },
+      select: { created_at: true },
+    });
+    const retryAfterMs = oldest
+      ? oldest.created_at.getTime() + LOGIN_WINDOW_MS - Date.now()
+      : LOGIN_WINDOW_MS;
+    throw new LoginRateLimitError(Math.max(1, Math.ceil(retryAfterMs / 1000)));
+  } catch (e) {
+    if (e instanceof LoginRateLimitError) throw e;
+    console.error("assertLoginRateLimit failed (fail-open):", e);
+  }
+}
+
+/** 로그인 시도 결과를 기록한다(성공·실패 모두). DB 장애 시 조용히 무시한다. */
+export async function recordLoginAttempt(
+  identifier: string,
+  ip: string,
+  success: boolean,
+): Promise<void> {
+  try {
+    await prisma.loginAttempt.create({ data: { identifier, ip_address: ip, success } });
+  } catch (e) {
+    console.error("recordLoginAttempt failed:", e);
+  }
+}

--- a/docs/api/api-spec.md
+++ b/docs/api/api-spec.md
@@ -33,6 +33,26 @@
 
 ---
 
+## `/api/auth/login` — POST
+
+**Body:** `{ loginId?: string, email?: string, password: string }` (loginId 우선, 없으면 email)
+
+**Response 200:** `{ user: { user_id, name, login_id, email, current_role, account_status, military_status } }` + `Set-Cookie: plawcess_token`
+
+**Rate limit (#179)** — brute-force / credential stuffing 방어. `identifier`(입력한 loginId/email 을 소문자·trim 정규화) 와 클라이언트 IP 두 축으로 최근 15분 *실패* 횟수를 센다:
+- `identifier` 당 15분에 5회 실패 → 이후 그 identifier 의 요청은 `429`
+- IP 당 15분에 30회 실패 → 이후 그 IP 의 요청은 `429`
+- 한도 초과 응답: `429 { error: "너무 많은 로그인 시도가 있었습니다. 잠시 후 다시 시도해주세요." }` + `Retry-After` 헤더(초)
+- 레이트 리미터(`login_attempts` 테이블) 장애 시 fail-open(로그인 허용).
+
+**Errors:**
+- 400: 요청 형식 / 아이디·비밀번호 누락
+- 401: 아이디 또는 비밀번호 불일치 (계정 존재 여부 비노출 — 동일 메시지)
+- 403: `account_status === "blocked"`
+- 429: rate limit 초과 (위 참조)
+
+---
+
 ## `/api/auth/me` — GET
 
 현재 사용자의 신상 + 계정 정보 조회.

--- a/packages/database/prisma/migrations/20260512230000_add_login_attempts/migration.sql
+++ b/packages/database/prisma/migrations/20260512230000_add_login_attempts/migration.sql
@@ -1,0 +1,19 @@
+-- 로그인 brute-force / credential stuffing 방어용 시도 기록 (#179).
+-- /api/auth/login 이 (identifier, IP)별 최근 15분 실패 횟수를 세서 한도 초과 시 429.
+
+-- CreateTable
+CREATE TABLE "login_attempts" (
+    "id"         UUID NOT NULL DEFAULT gen_random_uuid(),
+    "identifier" VARCHAR(255) NOT NULL,
+    "ip_address" VARCHAR(64) NOT NULL,
+    "success"    BOOLEAN NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "login_attempts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "login_attempts_identifier_created_at_idx" ON "login_attempts"("identifier", "created_at");
+
+-- CreateIndex
+CREATE INDEX "login_attempts_ip_address_created_at_idx" ON "login_attempts"("ip_address", "created_at");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -536,6 +536,25 @@ model SchoolPersonalStatement {
   @@map("school_personal_statements")
 }
 
+// ----------------------------------------------------------------
+// 12. login_attempts (#179)
+//    - 로그인 brute-force / credential stuffing 방어용 시도 기록.
+//    - /api/auth/login 이 시도 직전에 (identifier, IP)별 최근 15분 실패 횟수를 세고,
+//      한도 초과 시 429 + Retry-After.
+//    - identifier 는 시도된 loginId/email 을 소문자·trim 정규화한 값 (계정 존재 여부와 무관하게 기록).
+// ----------------------------------------------------------------
+model LoginAttempt {
+  id         String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  identifier String   @db.VarChar(255)
+  ip_address String   @db.VarChar(64)
+  success    Boolean
+  created_at DateTime @default(now())
+
+  @@index([identifier, created_at])
+  @@index([ip_address, created_at])
+  @@map("login_attempts")
+}
+
 // ================================================================
 // migration.sql에 수동으로 추가해야 할 SQL
 // (Prisma가 자동 생성하지 않는 PostgreSQL 전용 기능)


### PR DESCRIPTION
## 배경
  `/api/auth/login` 이 무제한 비밀번호 시도를 허용했다 — rate limit·계정 lockout·IP 스로틀 전무. 온라인 비번 무차별 대입 / credential stuffing 에 무방비.

  remediation L2(계정 단위 brute-force lockout) + M2(rate limit 인프라).

  ## 변경
  **스키마 — 신규 `LoginAttempt` 모델** (`packages/database/prisma/schema.prisma` + `migrations/20260512230000_add_login_attempts/migration.sql`)
  - `(id, identifier, ip_address, success, created_at)` + `(identifier, created_at)`·`(ip_address, created_at)` 인덱스
  - `identifier` = 입력한 `loginId`/`email` 을 `.trim().toLowerCase()` 정규화 — **계정이 실제로 존재하든 안 하든 동일하게 기록** (rate-limit 동작 차이로 계정 존재 여부가 새지 않게)
  - ⚠️ **공유 Supabase dev DB / 프로덕션에는 이 PR 머지와 함께 마이그레이션 적용 필요** (#176 패턴). 미적용 시 코드가 fail-open(rate limit 스킵)이라 로그인 자체는 안 깨진다.

  **신규 `apps/api/src/lib/login-rate-limit.ts`**
  - `assertLoginRateLimit(identifier, ip)` — 최근 15분 동안 `identifier`별·`ip`별 *실패* 횟수를 센다. `identifier` 당 5회 / `ip` 당 30회 초과 시 `LoginRateLimitError(retryAfter)` throw. `retryAfter` = 해당 버킷의 가장 오래된 실패가 15분 창에서 빠질 때까지의 초.
  - `recordLoginAttempt(identifier, ip, success)` — 시도 결과 기록.
  - `normalizeIdentifier(loginId, email)`.
  - 레이트 리미터 자체(DB 조회/insert)가 실패하면 **fail-open** (로그인 허용) — 인프라 장애로 정상 사용자를 self-DoS 시키지 않기 위함(rate limiter 의 관용적 선택).

  **`/api/auth/login`**
  - 본문 검증(400) 직후, bcrypt·DB 조회 *전에* `assertLoginRateLimit` → 한도 초과면 `429 { error: "너무 많은 로그인 시도가 있었습니다. 잠시 후 다시 시도해주세요." }` + `Retry-After` 헤더
  - 실패(유저 없음/비번 틀림) → `recordLoginAttempt(.., false)` → 기존 `401` (메시지·모양 불변)
  - `account_status === "blocked"` → 비번은 맞았으니 `recordLoginAttempt(.., true)` (실패 카운트 미포함) → 기존 `403`
  - 성공 → `recordLoginAttempt(.., true)` → 기존 `signToken` + 쿠키 + 200
  - `ip` 는 기존 `getClientIp(req.headers)` 재사용. 빈 본문(400)·OPTIONS 등은 기록 안 함 → IP 버킷 오염 없음.

  **`docs/api/api-spec.md`** — `/api/auth/login` 섹션 신설 (429 + rate-limit 정책 명시).

  FE 변경 없음(429 도 표시하면 좋지만 핸드오프 메모; 필수 아님). 데이터 변경 없음(테이블 추가만).

  ## 의도된 한계 / 후속
  - 한도값(15분 / 5회·30회)은 상수 — 운영 보며 튜닝.
  - 성공 로그인 시 실패 카운트를 명시적으로 비우지 않음 — sliding window 라 15분 뒤 자연 소멸.
  - `find-id` 의 인메모리 `assertIpRateLimit`(M2 잔여)도 같은 DB 패턴으로 이관 — 별개 후속.
  - `login_attempts` 오래된 행 정리(주기적 `DELETE created_at < now-1d`) — 후속.
  - CAPTCHA — 인프라 없음, 후속.

  ## 검증
  - [x] `pnpm db:generate` (schema → client) + `pnpm --filter api build` (next build + tsc) 통과
  - [x] `pnpm --filter api lint` 통과 (기존 warning 2건 외 신규 0)
  - [ ] **429 E2E**: `login_attempts` 적용된 환경에서 — 한 identifier 로 연속 실패 5회 → 6번째 `429 + Retry-After` / 같은 IP 로 30회 실패 → 429 / 비번 맞추면 200 + 쿠키. (마이그레이션 적용 후 수행)

  Closes #179