### PR TITLE
feat(#232): 멘토 프로세스 대시보드 + 멘티 상세 페이지

### DIFF
--- a/apps/api/src/app/api/mentor/history/route.ts
+++ b/apps/api/src/app/api/mentor/history/route.ts
@@ -1,0 +1,96 @@
+// apps/api/src/app/api/mentor/history/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@plawcess/database";
+import { getTokenFromCookie } from "@/lib/auth";
+
+type HistoryMentee = {
+  matchId: string;
+  name: string;
+  targetSchoolGa: string | null;
+  admissionTypeGa: string | null;
+  targetSchoolNa: string | null;
+  admissionTypeNa: string | null;
+  phone: string | null;
+};
+
+type ResponseBody = {
+  history: Array<{
+    processYear: number;
+    mentees: HistoryMentee[];
+  }>;
+};
+
+function admissionTypeLabel(school: string | null, isSpecial: boolean): string | null {
+  if (!school) return null;
+  return isSpecial ? "특별전형" : "일반전형";
+}
+
+// ----------------------------------------------------------------
+// GET /api/mentor/history
+// 활성 cycle 을 제외한 모든 과거 사이클의 멘토 참여 이력 (연도 내림차순).
+// 활성 cycle 이 없으면 전체 멘토 Application 이 대상.
+// ----------------------------------------------------------------
+export async function GET(req: NextRequest) {
+  const userId = getTokenFromCookie(req)?.user_id ?? null;
+  if (!userId) {
+    return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
+  }
+
+  const active = await prisma.cycleSchedule.findFirst({
+    where: { is_active: true },
+    select: { process_year: true },
+  });
+  const activeYear = active?.process_year ?? null;
+
+  const applications = await prisma.application.findMany({
+    where: {
+      user_id: userId,
+      role: "mentor",
+      ...(activeYear !== null ? { process_year: { not: activeYear } } : {}),
+    },
+    select: {
+      process_year: true,
+      mentor_match_results: {
+        where: { is_finalized: true },
+        select: {
+          match_id: true,
+          mentee_application: {
+            select: {
+              user: { select: { name: true, phone: true } },
+              mentee_record: {
+                select: {
+                  target_school_ga: true,
+                  is_special_ga: true,
+                  target_school_na: true,
+                  is_special_na: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    orderBy: { process_year: "desc" },
+  });
+
+  const history = applications
+    .map((app) => ({
+      processYear: app.process_year,
+      mentees: app.mentor_match_results.map((m) => {
+        const record = m.mentee_application.mentee_record;
+        return {
+          matchId: m.match_id,
+          name: m.mentee_application.user.name,
+          targetSchoolGa: record?.target_school_ga ?? null,
+          admissionTypeGa: admissionTypeLabel(record?.target_school_ga ?? null, record?.is_special_ga ?? false),
+          targetSchoolNa: record?.target_school_na ?? null,
+          admissionTypeNa: admissionTypeLabel(record?.target_school_na ?? null, record?.is_special_na ?? false),
+          phone: m.mentee_application.user.phone ?? null,
+        };
+      }),
+    }))
+    .filter((y) => y.mentees.length > 0);
+
+  const body: ResponseBody = { history };
+  return NextResponse.json(body);
+}

--- a/apps/api/src/app/api/mentor/mentees/[matchId]/route.ts
+++ b/apps/api/src/app/api/mentor/mentees/[matchId]/route.ts
@@ -1,0 +1,170 @@
+// apps/api/src/app/api/mentor/mentees/[matchId]/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@plawcess/database";
+import { getTokenFromCookie } from "@/lib/auth";
+
+// ----------------------------------------------------------------
+// GET /api/mentor/mentees/[matchId]
+// 멘토가 본인에게 매칭된 멘티의 정보를 read-only 로 조회.
+// 검증: matchId 의 mentor_application 이 현재 로그인 멘토 본인이어야 함.
+// ----------------------------------------------------------------
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ matchId: string }> },
+) {
+  const userId = getTokenFromCookie(req)?.user_id ?? null;
+  if (!userId) {
+    return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
+  }
+
+  const { matchId } = await params;
+
+  const match = await prisma.matchResult.findUnique({
+    where: { match_id: matchId },
+    select: {
+      match_id: true,
+      is_finalized: true,
+      mentor_application: { select: { user_id: true } },
+      mentee_application: {
+        select: {
+          user: {
+            select: {
+              name: true,
+              email: true,
+              phone: true,
+              birth_date: true,
+              gender: true,
+              military_status: true,
+              student_id: true,
+              undergrad_school_name: true,
+              undergrad_first_major: true,
+              undergrad_second_major: true,
+              undergrad_entry_year: true,
+              undergrad_graduation_year: true,
+            },
+          },
+          mentee_record: {
+            select: {
+              academic_status: true,
+              target_school_ga: true,
+              is_special_ga: true,
+              target_school_na: true,
+              is_special_na: true,
+              preferred_group: true,
+              gpa: true,
+              gpa_major: true,
+              gpa_converted: true,
+              leet_score: true,
+              leet_verbal_raw: true,
+              leet_verbal_standard: true,
+              leet_verbal_percentile: true,
+              leet_reasoning_raw: true,
+              leet_reasoning_standard: true,
+              leet_reasoning_percentile: true,
+              toeic_score: true,
+              toefl_score: true,
+              teps_score: true,
+              career_goal: true,
+              core_keywords: true,
+              qualitative_activities: true,
+              personal_statement_text_ga: true,
+              personal_statement_text_na: true,
+              personal_statement_hwp_ga: true,
+              personal_statement_hwp_na: true,
+              strengths_weaknesses: true,
+              desired_mentor: true,
+              special_notes: true,
+              extra_request: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!match) {
+    return NextResponse.json({ error: "매칭 정보를 찾을 수 없습니다." }, { status: 404 });
+  }
+
+  if (!match.is_finalized || match.mentor_application.user_id !== userId) {
+    return NextResponse.json({ error: "접근 권한이 없습니다." }, { status: 403 });
+  }
+
+  const user = match.mentee_application.user;
+  const record = match.mentee_application.mentee_record;
+
+  const num = (d: unknown): number | null =>
+    d === null || d === undefined ? null : Number(d);
+
+  return NextResponse.json({
+    matchId: match.match_id,
+    user: {
+      name: user.name,
+      email: user.email,
+      phone: user.phone,
+      birthDate: user.birth_date?.toISOString() ?? null,
+      gender: user.gender,
+      militaryStatus: user.military_status,
+      studentId: user.student_id,
+      undergradSchool: user.undergrad_school_name,
+      firstMajor: user.undergrad_first_major,
+      secondMajor: user.undergrad_second_major,
+      entryYear: user.undergrad_entry_year,
+      graduationYear: user.undergrad_graduation_year,
+      academicStatus: record?.academic_status ?? null,
+    },
+    admission: {
+      targetSchoolGa: record?.target_school_ga ?? null,
+      isSpecialGa: record?.is_special_ga ?? false,
+      targetSchoolNa: record?.target_school_na ?? null,
+      isSpecialNa: record?.is_special_na ?? false,
+      preferredGroup: record?.preferred_group ?? null,
+    },
+    quantitative: {
+      leet: {
+        total: num(record?.leet_score),
+        verbal: {
+          raw: record?.leet_verbal_raw ?? null,
+          standard: record?.leet_verbal_standard ?? null,
+          percentile: num(record?.leet_verbal_percentile),
+        },
+        reasoning: {
+          raw: record?.leet_reasoning_raw ?? null,
+          standard: record?.leet_reasoning_standard ?? null,
+          percentile: num(record?.leet_reasoning_percentile),
+        },
+      },
+      gpa: {
+        overall: num(record?.gpa),
+        major: num(record?.gpa_major),
+        converted: num(record?.gpa_converted),
+      },
+      language: {
+        toeic: record?.toeic_score ?? null,
+        toefl: record?.toefl_score ?? null,
+        teps: record?.teps_score ?? null,
+      },
+    },
+    qualitative: {
+      careerGoal: record?.career_goal ?? null,
+      coreKeywords: record?.core_keywords ?? null,
+      activities: record?.qualitative_activities ?? null,
+    },
+    personalStatement: {
+      ga: {
+        hasHwp: !!record?.personal_statement_hwp_ga,
+        textAnswers: record?.personal_statement_text_ga ?? null,
+      },
+      na: {
+        hasHwp: !!record?.personal_statement_hwp_na,
+        textAnswers: record?.personal_statement_text_na ?? null,
+      },
+    },
+    requests: {
+      strengthsWeaknesses: record?.strengths_weaknesses ?? null,
+      desiredMentor: record?.desired_mentor ?? null,
+      specialNotes: record?.special_notes ?? null,
+      extraRequest: record?.extra_request ?? null,
+    },
+  });
+}

--- a/apps/api/src/app/api/mentor/process-status/route.ts
+++ b/apps/api/src/app/api/mentor/process-status/route.ts
@@ -1,0 +1,130 @@
+// apps/api/src/app/api/mentor/process-status/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@plawcess/database";
+import { getTokenFromCookie } from "@/lib/auth";
+
+type ProcessStatus = "inactive" | "waiting" | "active";
+
+type MatchedMentee = {
+  matchId: string;
+  name: string;
+  targetSchoolGa: string | null;
+  admissionTypeGa: string | null;
+  targetSchoolNa: string | null;
+  admissionTypeNa: string | null;
+  personalStatementStatus: "not_submitted";
+};
+
+type ResponseBody = {
+  status: ProcessStatus;
+  processYear: number | null;
+  matchAnnounceDate: string | null;
+  matchedMentees: MatchedMentee[] | null;
+};
+
+function admissionTypeLabel(school: string | null, isSpecial: boolean): string | null {
+  if (!school) return null;
+  return isSpecial ? "특별전형" : "일반전형";
+}
+
+// ----------------------------------------------------------------
+// GET /api/mentor/process-status
+// 현재 활성 cycle 기준으로 사업 상태와 매칭 멘티 목록 반환.
+// - inactive : 활성 cycle 없음
+// - waiting  : 활성 cycle 있음 + 오늘 < match_announce_date (또는 match_announce_date null)
+// - active   : 활성 cycle 있음 + 오늘 >= match_announce_date  → matchedMentees 채움
+// ----------------------------------------------------------------
+export async function GET(req: NextRequest) {
+  const userId = getTokenFromCookie(req)?.user_id ?? null;
+  if (!userId) {
+    return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
+  }
+
+  const active = await prisma.cycleSchedule.findFirst({
+    where: { is_active: true },
+    select: { process_year: true, match_announce_date: true },
+  });
+
+  if (!active) {
+    const body: ResponseBody = {
+      status: "inactive",
+      processYear: null,
+      matchAnnounceDate: null,
+      matchedMentees: null,
+    };
+    return NextResponse.json(body);
+  }
+
+  const announceDate = active.match_announce_date;
+  const today = new Date();
+  const isActiveStatus = announceDate !== null && today.getTime() >= announceDate.getTime();
+
+  if (!isActiveStatus) {
+    const body: ResponseBody = {
+      status: "waiting",
+      processYear: active.process_year,
+      matchAnnounceDate: announceDate?.toISOString() ?? null,
+      matchedMentees: null,
+    };
+    return NextResponse.json(body);
+  }
+
+  // active: 본인의 멘토 Application → finalize 된 MatchResult → 상대 멘티 정보
+  const mentorApp = await prisma.application.findUnique({
+    where: {
+      user_id_process_year_role: {
+        user_id: userId,
+        process_year: active.process_year,
+        role: "mentor",
+      },
+    },
+    select: { application_id: true },
+  });
+
+  let matchedMentees: MatchedMentee[] = [];
+  if (mentorApp) {
+    const matches = await prisma.matchResult.findMany({
+      where: {
+        mentor_application_id: mentorApp.application_id,
+        is_finalized: true,
+      },
+      select: {
+        match_id: true,
+        mentee_application: {
+          select: {
+            user: { select: { name: true } },
+            mentee_record: {
+              select: {
+                target_school_ga: true,
+                is_special_ga: true,
+                target_school_na: true,
+                is_special_na: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    matchedMentees = matches.map((m) => {
+      const record = m.mentee_application.mentee_record;
+      return {
+        matchId: m.match_id,
+        name: m.mentee_application.user.name,
+        targetSchoolGa: record?.target_school_ga ?? null,
+        admissionTypeGa: admissionTypeLabel(record?.target_school_ga ?? null, record?.is_special_ga ?? false),
+        targetSchoolNa: record?.target_school_na ?? null,
+        admissionTypeNa: admissionTypeLabel(record?.target_school_na ?? null, record?.is_special_na ?? false),
+        personalStatementStatus: "not_submitted",
+      };
+    });
+  }
+
+  const body: ResponseBody = {
+    status: "active",
+    processYear: active.process_year,
+    matchAnnounceDate: announceDate?.toISOString() ?? null,
+    matchedMentees,
+  };
+  return NextResponse.json(body);
+}

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -10,9 +10,9 @@ import { saveUser } from '@/lib/api';
 const API_BASE = '';
 
 const ROLE_REDIRECT: Record<string, string> = {
-  mentee: '/mentee/dashboard',
+  mentee: '/mentee/dashboard/basic-info',
   mentor: '/mentor/dashboard',
-  admin: '/admin/users',
+  admin: '/admin/schedule',
 };
 
 export default function LoginPage() {
@@ -87,6 +87,39 @@ export default function LoginPage() {
     router.push(ROLE_REDIRECT['admin'] ?? '/');
   }
 
+  async function handleTestMentorLogin() {
+    setError('');
+    setLoading(true);
+
+    const testLoginId = process.env.NEXT_PUBLIC_TEST_MENTOR_LOGIN_ID ?? 'test.mentor';
+    const testPassword = process.env.NEXT_PUBLIC_TEST_MENTOR_PASSWORD ?? 'test1234';
+
+    let res: Response;
+    try {
+      res = await fetch(`${API_BASE}/api/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ loginId: testLoginId, password: testPassword }),
+      });
+    } catch {
+      setError('테스트 로그인 실패: 서버에 연결할 수 없습니다.');
+      setLoading(false);
+      return;
+    }
+
+    const data = await res.json();
+    setLoading(false);
+
+    if (!res.ok) {
+      setError(`테스트 로그인 실패: ${data.error ?? '알 수 없는 오류'}`);
+      return;
+    }
+
+    saveUser(data.user);
+    router.push(ROLE_REDIRECT['mentor'] ?? '/');
+  }
+
   return (
     <div className="flex flex-col min-h-screen">
       <header className="sticky top-0 z-50 h-16 bg-white border-b border-border flex items-center px-6 shrink-0">
@@ -146,13 +179,22 @@ export default function LoginPage() {
               </button>
 
               {process.env.NEXT_PUBLIC_SHOW_DEV_LOGIN === 'true' && (
-                <button
-                  type="button"
-                  onClick={() => handleTestAdminLogin()}
-                  className="w-full py-2.5 text-sm font-semibold text-brand bg-blue-50 rounded-md hover:bg-blue-100 transition-colors border border-blue-200"
-                >
-                  [dev용] Admin으로 빠른 로그인
-                </button>
+                <div className="flex flex-col gap-2">
+                  <button
+                    type="button"
+                    onClick={() => handleTestAdminLogin()}
+                    className="w-full py-2.5 text-sm font-semibold text-brand bg-blue-50 rounded-md hover:bg-blue-100 transition-colors border border-blue-200"
+                  >
+                    [dev용] Admin으로 빠른 로그인
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleTestMentorLogin()}
+                    className="w-full py-2.5 text-sm font-semibold text-brand bg-blue-50 rounded-md hover:bg-blue-100 transition-colors border border-blue-200"
+                  >
+                    [dev용] Mentor로 빠른 로그인
+                  </button>
+                </div>
               )}
 
               <p className="text-center text-sm text-text-secondary flex justify-center gap-4">

--- a/apps/web/src/app/mentor/dashboard/MentorDashboardClient.tsx
+++ b/apps/web/src/app/mentor/dashboard/MentorDashboardClient.tsx
@@ -1,0 +1,322 @@
+'use client';
+
+import Link from 'next/link';
+import type { MentorProcessStatus, MatchedMentee, CycleSchedule } from '@/lib/api';
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '미정';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '미정';
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}.${m}.${day}`;
+}
+
+function formatShortDate(iso: string | null): string {
+  if (!iso) return '미정';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '미정';
+  return `${String(d.getMonth() + 1).padStart(2, '0')}.${String(d.getDate()).padStart(2, '0')}`;
+}
+
+// ------------------- 상태 안내 -------------------
+
+function StatusMessage({ status }: { status: MentorProcessStatus }) {
+  if (status.status === 'inactive') {
+    return (
+      <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
+        <div className="flex items-center gap-4">
+          <div className="w-12 h-12 rounded-full bg-gray-100 flex items-center justify-center text-text-secondary shrink-0">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="10" />
+              <line x1="12" y1="8" x2="12" y2="12" />
+              <line x1="12" y1="16" x2="12.01" y2="16" />
+            </svg>
+          </div>
+          <div>
+            <p className="text-base font-semibold text-text-primary">비운영 기간</p>
+            <p className="text-sm text-text-secondary mt-0.5">
+              현재는 pLAWcess 멘토링 운영 기간이 아닙니다.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (status.status === 'waiting') {
+    return (
+      <div className="bg-white rounded-xl border border-border shadow-sm overflow-hidden">
+        <div className="flex items-center gap-4 px-4 sm:px-8 py-6 bg-brand-light border-b border-border">
+          <div className="w-12 h-12 rounded-full bg-brand-muted flex items-center justify-center text-brand shrink-0">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="10" />
+              <polyline points="12 6 12 12 16 14" />
+            </svg>
+          </div>
+          <div>
+            <p className="text-base font-bold text-text-primary">매칭 대기 중</p>
+            <p className="text-sm text-text-secondary mt-0.5">
+              {status.processYear} pLAWcess 멘토 참여 감사드립니다.
+            </p>
+          </div>
+        </div>
+        <div className="px-4 sm:px-8 py-5 space-y-1.5">
+          <p className="text-sm text-text-primary">
+            멘티 매칭 결과는{' '}
+            <span className="font-semibold text-brand">
+              {formatDate(status.matchAnnounceDate)}
+            </span>
+            에 공개될 예정입니다.
+          </p>
+          <p className="text-sm text-text-secondary">
+            매칭이 완료되면 메시지를 발송드리겠습니다.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-xl border border-border shadow-sm overflow-hidden">
+      <div className="flex items-center gap-4 px-4 sm:px-8 py-6 bg-brand-light border-b border-border">
+        <div className="w-12 h-12 rounded-full bg-brand text-white flex items-center justify-center shrink-0">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        </div>
+        <div>
+          <p className="text-base font-bold text-text-primary">멘토링 운영 중</p>
+          <p className="text-sm text-text-secondary mt-0.5">
+            {status.processYear} pLAWcess에 멘토로 참여해주셔서 감사드립니다.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ------------------- 매칭 멘티 카드 -------------------
+
+function MenteeCard({ m }: { m: MatchedMentee }) {
+  return (
+    <Link
+      href={`/mentor/mentees/${m.matchId}`}
+      className="group bg-white rounded-xl border border-border shadow-sm overflow-hidden hover:border-brand hover:shadow-md transition-all"
+    >
+      <div className="flex items-center gap-4 px-5 py-5 bg-brand-light border-b border-border">
+        <div className="w-12 h-12 rounded-full bg-brand-muted flex items-center justify-center text-brand shrink-0">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+            <circle cx="12" cy="7" r="4" />
+          </svg>
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-base font-bold text-text-primary truncate">{m.name}</p>
+          <p className="text-xs text-text-secondary mt-0.5">매칭 멘티</p>
+        </div>
+        <svg
+          className="text-text-secondary group-hover:text-brand transition-colors shrink-0"
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <polyline points="9 18 15 12 9 6" />
+        </svg>
+      </div>
+
+      <div className="px-5 py-4 space-y-3">
+        <div className="space-y-2">
+          <div className="flex items-start gap-2">
+            <span className="inline-block text-xs font-semibold text-brand bg-brand-light px-2 py-0.5 rounded shrink-0 mt-0.5">
+              가
+            </span>
+            <p className="text-sm text-text-primary flex-1">
+              {m.targetSchoolGa ? (
+                <>
+                  {m.targetSchoolGa}
+                  {m.admissionTypeGa && (
+                    <span className="text-text-secondary"> · {m.admissionTypeGa}</span>
+                  )}
+                </>
+              ) : (
+                <span className="text-text-secondary">-</span>
+              )}
+            </p>
+          </div>
+          <div className="flex items-start gap-2">
+            <span className="inline-block text-xs font-semibold text-brand bg-brand-light px-2 py-0.5 rounded shrink-0 mt-0.5">
+              나
+            </span>
+            <p className="text-sm text-text-primary flex-1">
+              {m.targetSchoolNa ? (
+                <>
+                  {m.targetSchoolNa}
+                  {m.admissionTypeNa && (
+                    <span className="text-text-secondary"> · {m.admissionTypeNa}</span>
+                  )}
+                </>
+              ) : (
+                <span className="text-text-secondary">-</span>
+              )}
+            </p>
+          </div>
+        </div>
+
+        <div className="pt-3 border-t border-border flex items-center justify-between">
+          <span className="text-xs text-text-secondary">자기소개서</span>
+          <span className="inline-flex items-center gap-1 text-xs font-medium px-2 py-1 rounded bg-gray-100 text-text-secondary">
+            <span className="w-1.5 h-1.5 rounded-full bg-gray-400" />
+            미제출
+          </span>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+function MatchedMenteeSection({ status }: { status: MentorProcessStatus }) {
+  if (status.status !== 'active') return null;
+
+  const mentees = status.matchedMentees ?? [];
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-bold text-text-primary">매칭 멘티</h2>
+        <span className="text-sm text-text-secondary">총 {mentees.length}명</span>
+      </div>
+      {mentees.length === 0 ? (
+        <div className="bg-white rounded-xl border border-border shadow-sm px-8 py-12 text-center">
+          <div className="w-14 h-14 rounded-full bg-gray-100 flex items-center justify-center text-text-secondary mx-auto mb-3">
+            <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+              <circle cx="9" cy="7" r="4" />
+              <path d="M22 11h-6" />
+            </svg>
+          </div>
+          <p className="text-sm text-text-secondary">매칭된 멘티가 없습니다.</p>
+        </div>
+      ) : (
+        <div className={`grid gap-4 ${mentees.length > 1 ? 'sm:grid-cols-2' : ''}`}>
+          {mentees.map((m) => (
+            <MenteeCard key={m.matchId} m={m} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ------------------- 사이클 일정 카드 -------------------
+
+type ScheduleItem = {
+  label: string;
+  start: string | null;
+  end: string | null;
+};
+
+function CycleScheduleCard({ cycle }: { cycle: CycleSchedule }) {
+  const items: ScheduleItem[] = [
+    { label: '멘티 신청', start: cycle.mentee_apply_start, end: cycle.mentee_apply_end },
+    { label: 'AI 매칭', start: cycle.matching_start, end: cycle.matching_end },
+    { label: '매칭 발표', start: cycle.match_announce_date, end: null },
+    { label: '합격자 결과 입력', start: cycle.admission_result_start, end: cycle.admission_result_end },
+  ];
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const isPast = (iso: string | null) => {
+    if (!iso) return false;
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return false;
+    return d.getTime() < today.getTime();
+  };
+
+  const formatRange = (item: ScheduleItem) => {
+    if (!item.start && !item.end) return '일정 미정';
+    if (item.start && !item.end) return formatDate(item.start);
+    return `${formatShortDate(item.start)} ~ ${formatShortDate(item.end)}`;
+  };
+
+  return (
+    <section className="space-y-4">
+      <h2 className="text-lg font-bold text-text-primary">{cycle.process_year} 사이클 일정</h2>
+      <div className="bg-white rounded-xl border border-border shadow-sm overflow-hidden">
+        <ol className="divide-y divide-border">
+          {items.map((item) => {
+            const past = isPast(item.end ?? item.start);
+            return (
+              <li key={item.label} className="flex items-center gap-4 px-5 sm:px-6 py-4">
+                <div
+                  className={`w-9 h-9 rounded-full flex items-center justify-center shrink-0 ${
+                    past
+                      ? 'bg-brand-muted text-brand'
+                      : 'bg-gray-100 text-text-secondary'
+                  }`}
+                >
+                  {past ? (
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                      <polyline points="20 6 9 17 4 12" />
+                    </svg>
+                  ) : (
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                      <circle cx="12" cy="12" r="10" />
+                    </svg>
+                  )}
+                </div>
+                <div className="flex-1">
+                  <p className={`text-sm font-medium ${past ? 'text-text-secondary' : 'text-text-primary'}`}>
+                    {item.label}
+                  </p>
+                </div>
+                <p className={`text-sm tabular-nums ${past ? 'text-text-secondary' : 'text-text-primary'}`}>
+                  {formatRange(item)}
+                </p>
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+    </section>
+  );
+}
+
+// ------------------- 페이지 -------------------
+
+type Props = {
+  status: MentorProcessStatus | null;
+  cycle: CycleSchedule | null;
+};
+
+export default function MentorDashboardClient({ status, cycle }: Props) {
+  return (
+    <div className="flex flex-col gap-8 page-container w-full">
+      <div>
+        <h1 className="text-2xl font-bold text-text-primary">멘토 대시보드</h1>
+        <p className="text-sm text-text-secondary mt-1">
+          진행 상태와 매칭 멘티 정보를 확인하세요.
+        </p>
+      </div>
+
+      {!status ? (
+        <div className="bg-white rounded-xl border border-border shadow-sm p-5 text-sm text-red-600">
+          데이터를 불러오지 못했습니다.
+        </div>
+      ) : (
+        <>
+          <StatusMessage status={status} />
+          <MatchedMenteeSection status={status} />
+          {status.status !== 'inactive' && cycle && <CycleScheduleCard cycle={cycle} />}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/mentor/dashboard/page.tsx
+++ b/apps/web/src/app/mentor/dashboard/page.tsx
@@ -1,106 +1,15 @@
-'use client';
+import { cookies } from 'next/headers';
+import MentorDashboardClient from './MentorDashboardClient';
+import { serverFetch } from '@/lib/server-fetch';
+import type { MentorProcessStatus, CycleSchedule } from '@/lib/api';
 
-import { useState } from 'react';
+export default async function MentorDashboardPage() {
+  const token = (await cookies()).get('plawcess_token')?.value ?? '';
 
-// TODO: API 연결 후 실제 데이터로 교체
-const MOCK_MENTEES = [
-  {
-    matchId: '1',
-    name: '김자전',
-    email: 'kim@korea.ac.kr',
-    phone: '010-1234-5678',
-    targetSchoolGa: '고려대학교',
-    targetSchoolNa: '연세대학교',
-    desiredMentor: '자소서와 면접 준비를 도와줄 멘토를 원합니다.',
-  },
-  {
-    matchId: '2',
-    name: '이지원',
-    email: 'lee@korea.ac.kr',
-    phone: '010-9876-5432',
-    targetSchoolGa: '서울대학교',
-    targetSchoolNa: null,
-    desiredMentor: null,
-  },
-];
+  const [status, cycle] = await Promise.all([
+    serverFetch<MentorProcessStatus>('/api/mentor/process-status', token),
+    serverFetch<CycleSchedule>('/api/cycle-schedules/active', token),
+  ]);
 
-export default function MentorDashboardPage() {
-  const [kakaoLink, setKakaoLink] = useState('');
-  const [copied, setCopied] = useState(false);
-
-  function handleCopy() {
-    if (!kakaoLink) return;
-    navigator.clipboard.writeText(kakaoLink);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  }
-
-  return (
-    <div className="flex flex-col gap-8 page-container w-full">
-      <div>
-        <h1 className="text-xl font-bold text-text-primary">멘토 대시보드</h1>
-        <p className="mt-1 text-sm text-text-secondary">매칭된 멘티 목록입니다.</p>
-      </div>
-
-      {/* 카카오톡 오픈채팅 */}
-      <div className="bg-white border border-border rounded-xl p-5 max-w-md">
-        <p className="text-sm font-medium text-text-primary">카카오톡 오픈채팅 링크</p>
-        <div className="flex gap-2 mt-2">
-          <input
-            type="url"
-            value={kakaoLink}
-            onChange={(e) => setKakaoLink(e.target.value)}
-            placeholder="https://open.kakao.com/o/..."
-            className="flex-1 px-3 py-2 text-sm border border-border-input rounded-md focus:outline-none focus:border-brand transition-colors"
-          />
-          <button
-            onClick={handleCopy}
-            disabled={!kakaoLink}
-            className="px-4 py-2 text-sm font-medium text-white bg-brand rounded-md hover:bg-brand-dark transition-colors disabled:opacity-40"
-          >
-            {copied ? '복사됨' : '복사'}
-          </button>
-        </div>
-        <p className="mt-1.5 text-xs text-text-secondary">링크를 입력하고 복사해 멘티에게 공유하세요.</p>
-      </div>
-
-      {/* 멘티 카드 목록 */}
-      {MOCK_MENTEES.length === 0 ? (
-        <div className="bg-white border border-border rounded-xl p-10 text-center text-text-secondary text-sm">
-          아직 매칭된 멘티가 없습니다.
-        </div>
-      ) : (
-        <div className="grid gap-4 sm:grid-cols-2">
-          {MOCK_MENTEES.map((mentee) => (
-            <div key={mentee.matchId} className="bg-white border border-border rounded-xl p-5 space-y-3">
-              <div>
-                <p className="font-semibold text-text-primary">{mentee.name}</p>
-                <p className="text-sm text-text-secondary">{mentee.email}</p>
-                {mentee.phone && (
-                  <p className="text-sm text-text-secondary">{mentee.phone}</p>
-                )}
-              </div>
-              <div className="pt-3 border-t border-border space-y-1">
-                {mentee.targetSchoolGa && (
-                  <p className="text-xs text-text-secondary">
-                    <span className="font-medium text-text-primary">가군</span> {mentee.targetSchoolGa}
-                  </p>
-                )}
-                {mentee.targetSchoolNa && (
-                  <p className="text-xs text-text-secondary">
-                    <span className="font-medium text-text-primary">나군</span> {mentee.targetSchoolNa}
-                  </p>
-                )}
-              </div>
-              {mentee.desiredMentor && (
-                <p className="text-xs text-text-secondary italic border-t border-border pt-3">
-                  &quot;{mentee.desiredMentor}&quot;
-                </p>
-              )}
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
-  );
+  return <MentorDashboardClient status={status} cycle={cycle} />;
 }

--- a/apps/web/src/app/mentor/mentees/[matchId]/MenteeDetailClient.tsx
+++ b/apps/web/src/app/mentor/mentees/[matchId]/MenteeDetailClient.tsx
@@ -1,0 +1,457 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import type { MenteeDetailResponse } from '@/lib/api';
+import LeetCard from '@/components/quantitative/LeetCard';
+import GpaCard from '@/components/quantitative/GpaCard';
+import LanguageCard from '@/components/quantitative/LanguageCard';
+
+const GENDER_LABEL: Record<string, string> = {
+  male: '남성', female: '여성', other: '기타',
+};
+const MILITARY_LABEL: Record<string, string> = {
+  completed: '군필', not_completed: '미필', not_applicable: '해당없음',
+};
+const ACADEMIC_LABEL: Record<string, string> = {
+  enrolled: '재학', on_leave: '휴학', graduated: '졸업', completed: '수료', expelled: '제적',
+};
+
+type TabKey = 'basic' | 'quantitative' | 'qualitative' | 'statement' | 'requests';
+
+const TABS: Array<{ key: TabKey; label: string }> = [
+  { key: 'basic', label: '기본정보' },
+  { key: 'quantitative', label: '정량데이터' },
+  { key: 'qualitative', label: '정성데이터' },
+  { key: 'statement', label: '자기소개서' },
+  { key: 'requests', label: '요청사항' },
+];
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '-';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '-';
+  return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, '0')}.${String(d.getDate()).padStart(2, '0')}.`;
+}
+
+// ------------------- 기본정보 탭 -------------------
+
+function FieldRow({
+  rows,
+}: {
+  rows: Array<Array<{ label: string; value: string | number | null | undefined }>>;
+}) {
+  return (
+    <div className="px-4 sm:px-8 py-2">
+      {rows.map((row, rowIdx) => (
+        <div
+          key={rowIdx}
+          className={`grid grid-cols-1 sm:grid-cols-2 sm:divide-x divide-border py-5 ${
+            rowIdx < rows.length - 1 ? 'border-b border-border' : ''
+          }`}
+        >
+          {row.map((item, colIdx) => {
+            const display =
+              item.value === null || item.value === undefined || item.value === ''
+                ? '-'
+                : String(item.value);
+            return (
+              <div
+                key={item.label}
+                className={`flex flex-col gap-2${colIdx === 1 ? ' sm:pl-8 pt-4 sm:pt-0' : ''}`}
+              >
+                <span className="text-sm text-text-secondary shrink-0">{item.label}</span>
+                <div className="h-6">
+                  <span className="text-base text-text-primary">{display}</span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function BasicTab({ data }: { data: MenteeDetailResponse }) {
+  const { user, admission } = data;
+
+  const personalRows = [
+    [
+      { label: '생년월일', value: formatDate(user.birthDate) },
+      { label: '성별', value: user.gender ? GENDER_LABEL[user.gender] : null },
+    ],
+    [
+      { label: '제1전공', value: user.firstMajor },
+      { label: '제2전공', value: user.secondMajor },
+    ],
+    [
+      { label: '입학년도', value: user.entryYear },
+      { label: '병역여부', value: user.militaryStatus ? MILITARY_LABEL[user.militaryStatus] : null },
+    ],
+    [
+      { label: '학적상태', value: user.academicStatus ? ACADEMIC_LABEL[user.academicStatus] : null },
+      { label: '졸업년도', value: user.graduationYear },
+    ],
+    [
+      { label: '이메일', value: user.email },
+      { label: '연락처', value: user.phone },
+    ],
+  ];
+
+  const renderAdmissionRow = (group: '가' | '나') => {
+    const school = group === '가' ? admission.targetSchoolGa : admission.targetSchoolNa;
+    const isSpecial = group === '가' ? admission.isSpecialGa : admission.isSpecialNa;
+    const isPreferred = admission.preferredGroup === group;
+    return (
+      <div
+        key={group}
+        className={`${group === '나' ? 'sm:pl-8' : 'sm:pr-8'} rounded-lg transition-colors ${
+          isPreferred ? 'bg-brand-light' : ''
+        }`}
+      >
+        <div className="flex items-center gap-3 mb-5">
+          <span className="inline-block text-sm font-semibold text-brand bg-brand-light px-3 py-1 rounded">
+            {group}군
+          </span>
+          {isPreferred && <span className="text-xs font-medium text-brand">1순위</span>}
+        </div>
+        <table className="w-full text-sm">
+          <tbody>
+            <tr>
+              <td className="py-2 pr-4 text-text-secondary w-20">학교</td>
+              <td className="py-2 text-text-primary">{school || '-'}</td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 text-text-secondary">전형</td>
+              <td className="py-2 text-text-primary">
+                {school ? (isSpecial ? '특별전형' : '일반전형') : '-'}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    );
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* 프로필 카드 */}
+      <div className="bg-white rounded-xl border border-border shadow-sm">
+        <div className="flex items-center justify-between px-4 sm:px-8 py-6 bg-brand-light border-b border-border rounded-t-xl">
+          <div className="flex items-center gap-4">
+            <div className="w-14 h-14 rounded-full bg-brand-muted flex items-center justify-center text-brand">
+              <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                <circle cx="12" cy="7" r="4" />
+              </svg>
+            </div>
+            <div>
+              <p className="text-xl font-bold text-text-primary">{user.name}</p>
+              <p className="text-sm text-text-secondary mt-0.5">{user.undergradSchool || '-'}</p>
+            </div>
+          </div>
+        </div>
+        <FieldRow rows={personalRows} />
+      </div>
+
+      {/* 희망 학교 카드 */}
+      <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
+        <h2 className="text-base font-semibold text-text-primary mb-6">희망 로스쿨</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 sm:divide-x divide-border gap-y-4 sm:gap-y-0">
+          {renderAdmissionRow('가')}
+          {renderAdmissionRow('나')}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ------------------- 정량 탭 -------------------
+
+function QuantitativeTab({ data }: { data: MenteeDetailResponse }) {
+  const { quantitative } = data;
+  return (
+    <div className="flex flex-col gap-6">
+      <LeetCard
+        initialData={{
+          verbal: quantitative.leet.verbal,
+          reasoning: quantitative.leet.reasoning,
+        }}
+        readOnly
+      />
+      <GpaCard initialData={quantitative.gpa} readOnly />
+      <LanguageCard initialData={quantitative.language} readOnly />
+    </div>
+  );
+}
+
+// ------------------- 정성 탭 -------------------
+
+type Activity = {
+  name?: string;
+  organization?: string;
+  startDate?: string;
+  endDate?: string;
+  ongoing?: boolean;
+  content?: string;
+  category?: string;
+};
+
+function parseActivities(raw: unknown): Activity[] {
+  if (!Array.isArray(raw)) return [];
+  return raw as Activity[];
+}
+
+function QualitativeTab({ data }: { data: MenteeDetailResponse }) {
+  const { qualitative } = data;
+  const activities = parseActivities(qualitative.activities);
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* 진로 목표 + 핵심 키워드 */}
+      <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6 space-y-6">
+        <div>
+          <h2 className="text-base font-semibold text-text-primary mb-3">진로 목표</h2>
+          <p className="text-sm text-text-primary whitespace-pre-wrap">
+            {qualitative.careerGoal || '-'}
+          </p>
+        </div>
+        <div className="border-t border-border pt-6">
+          <h2 className="text-base font-semibold text-text-primary mb-3">핵심 키워드</h2>
+          <p className="text-sm text-text-primary whitespace-pre-wrap">
+            {qualitative.coreKeywords || '-'}
+          </p>
+        </div>
+      </div>
+
+      {/* 활동 카드들 */}
+      <div className="flex flex-col gap-4">
+        <h2 className="text-base font-semibold text-text-primary px-1">
+          활동 <span className="text-text-secondary font-normal">({activities.length})</span>
+        </h2>
+        {activities.length === 0 ? (
+          <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-10 text-center text-sm text-text-secondary">
+            등록된 활동이 없습니다.
+          </div>
+        ) : (
+          activities.map((a, i) => (
+            <div
+              key={i}
+              className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6"
+            >
+              <div className="flex items-start justify-between gap-3 mb-3">
+                <h3 className="text-lg font-semibold text-text-primary">
+                  {a.name || `활동 ${i + 1}`}
+                </h3>
+                {a.category && (
+                  <span className="shrink-0 px-2.5 py-1 text-xs rounded-md bg-blue-50 text-blue-600">
+                    {a.category}
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-4 text-sm text-text-secondary mb-4">
+                <span>{a.organization || '-'}</span>
+                <span className="text-border">|</span>
+                <span>
+                  {a.startDate || '-'} ~ {a.ongoing ? '진행중' : a.endDate || '-'}
+                </span>
+              </div>
+              {a.content && (
+                <p className="text-sm text-text-primary whitespace-pre-wrap leading-relaxed">
+                  {a.content}
+                </p>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ------------------- 자기소개서 탭 -------------------
+
+type TextAnswer = { questionId: string; text: string };
+
+function parseTextAnswers(raw: unknown): TextAnswer[] {
+  if (!Array.isArray(raw)) return [];
+  return raw as TextAnswer[];
+}
+
+function StatementTab({ data }: { data: MenteeDetailResponse }) {
+  const [group, setGroup] = useState<'ga' | 'na'>('ga');
+  const ps = data.personalStatement[group];
+  const school =
+    group === 'ga' ? data.admission.targetSchoolGa : data.admission.targetSchoolNa;
+  const answers = parseTextAnswers(ps.textAnswers);
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* 가/나군 서브탭 */}
+      <div className="flex gap-4 border-b border-border">
+        {(['ga', 'na'] as const).map((g) => {
+          const active = g === group;
+          const sch = g === 'ga' ? data.admission.targetSchoolGa : data.admission.targetSchoolNa;
+          return (
+            <button
+              key={g}
+              onClick={() => setGroup(g)}
+              className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+                active
+                  ? 'border-brand text-brand'
+                  : 'border-transparent text-text-secondary hover:text-text-primary'
+              }`}
+            >
+              {g === 'ga' ? '가군' : '나군'}
+              {sch && <span className="text-text-secondary"> · {sch}</span>}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* 학교 + HWP 상태 카드 */}
+      <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm text-text-secondary mb-1">지원 학교</p>
+            <p className="text-base font-semibold text-text-primary">{school || '미설정'}</p>
+          </div>
+          <div className="text-right">
+            <p className="text-sm text-text-secondary mb-1">HWP 첨부</p>
+            <p className="text-base font-semibold text-text-primary">
+              {ps.hasHwp ? '있음' : '없음'}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* 문항 답변 카드들 */}
+      {answers.length === 0 ? (
+        <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-10 text-center text-sm text-text-secondary">
+          작성된 문항 답변이 없습니다.
+        </div>
+      ) : (
+        answers.map((a, i) => (
+          <div
+            key={`${a.questionId}-${i}`}
+            className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6"
+          >
+            <div className="flex items-center gap-3 mb-4">
+              <span className="w-6 h-6 rounded-full bg-brand text-white text-xs font-semibold flex items-center justify-center">
+                {i + 1}
+              </span>
+              <p className="text-sm font-semibold text-text-primary">문항 {i + 1}</p>
+              <span className="text-xs text-text-secondary ml-auto">
+                {a.text?.length ?? 0}자
+              </span>
+            </div>
+            <p className="text-sm text-text-primary whitespace-pre-wrap leading-relaxed">
+              {a.text || '-'}
+            </p>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+// ------------------- 요청사항 탭 -------------------
+
+function RequestsTab({ data }: { data: MenteeDetailResponse }) {
+  const { requests } = data;
+  const items = [
+    { label: '강점·약점', value: requests.strengthsWeaknesses },
+    { label: '원하는 멘토상', value: requests.desiredMentor },
+    { label: '특이사항', value: requests.specialNotes },
+  ];
+
+  return (
+    <div className="flex flex-col gap-4">
+      {items.map((item) => (
+        <div
+          key={item.label}
+          className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6"
+        >
+          <h2 className="text-base font-semibold text-text-primary mb-3">{item.label}</h2>
+          <p className="text-sm text-text-primary whitespace-pre-wrap leading-relaxed">
+            {item.value || '-'}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ------------------- 페이지 -------------------
+
+type Props = {
+  data: MenteeDetailResponse | null;
+};
+
+export default function MenteeDetailClient({ data }: Props) {
+  const [activeTab, setActiveTab] = useState<TabKey>('basic');
+
+  if (!data) {
+    return (
+      <div className="flex flex-col gap-8 page-container w-full">
+        <Link href="/mentor/dashboard" className="text-sm text-brand hover:underline">
+          ← 멘토 대시보드
+        </Link>
+        <div className="bg-white border border-border rounded-xl shadow-sm p-5 text-sm text-red-600">
+          데이터를 불러올 수 없습니다.
+        </div>
+      </div>
+    );
+  }
+
+  const renderTab = () => {
+    switch (activeTab) {
+      case 'basic': return <BasicTab data={data} />;
+      case 'quantitative': return <QuantitativeTab data={data} />;
+      case 'qualitative': return <QualitativeTab data={data} />;
+      case 'statement': return <StatementTab data={data} />;
+      case 'requests': return <RequestsTab data={data} />;
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-6 page-container w-full">
+      <Link href="/mentor/dashboard" className="text-sm text-brand hover:underline">
+        ← 멘토 대시보드
+      </Link>
+
+      <div>
+        <h1 className="text-2xl font-bold text-text-primary">
+          멘티 {data.user.name}의 정보
+        </h1>
+        <p className="mt-1 text-sm text-text-secondary">
+          매칭 멘티가 작성한 데이터를 읽기 전용으로 열람합니다.
+        </p>
+      </div>
+
+      {/* 메인 탭 네비게이션 */}
+      <div className="flex gap-6 border-b border-border">
+        {TABS.map((tab) => {
+          const active = tab.key === activeTab;
+          return (
+            <button
+              key={tab.key}
+              onClick={() => setActiveTab(tab.key)}
+              className={`pb-3 text-sm transition-colors border-b-2 -mb-px ${
+                active
+                  ? 'border-brand text-brand font-semibold'
+                  : 'border-transparent text-text-secondary hover:text-text-primary'
+              }`}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* 탭 컨텐츠 */}
+      <div>{renderTab()}</div>
+    </div>
+  );
+}

--- a/apps/web/src/app/mentor/mentees/[matchId]/page.tsx
+++ b/apps/web/src/app/mentor/mentees/[matchId]/page.tsx
@@ -1,0 +1,19 @@
+import { cookies } from 'next/headers';
+import MenteeDetailClient from './MenteeDetailClient';
+import { serverFetch } from '@/lib/server-fetch';
+import type { MenteeDetailResponse } from '@/lib/api';
+
+export default async function MenteeDetailPage({
+  params,
+}: {
+  params: Promise<{ matchId: string }>;
+}) {
+  const { matchId } = await params;
+  const token = (await cookies()).get('plawcess_token')?.value ?? '';
+  const data = await serverFetch<MenteeDetailResponse>(
+    `/api/mentor/mentees/${encodeURIComponent(matchId)}`,
+    token,
+  );
+
+  return <MenteeDetailClient data={data} />;
+}

--- a/apps/web/src/app/mentor/mentees/layout.tsx
+++ b/apps/web/src/app/mentor/mentees/layout.tsx
@@ -1,0 +1,24 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import DashboardShell from '@/components/layout/DashboardShell';
+import { getAuthUser, serverFetch, getRoleHomePath } from '@/lib/server-fetch';
+
+const COOKIE_NAME = 'plawcess_token';
+
+export default async function MentorMenteesLayout({ children }: { children: React.ReactNode }) {
+  const token = (await cookies()).get(COOKIE_NAME)?.value;
+  if (!token) redirect('/login');
+
+  const [initialUser, reminderStatus] = await Promise.all([
+    getAuthUser(token),
+    serverFetch<{ showReminder: boolean }>('/api/auth/password-reminder-status', token),
+  ]);
+  if (!initialUser) redirect('/login');
+  if (initialUser.current_role !== 'mentor' && initialUser.current_role !== 'admin') redirect(getRoleHomePath(initialUser.current_role));
+
+  return (
+    <DashboardShell initialUser={initialUser} showPasswordReminder={reminderStatus?.showReminder ?? false}>
+      {children}
+    </DashboardShell>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -8,7 +8,8 @@ import Footer from '@/components/layout/Footer';
 
 function getStartHref(user: AuthUser | null): string {
   if (!user) return '/login';
-  if (user.current_role === 'admin') return '/admin/dashboard';
+  if (user.current_role === 'admin') return '/admin/schedule';
+  if (user.current_role === 'mentor') return '/mentor/dashboard';
   return `/${user.current_role}/dashboard/basic-info`;
 }
 

--- a/apps/web/src/components/landing/LandingNavbar.tsx
+++ b/apps/web/src/components/landing/LandingNavbar.tsx
@@ -65,12 +65,7 @@ export default function LandingNavbar({ initialUser }: Props) {
     router.push('/');
   }
 
-  const allNavItems = [
-    ...NAV_ITEMS,
-    { href: '/mentee/dashboard', label: '멘티' },
-    { href: '/mentor/dashboard', label: '멘토' },
-    { href: '/admin/users', label: '어드민' },
-  ];
+  const allNavItems = NAV_ITEMS;
 
   return (
     <header className="sticky top-0 z-50 bg-white border-b border-border shrink-0" ref={menuRef}>
@@ -97,11 +92,6 @@ export default function LandingNavbar({ initialUser }: Props) {
               {label}
             </Link>
           ))}
-          <>
-            <Link href="/mentee/dashboard" className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors">멘티</Link>
-            <Link href="/mentor/dashboard" className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors">멘토</Link>
-            <Link href="/admin/users" className="text-sm font-medium text-text-secondary hover:text-text-primary transition-colors">어드민</Link>
-          </>
         </nav>
 
         {/* Right: Action buttons + mobile hamburger */}

--- a/apps/web/src/components/landing/LandingNavbarInner.tsx
+++ b/apps/web/src/components/landing/LandingNavbarInner.tsx
@@ -11,9 +11,6 @@ const NAV_ITEMS = [
   { href: '/guide', label: '이용 가이드' },
   { href: '/faq', label: 'FAQ' },
   { href: '/announcements', label: '공지사항' },
-  { href: '/mentee/dashboard', label: '멘티' },
-  { href: '/mentor/dashboard', label: '멘토' },
-  { href: '/admin/users', label: '어드민' },
 ];
 
 export default function LandingNavbarInner({ initialUser }: { initialUser: AuthUser | null }) {

--- a/apps/web/src/components/landing/LandingNavbarMobile.tsx
+++ b/apps/web/src/components/landing/LandingNavbarMobile.tsx
@@ -10,9 +10,6 @@ const NAV_ITEMS = [
   { href: '/guide', label: '이용 가이드' },
   { href: '/faq', label: 'FAQ' },
   { href: '/announcements', label: '공지사항' },
-  { href: '/mentee/dashboard', label: '멘티' },
-  { href: '/mentor/dashboard', label: '멘토' },
-  { href: '/admin/users', label: '어드민' },
 ];
 
 export default function LandingNavbarMobile({ user }: { user: AuthUser | null }) {

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import { clearUser, type AuthUser } from '@/lib/api';
 
-type NavItem = { label: string; href: string; match?: string; exact?: boolean; dividerBefore?: boolean };
+type NavItem = { label: string; href: string; match?: string; matchAny?: string[]; exact?: boolean; dividerBefore?: boolean };
 type NavSection = { section: string; items: NavItem[] };
 type NavConfig = NavItem[] | NavSection[];
 
@@ -25,7 +25,7 @@ const menteeNavItems: NavItem[] = [
 ];
 
 const mentorNavItems: NavItem[] = [
-  { label: '프로세스 대시보드', href: '/mentor/dashboard', exact: true },
+  { label: '멘토 대시보드', href: '/mentor/dashboard', exact: true, matchAny: ['/mentor/mentees'] },
   { label: '기본정보', href: '/mentor/dashboard/basic-info' },
   { label: '정량 데이터', href: '/mentor/dashboard/quantitative' },
   { label: '정성 데이터', href: '/mentor/dashboard/qualitative' },
@@ -72,9 +72,13 @@ interface SidebarProps {
 
 function NavLink({ item, pathname, onClose }: { item: NavItem; pathname: string; onClose?: () => void }) {
   const matchPath = item.match ?? item.href;
-  const isActive = item.exact
+  const baseActive = item.exact
     ? pathname === matchPath
     : pathname === matchPath || pathname.startsWith(matchPath + '/');
+  const extraActive = (item.matchAny ?? []).some(
+    (p) => pathname === p || pathname.startsWith(p + '/'),
+  );
+  const isActive = baseActive || extraActive;
   return (
     <Link
       href={item.href}
@@ -103,7 +107,16 @@ export default function Sidebar({ mobileOpen, onClose, initialRole, initialUser,
 
   const isAdmin = pathname.startsWith('/admin') || initialRole === 'admin';
   const isMentor = pathname.startsWith('/mentor') || initialRole === 'mentor';
-  const config: NavConfig = isAdmin ? adminNavSections : isMentor ? mentorNavItems : menteeNavItems;
+  const rawConfig: NavConfig = isAdmin ? adminNavSections : isMentor ? mentorNavItems : menteeNavItems;
+
+  // admin 계정이 본인 영역(/admin/*) 이외의 페이지를 볼 때 '설정' 항목을 숨긴다.
+  // /settings 진입 시 settings/layout 이 role=admin 으로 사이드바를 강제 전환해 UI가 깨지기 때문.
+  const userIsAdmin = initialUser?.current_role === 'admin' || initialRole === 'admin';
+  const hideSettings = userIsAdmin && !pathname.startsWith('/admin');
+  const shouldKeep = (item: NavItem) => !(hideSettings && item.href === '/settings');
+  const config: NavConfig = isSections(rawConfig)
+    ? rawConfig.map((s) => ({ ...s, items: s.items.filter(shouldKeep) }))
+    : rawConfig.filter(shouldKeep);
 
   const navContent = (
     <nav className="flex flex-col gap-1 px-2 pb-2">

--- a/apps/web/src/components/layout/UserMenu.tsx
+++ b/apps/web/src/components/layout/UserMenu.tsx
@@ -37,8 +37,10 @@ export default function UserMenu({ user, onLogout }: Props) {
   const roleLabel = ROLE_LABEL[user.current_role] ?? user.current_role;
   const profileHref =
     user.current_role === 'admin'
-      ? '/admin/dashboard'
-      : `/${user.current_role}/dashboard/basic-info`;
+      ? '/admin/schedule'
+      : user.current_role === 'mentor'
+        ? '/mentor/dashboard'
+        : `/${user.current_role}/dashboard/basic-info`;
 
   return (
     <div ref={ref} className="relative">
@@ -93,8 +95,36 @@ export default function UserMenu({ user, onLogout }: Props) {
               <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
               <circle cx="12" cy="7" r="4" />
             </svg>
-            내 대시보드
+            {user.current_role === 'admin' ? '관리자 대시보드' : '내 대시보드'}
           </Link>
+          {user.current_role === 'admin' && (
+            <>
+              <Link
+                href="/mentee/dashboard/basic-info"
+                onClick={() => setOpen(false)}
+                role="menuitem"
+                className="flex items-center gap-2.5 px-4 py-2.5 text-sm text-text-primary hover:bg-gray-50 transition-colors"
+              >
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-text-secondary">
+                  <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                  <circle cx="12" cy="7" r="4" />
+                </svg>
+                멘티 대시보드
+              </Link>
+              <Link
+                href="/mentor/dashboard"
+                onClick={() => setOpen(false)}
+                role="menuitem"
+                className="flex items-center gap-2.5 px-4 py-2.5 text-sm text-text-primary hover:bg-gray-50 transition-colors"
+              >
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-text-secondary">
+                  <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                  <circle cx="12" cy="7" r="4" />
+                </svg>
+                멘토 대시보드
+              </Link>
+            </>
+          )}
           {(user.current_role === 'mentee' || user.current_role === 'mentor') && (
             <Link
               href={`/${user.current_role}/history`}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -934,3 +934,117 @@ export async function updateSchoolQuestions(
   );
   await jsonOrError(res, "문항 저장 실패");
 }
+
+// ----------------------------------------------------------------
+// Mentor Process Dashboard (#232)
+// ----------------------------------------------------------------
+
+export type ProcessStatus = "inactive" | "waiting" | "active";
+
+export type MatchedMentee = {
+  matchId: string;
+  name: string;
+  targetSchoolGa: string | null;
+  admissionTypeGa: string | null;
+  targetSchoolNa: string | null;
+  admissionTypeNa: string | null;
+  personalStatementStatus: "not_submitted";
+};
+
+export type MentorProcessStatus = {
+  status: ProcessStatus;
+  processYear: number | null;
+  matchAnnounceDate: string | null;
+  matchedMentees: MatchedMentee[] | null;
+};
+
+export type HistoryMentee = {
+  matchId: string;
+  name: string;
+  targetSchoolGa: string | null;
+  admissionTypeGa: string | null;
+  targetSchoolNa: string | null;
+  admissionTypeNa: string | null;
+  phone: string | null;
+};
+
+export type MentorHistory = {
+  history: Array<{
+    processYear: number;
+    mentees: HistoryMentee[];
+  }>;
+};
+
+export async function getMentorProcessStatus(): Promise<MentorProcessStatus> {
+  const res = await fetch(`${API_BASE}/api/mentor/process-status`, {
+    headers: headers(),
+    credentials: "include",
+  });
+  return jsonOrError(res, "프로세스 상태 조회 실패");
+}
+
+export async function getMentorHistory(): Promise<MentorHistory> {
+  const res = await fetch(`${API_BASE}/api/mentor/history`, {
+    headers: headers(),
+    credentials: "include",
+  });
+  return jsonOrError(res, "참여 이력 조회 실패");
+}
+
+export type MenteeDetailResponse = {
+  matchId: string;
+  user: {
+    name: string;
+    email: string;
+    phone: string | null;
+    birthDate: string | null;
+    gender: "male" | "female" | "other" | null;
+    militaryStatus: "completed" | "not_completed" | "not_applicable" | null;
+    studentId: string | null;
+    undergradSchool: string | null;
+    firstMajor: string | null;
+    secondMajor: string | null;
+    entryYear: number | null;
+    graduationYear: number | null;
+    academicStatus: "enrolled" | "on_leave" | "graduated" | "completed" | "expelled" | null;
+  };
+  admission: {
+    targetSchoolGa: string | null;
+    isSpecialGa: boolean;
+    targetSchoolNa: string | null;
+    isSpecialNa: boolean;
+    preferredGroup: string | null;
+  };
+  quantitative: {
+    leet: {
+      total: number | null;
+      verbal: { raw: number | null; standard: number | null; percentile: number | null };
+      reasoning: { raw: number | null; standard: number | null; percentile: number | null };
+    };
+    gpa: { overall: number | null; major: number | null; converted: number | null };
+    language: { toeic: number | null; toefl: number | null; teps: number | null };
+  };
+  qualitative: {
+    careerGoal: string | null;
+    coreKeywords: string | null;
+    activities: unknown;
+  };
+  personalStatement: {
+    ga: { hasHwp: boolean; textAnswers: unknown };
+    na: { hasHwp: boolean; textAnswers: unknown };
+  };
+  requests: {
+    strengthsWeaknesses: string | null;
+    desiredMentor: string | null;
+    specialNotes: string | null;
+    extraRequest: string | null;
+  };
+};
+
+export async function getMatchedMenteeDetail(matchId: string): Promise<MenteeDetailResponse> {
+  const res = await fetch(`${API_BASE}/api/mentor/mentees/${encodeURIComponent(matchId)}`, {
+    headers: headers(),
+    credentials: "include",
+  });
+  return jsonOrError(res, "멘티 정보 조회 실패");
+}

--- a/apps/web/src/lib/server-fetch.ts
+++ b/apps/web/src/lib/server-fetch.ts
@@ -2,8 +2,9 @@ import type { AuthUser } from '@/lib/api';
 import { decodeSessionToken } from '@/lib/jwt';
 
 export function getRoleHomePath(role: string): string {
-  if (role === 'admin') return '/admin/dashboard';
-  if (role === 'mentee' || role === 'mentor') return `/${role}/dashboard/basic-info`;
+  if (role === 'admin') return '/admin/schedule';
+  if (role === 'mentor') return '/mentor/dashboard';
+  if (role === 'mentee') return '/mentee/dashboard/basic-info';
   return '/login';
 }
 

--- a/tools/seed-mentor-test.sql
+++ b/tools/seed-mentor-test.sql
@@ -1,0 +1,195 @@
+-- ============================================================
+-- 멘토 프로세스 대시보드 (#232) 테스트 시드
+-- ============================================================
+-- 시나리오:
+--   - 활성 사이클 2026 (match_announce_date 어제 → status = active)
+--   - 과거 사이클 2025 (비활성, 이전 참여 이력용)
+--   - 멘토 1명 (login_id: test.mentor / password: test1234)
+--   - 2026 매칭 멘티 2명 (대시보드 "매칭 멘티" 섹션)
+--   - 2025 매칭 멘티 2명 (대시보드 "이전 참여 이력" 섹션)
+--
+-- 모두 ON CONFLICT 로 idempotent — 반복 실행 가능.
+-- Prisma @updatedAt 은 ORM 레벨이라 raw SQL 에서는 NOW() 명시 필요.
+-- ============================================================
+
+BEGIN;
+
+-- ----------------------------------------------------------------
+-- 1. CycleSchedule
+-- ----------------------------------------------------------------
+INSERT INTO cycle_schedules (
+  process_year, is_active, is_schedule_visible,
+  match_announce_date,
+  created_at, updated_at
+) VALUES
+  (2026, TRUE,  TRUE, CURRENT_DATE - INTERVAL '1 day', NOW(), NOW()),
+  (2025, FALSE, TRUE, DATE '2025-09-01',               NOW(), NOW())
+ON CONFLICT (process_year) DO UPDATE SET
+  is_active           = EXCLUDED.is_active,
+  is_schedule_visible = EXCLUDED.is_schedule_visible,
+  match_announce_date = EXCLUDED.match_announce_date,
+  updated_at          = NOW();
+
+-- ----------------------------------------------------------------
+-- 2. Users
+-- ----------------------------------------------------------------
+-- 비밀번호 hash 는 모두 "test1234" (bcrypt cost 12)
+INSERT INTO users (
+  user_id, login_id, name, email, phone, password_hash,
+  account_status, "current_role", is_deleted,
+  created_at, updated_at
+) VALUES
+  -- 멘토
+  ('11111111-1111-1111-1111-111111111111', 'test.mentor',  '테스트멘토',   'mentor@test.local', '010-0000-0001',
+   '$2b$12$QbLU3aTQcTKKi0fqCrA6LOOry5VD4zoHH.5Me6Ys.Jmnj0vCc0kqm',
+   'active', 'mentor', FALSE, NOW(), NOW()),
+  -- 2026 매칭 멘티
+  ('22222222-2222-2222-2222-222222222222', 'test.mentee.1', '김자전', 'mentee1@test.local', '010-1111-1111',
+   '$2b$12$QbLU3aTQcTKKi0fqCrA6LOOry5VD4zoHH.5Me6Ys.Jmnj0vCc0kqm',
+   'active', 'mentee', FALSE, NOW(), NOW()),
+  ('33333333-3333-3333-3333-333333333333', 'test.mentee.2', '이지원', 'mentee2@test.local', '010-2222-2222',
+   '$2b$12$QbLU3aTQcTKKi0fqCrA6LOOry5VD4zoHH.5Me6Ys.Jmnj0vCc0kqm',
+   'active', 'mentee', FALSE, NOW(), NOW()),
+  -- 2025 과거 매칭 멘티
+  ('44444444-4444-4444-4444-444444444444', 'test.mentee.3', '박합격', 'mentee3@test.local', '010-3333-3333',
+   '$2b$12$QbLU3aTQcTKKi0fqCrA6LOOry5VD4zoHH.5Me6Ys.Jmnj0vCc0kqm',
+   'active', 'mentee', FALSE, NOW(), NOW()),
+  ('55555555-5555-5555-5555-555555555555', 'test.mentee.4', '최재학', 'mentee4@test.local', '010-4444-4444',
+   '$2b$12$QbLU3aTQcTKKi0fqCrA6LOOry5VD4zoHH.5Me6Ys.Jmnj0vCc0kqm',
+   'active', 'mentee', FALSE, NOW(), NOW())
+ON CONFLICT (user_id) DO UPDATE SET
+  login_id        = EXCLUDED.login_id,
+  name            = EXCLUDED.name,
+  email           = EXCLUDED.email,
+  phone           = EXCLUDED.phone,
+  password_hash   = EXCLUDED.password_hash,
+  "current_role"  = EXCLUDED."current_role",
+  is_deleted      = FALSE,
+  updated_at      = NOW();
+
+-- ----------------------------------------------------------------
+-- 3. MentorRecord — 2025, 2026
+-- ----------------------------------------------------------------
+INSERT INTO mentor_records (
+  record_id, user_id, process_year, record_status,
+  lawschool_name, lawschool_grade,
+  created_at, updated_at
+) VALUES
+  ('a1111111-1111-1111-1111-111111111111', '11111111-1111-1111-1111-111111111111', 2026,
+   'submitted', '고려대학교 법학전문대학원', 17, NOW(), NOW()),
+  ('a1111111-1111-1111-1111-111111111112', '11111111-1111-1111-1111-111111111111', 2025,
+   'submitted', '고려대학교 법학전문대학원', 16, NOW() - INTERVAL '1 year', NOW() - INTERVAL '1 year')
+ON CONFLICT (user_id, process_year) DO UPDATE SET
+  record_status   = EXCLUDED.record_status,
+  lawschool_name  = EXCLUDED.lawschool_name,
+  lawschool_grade = EXCLUDED.lawschool_grade,
+  updated_at      = NOW();
+
+-- ----------------------------------------------------------------
+-- 4. MenteeRecord — 2026 (현재 매칭), 2025 (과거 이력)
+-- ----------------------------------------------------------------
+INSERT INTO mentee_records (
+  record_id, user_id, process_year, record_status,
+  target_school_ga, is_special_ga,
+  target_school_na, is_special_na,
+  created_at, updated_at
+) VALUES
+  -- 2026 현재
+  ('b2222222-2222-2222-2222-222222222222', '22222222-2222-2222-2222-222222222222', 2026,
+   'submitted', '고려대학교', FALSE, '연세대학교', FALSE, NOW(), NOW()),
+  ('b3333333-3333-3333-3333-333333333333', '33333333-3333-3333-3333-333333333333', 2026,
+   'submitted', '서울대학교', TRUE,  NULL,           FALSE, NOW(), NOW()),
+  -- 2025 과거
+  ('b4444444-4444-4444-4444-444444444444', '44444444-4444-4444-4444-444444444444', 2025,
+   'submitted', '고려대학교', FALSE, '연세대학교',   TRUE,
+   NOW() - INTERVAL '1 year', NOW() - INTERVAL '1 year'),
+  ('b5555555-5555-5555-5555-555555555555', '55555555-5555-5555-5555-555555555555', 2025,
+   'submitted', '한양대학교', FALSE, '이화여자대학교', FALSE,
+   NOW() - INTERVAL '1 year', NOW() - INTERVAL '1 year')
+ON CONFLICT (user_id, process_year) DO UPDATE SET
+  record_status    = EXCLUDED.record_status,
+  target_school_ga = EXCLUDED.target_school_ga,
+  is_special_ga    = EXCLUDED.is_special_ga,
+  target_school_na = EXCLUDED.target_school_na,
+  is_special_na    = EXCLUDED.is_special_na,
+  updated_at       = NOW();
+
+-- ----------------------------------------------------------------
+-- 5. Application — 멘토 2개 (2025/2026), 멘티 4개
+-- ----------------------------------------------------------------
+INSERT INTO applications (
+  application_id, user_id, process_year, role, application_status,
+  mentee_record_id, mentor_record_id, submitted_at, approved_at,
+  created_at, updated_at
+) VALUES
+  -- 멘토 본인 applications
+  ('c1111111-1111-1111-1111-111111111126', '11111111-1111-1111-1111-111111111111', 2026,
+   'mentor', 'approved', NULL, 'a1111111-1111-1111-1111-111111111111',
+   NOW(), NOW(), NOW(), NOW()),
+  ('c1111111-1111-1111-1111-111111111125', '11111111-1111-1111-1111-111111111111', 2025,
+   'mentor', 'approved', NULL, 'a1111111-1111-1111-1111-111111111112',
+   NOW() - INTERVAL '1 year', NOW() - INTERVAL '1 year',
+   NOW() - INTERVAL '1 year', NOW() - INTERVAL '1 year'),
+  -- 2026 멘티 applications
+  ('c2222222-2222-2222-2222-222222222226', '22222222-2222-2222-2222-222222222222', 2026,
+   'mentee', 'approved', 'b2222222-2222-2222-2222-222222222222', NULL,
+   NOW(), NOW(), NOW(), NOW()),
+  ('c3333333-3333-3333-3333-333333333326', '33333333-3333-3333-3333-333333333333', 2026,
+   'mentee', 'approved', 'b3333333-3333-3333-3333-333333333333', NULL,
+   NOW(), NOW(), NOW(), NOW()),
+  -- 2025 멘티 applications
+  ('c4444444-4444-4444-4444-444444444425', '44444444-4444-4444-4444-444444444444', 2025,
+   'mentee', 'approved', 'b4444444-4444-4444-4444-444444444444', NULL,
+   NOW() - INTERVAL '1 year', NOW() - INTERVAL '1 year',
+   NOW() - INTERVAL '1 year', NOW() - INTERVAL '1 year'),
+  ('c5555555-5555-5555-5555-555555555525', '55555555-5555-5555-5555-555555555555', 2025,
+   'mentee', 'approved', 'b5555555-5555-5555-5555-555555555555', NULL,
+   NOW() - INTERVAL '1 year', NOW() - INTERVAL '1 year',
+   NOW() - INTERVAL '1 year', NOW() - INTERVAL '1 year')
+ON CONFLICT (user_id, process_year, role) DO UPDATE SET
+  application_status = EXCLUDED.application_status,
+  mentee_record_id   = EXCLUDED.mentee_record_id,
+  mentor_record_id   = EXCLUDED.mentor_record_id,
+  submitted_at       = EXCLUDED.submitted_at,
+  approved_at        = EXCLUDED.approved_at,
+  updated_at         = NOW();
+
+-- ----------------------------------------------------------------
+-- 6. MatchResult — 2026 매칭 2건, 2025 매칭 2건 (모두 finalized)
+-- ----------------------------------------------------------------
+-- 멱등 보장을 위해 테스트 멘토의 모든 매칭을 먼저 삭제 후 재삽입
+DELETE FROM match_results
+WHERE mentor_application_id IN (
+  'c1111111-1111-1111-1111-111111111126',
+  'c1111111-1111-1111-1111-111111111125'
+);
+
+INSERT INTO match_results (
+  match_id, process_year, mentee_application_id, mentor_application_id,
+  match_status, is_finalized,
+  created_at, updated_at
+) VALUES
+  -- 2026
+  ('d2222222-2222-2222-2222-222222222226', 2026,
+   'c2222222-2222-2222-2222-222222222226', 'c1111111-1111-1111-1111-111111111126',
+   'finalized', TRUE, NOW(), NOW()),
+  ('d3333333-3333-3333-3333-333333333326', 2026,
+   'c3333333-3333-3333-3333-333333333326', 'c1111111-1111-1111-1111-111111111126',
+   'finalized', TRUE, NOW(), NOW()),
+  -- 2025
+  ('d4444444-4444-4444-4444-444444444425', 2025,
+   'c4444444-4444-4444-4444-444444444425', 'c1111111-1111-1111-1111-111111111125',
+   'finalized', TRUE,
+   NOW() - INTERVAL '1 year', NOW() - INTERVAL '1 year'),
+  ('d5555555-5555-5555-5555-555555555525', 2025,
+   'c5555555-5555-5555-5555-555555555525', 'c1111111-1111-1111-1111-111111111125',
+   'finalized', TRUE,
+   NOW() - INTERVAL '1 year', NOW() - INTERVAL '1 year');
+
+COMMIT;
+
+-- ============================================================
+-- 로그인 정보
+--   login_id: test.mentor
+--   password: test1234
+-- ============================================================

--- a/tools/toggle-mentor-status.sql
+++ b/tools/toggle-mentor-status.sql
@@ -1,0 +1,24 @@
+-- ============================================================
+-- 멘토 대시보드 상태 전환용 토글 SQL
+-- 한 줄씩 실행하고 브라우저 새로고침으로 확인
+-- ============================================================
+
+-- ① active (운영 중) — 멘토링 운영 중 + 매칭 멘티 2명 + 사이클 일정 카드
+UPDATE cycle_schedules
+SET is_active = TRUE,
+    match_announce_date = CURRENT_DATE - INTERVAL '1 day',
+    updated_at = NOW()
+WHERE process_year = 2026;
+
+-- ② waiting (매칭 대기) — 매칭 대기 중 메시지 + 사이클 일정 카드 (멘티 섹션 없음)
+UPDATE cycle_schedules
+SET is_active = TRUE,
+    match_announce_date = CURRENT_DATE + INTERVAL '30 days',
+    updated_at = NOW()
+WHERE process_year = 2026;
+
+-- ③ inactive (비운영) — 비운영 메시지만 표시 (멘티/일정 모두 숨김)
+UPDATE cycle_schedules
+SET is_active = FALSE,
+    updated_at = NOW()
+WHERE process_year = 2026;


### PR DESCRIPTION
- 멘토 대시보드: 사이클 상태(inactive/waiting/active) 안내, 매칭 멘티 카드, 사이클 일정 카드
- 멘티 상세 read-only 페이지(`/mentor/mentees/[matchId]`): 기본정보/정량/정성/자기소개서/요청사항 탭
- 신규 API: `GET /api/mentor/process-status`, `GET /api/mentor/history`, `GET /api/mentor/mentees/[matchId]`
- SSR 적용: 대시보드 + 멘티 상세 모두 server fetch
- 사이드바: `/mentor/mentees/*` 도 "멘토 대시보드" 메뉴 활성화, admin 계정이 멘티/멘토 페이지 볼 때 "설정" 항목 숨김
- 라우팅 정리: admin 시작/내 대시보드 → `/admin/schedule`, mentor → `/mentor/dashboard`, 로그인 ROLE_REDIRECT 일관화
- 로그인 페이지: dev용 Mentor 빠른 로그인 버튼 추가
- UserMenu: admin 사용자에 "관리자 대시보드" + 하위 "멘티/멘토 대시보드" 빠른 진입
- 랜딩 Navbar: 멘티/멘토/어드민 직접 링크 제거
- 시드 SQL: 멘토 테스트 계정 + 매칭 멘티 + 상태 전환 토글