### PR TITLE
feat(security): CSP 추가 — apps/web nonce 기반 Report-Only + apps/api 정적 …

### DIFF
--- a/apps/api/next.config.ts
+++ b/apps/api/next.config.ts
@@ -6,6 +6,8 @@ const securityHeaders = [
   { key: "X-Frame-Options", value: "DENY" },
   { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
   { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+  // API 는 JSON 응답만 — 스크립트/스타일/프레임이 실행될 일이 없으므로 가장 엄격하게.
+  { key: "Content-Security-Policy", value: "default-src 'none'; frame-ancestors 'none'" },
 ];
 
 const nextConfig: NextConfig = {

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// Content-Security-Policy — nonce 기반 엄격 정책. 지금은 Report-Only(차단 안 함, 위반만
+// 브라우저 콘솔에 로그) 로 깔아 두고, 위반을 관찰한 뒤 후속 PR 에서 enforce 로 전환한다.
+//
+// Next.js 의 nonce 메커니즘: 미들웨어가 요청 헤더에 "Content-Security-Policy" 를 세팅하면
+// Next 가 거기서 'nonce-...' 를 추출해 자기 인라인 <script>/<style> 에 자동 부착한다.
+// 앱 코드에서 인라인 스크립트가 필요하면 headers().get("x-nonce") 로 받아 쓰면 된다.
+//
+// 기존 보안 헤더 5종은 next.config.mjs 의 headers() 에서 계속 적용된다(X-Frame-Options 포함 —
+// CSP frame-ancestors 미지원 구형 브라우저 폴백).
+
+export function middleware(request: NextRequest) {
+  // Edge 런타임이라 Buffer 가 없음 → crypto.getRandomValues + btoa.
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  const nonce = btoa(String.fromCharCode(...bytes));
+
+  const isDev = process.env.NODE_ENV !== "production";
+  const csp = [
+    `default-src 'self'`,
+    // dev 에서는 Next HMR/React refresh 가 eval 을 써서 'unsafe-eval' 이 필요(프로덕션엔 없음).
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${isDev ? " 'unsafe-eval'" : ""}`,
+    `style-src 'self' 'nonce-${nonce}'`,
+    `img-src 'self' blob: data:`, // HWP 에디터 페이지 렌더링 / OG 이미지 등
+    `font-src 'self'`, // Pretendard — public/ 로컬 폰트
+    `connect-src 'self'`, // API 는 /api/* rewrite 라 same-origin
+    `worker-src 'self' blob:`, // @rhwp/editor 가 Worker 를 쓸 수 있음
+    `frame-ancestors 'none'`,
+    `base-uri 'self'`,
+    `form-action 'self'`,
+    `object-src 'none'`,
+    `upgrade-insecure-requests`,
+  ].join("; ");
+
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-nonce", nonce);
+  // Next 가 nonce 를 추출하려면 요청 헤더의 "Content-Security-Policy" 를 본다 (-Report-Only 아님).
+  requestHeaders.set("Content-Security-Policy", csp);
+
+  const response = NextResponse.next({ request: { headers: requestHeaders } });
+  // 브라우저에는 Report-Only 로 — 위반을 콘솔에 로그만 하고 차단하지 않는다.
+  response.headers.set("Content-Security-Policy-Report-Only", csp);
+  return response;
+}
+
+export const config = {
+  // _next 내부·favicon·정적 에셋(확장자 있는 경로)·/api/* 는 제외 — HTML 페이지 요청에만.
+  matcher: ["/((?!api|_next/static|_next/image|favicon.ico|.*\\.[\\w]+$).*)"],
+};


### PR DESCRIPTION
  ## 배경
  #202 에서 보안 헤더 5종을 추가했으나 Content-Security-Policy 가 빠져 있었다 (remediation H2 의 잔여분).

  Next.js 16 App Router 는 프레임워크가 hydration·`__NEXT_DATA__` 인라인 `<script>` 와 `next/font` 의 `@font-face` 인라인 `<style>` 을  넣으므로, `'unsafe-inline'` 없는 엄격 `script-src`/`style-src` 를 쓰려면 Next 의 nonce 메커니즘(미들웨어가 요청마다 nonce 생성 → CSP 헤더에 주입 → Next 가 자기 인라인 태그에 자동 부착)이 필요하다. `apps/web` 에 미들웨어가 없어 새로 만든다. 그리고 `@rhwp/editor`(HWP 에디터)가 WASM/Worker/Blob 등을 어떻게 쓰는지 예측 불가하므로, **Report-Only 로 먼저 깔아 위반을 관찰**한 뒤 후속 PR 에서 enforce 로 전환한다 (H2 의 계획).

  ## 변경
  **`apps/web/src/middleware.ts` (신규)** — Next.js CSP nonce 패턴
  - 요청마다 `crypto.getRandomValues` 16바이트 → base64 nonce (Edge 런타임이라 `Buffer` 대신 `btoa`)
  - 요청 헤더에 `Content-Security-Policy: <csp>` (Next 가 여기서 `'nonce-..'` 추출) + `x-nonce` (앱 코드용)
  - 응답 헤더에 `Content-Security-Policy-Report-Only: <csp>` (브라우저는 위반을 콘솔에 로그만, 차단 안 함)
  - 정책: `default-src 'self'; script-src 'self' 'nonce-..' 'strict-dynamic'`(+dev `'unsafe-eval'` — Next HMR)`; style-src 'self' 'nonce-..'; 
  img-src 'self' blob: data:`(HWP 페이지 렌더·OG)`; font-src 'self'`(Pretendard 로컬)`; connect-src 'self'`(API 는 `/api/*` rewrite 라        
  same-origin)`; worker-src 'self' blob:`(`@rhwp/editor` 대비)`; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src      
  'none'; upgrade-insecure-requests`
  - `matcher`: `_next/static`·`_next/image`·`favicon.ico`·확장자 있는 정적 경로·`/api/*` 제외 (HTML 페이지 요청에만)
  - `next.config.mjs` 의 기존 헤더 5종·`X-Frame-Options: DENY` 는 그대로 유지(CSP `frame-ancestors` 미지원 구형 브라우저 폴백)

  **`apps/api/next.config.ts`** — `securityHeaders` 에 `Content-Security-Policy: default-src 'none'; frame-ancestors 'none'` 추가. API 는 JSON 응답뿐이라 위반 날 게 없으므로 enforce 로 바로, nonce 불필요.

  ## 의도된 한계 / 후속 (별도 PR)
  - **Report-Only → enforce 전환**: 이번 PR 은 Report-Only. dev/스테이징/프로덕션 콘솔에서 위반 관찰(특히 HWP 에디터 페이지 — WASM 쓰면 `script-src 'wasm-unsafe-eval'` 추가 필요할 수 있음, Worker/Blob 은 이미 포함) → 디렉티브 튜닝 → `Content-Security-Policy-Report-Only` →  `Content-Security-Policy` 전환.
  - **위반 리포트 엔드포인트** (`report-uri`/`report-to` + `/api/csp-report`) — 후속 (지금은 콘솔 관찰로 충분).
  - `'strict-dynamic'` — Next 코드 분할 청크가 nonce 부착 부트스트랩에서 로드되므로 동작. 위반에서 청크 차단이 보이면 재검토.

  ## 검증
  - [x] `pnpm --filter web build`·`lint`, `pnpm --filter api build`·`lint` 통과 (web 빌드 출력에 `ƒ Proxy (Middleware)` — 미들웨어 인식됨)    
  - [x] dev: `apps/web` `GET /` 에 `Content-Security-Policy-Report-Only` 헤더 존재
  - [x] dev: 헤더의 nonce ↔ HTML 인라인 `<script nonce="..">` 가 같은 요청 내에서 일치 (Next 메커니즘 동작)
  - [x] dev: `/login` 정상 로드 (Report-Only — 안 깨짐)
  - [x] dev: `apps/api` `/api/health` 에 `Content-Security-Policy: default-src 'none'; frame-ancestors 'none'`
  - [ ] **(후속)** 콘솔 CSP 위반 수집 — HWP 에디터 페이지·자기소개서·로그인 흐름 직접 둘러보며

  #203