### PR TITLE
chore(security): JWT_SECRET 미설정 시 fail-fast 검증 추가 (#183)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
         run: pnpm build:web
         env:
           NEXT_PUBLIC_API_URL: http://localhost:3001
+          # apps/web/src/lib/jwt.ts (decodeSessionToken) 가 모듈 로드 시점에
+          # JWT_SECRET 존재를 검증 → 빌드 통과용 더미. apps/api 빌드와 동일 패턴(#183).
+          JWT_SECRET: ci-secret-for-build
 
       - name: Build (api)
         run: pnpm build:api

--- a/apps/api/src/lib/auth-tokens.ts
+++ b/apps/api/src/lib/auth-tokens.ts
@@ -1,6 +1,10 @@
 import jwt from "jsonwebtoken";
 
-const JWT_SECRET = process.env.JWT_SECRET!;
+// JWT_SECRET 미설정 시 모듈 로드 시점에 즉시·명확하게 죽는다(fail fast). auth.ts 와 동일.
+const rawJwtSecret = process.env.JWT_SECRET;
+if (!rawJwtSecret) throw new Error("JWT_SECRET 환경변수가 설정되지 않았습니다.");
+const JWT_SECRET = rawJwtSecret;
+
 const ISSUER = "pLAWcess";
 
 const SIGNUP_VERIFICATION_AUDIENCE = "email-verification:signup";

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -1,7 +1,13 @@
 import jwt from "jsonwebtoken";
 import type { NextRequest } from "next/server";
 
-const JWT_SECRET = process.env.JWT_SECRET!;
+// JWT_SECRET 미설정 시 모듈 로드 시점(서버 부팅 / next build)에 즉시·명확하게 죽는다(fail fast) —
+// non-null assertion(!) 만 쓰면 요청 처리 중 jsonwebtoken 이 맥락 없는 에러를 던져 디버깅이 길어진다.
+// (가드 통과 값으로 재대입 → JWT_SECRET 의 타입이 string 으로 확정돼 아래 hoisted 함수들에서도 안전.)
+const rawJwtSecret = process.env.JWT_SECRET;
+if (!rawJwtSecret) throw new Error("JWT_SECRET 환경변수가 설정되지 않았습니다.");
+const JWT_SECRET = rawJwtSecret;
+
 const COOKIE_NAME = "plawcess_token";
 const EXPIRES_IN = "7d";
 const ISSUER = "pLAWcess";

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,2 +1,5 @@
 NEXT_PUBLIC_API_URL="http://localhost:3001"
 NEXT_PUBLIC_TEMP_USER_ID=""
+
+# apps/api 의 JWT_SECRET 과 동일한 값 — SSR 세션 쿠키 검증(decodeSessionToken)에 사용.
+JWT_SECRET=""

--- a/apps/web/src/lib/jwt.ts
+++ b/apps/web/src/lib/jwt.ts
@@ -1,7 +1,9 @@
 import { jwtVerify } from 'jose';
 import type { AuthUser } from '@/lib/api';
 
-const secret = new TextEncoder().encode(process.env.JWT_SECRET!);
+const rawSecret = process.env.JWT_SECRET;
+if (!rawSecret) throw new Error('JWT_SECRET 환경변수가 설정되지 않았습니다.');
+const secret = new TextEncoder().encode(rawSecret);
 
 export async function decodeSessionToken(token: string): Promise<AuthUser | null> {
   if (!token) return null;


### PR DESCRIPTION
## 무엇을

  `JWT_SECRET` 환경변수를 TypeScript non-null assertion(`!`)으로만 처리하던 것을, **모듈 로드 시점(서버 부팅 / `next build`)에 존재 여부를 검증하고 미설정이면 즉시 명확한 에러로 죽도록(fail fast)** 변경합니다. 

Closes #183 

  ## 왜

  `process.env.JWT_SECRET!` 의 `!` 는 컴파일러 입막음일 뿐 런타임 가드가 아닙니다. 변수가 비어 있으면:
  - 부팅 / `next build` 는 경고 없이 통과 → 문제를 안 알려줌
  - 로그인 시 `jwt.sign(payload, undefined)` → `jsonwebtoken` 이 `secretOrPrivateKey must have a value` 같은 맥락 없는 에러 → 500
  - 인증 페이지 접근 시 `jwt.verify` 가 던짐 → `catch` 가 삼킴 → 멀쩡한 사용자가 이유 없이 401/로그아웃

  → 진짜 원인("`JWT_SECRET` 미설정")이 에러 어디에도 안 드러나 디버깅이 길어집니다. (보안 취약점이 아니라 운영 견고성 / 설정 실수 방어.)      

  ## 변경 내용

  | 파일 | 변경 |
  |---|---|
  | `apps/api/src/lib/auth.ts` | `const JWT_SECRET = process.env.JWT_SECRET!;` → 가드(`if (!rawJwtSecret) throw new Error("JWT_SECRET
  환경변수가 설정되지 않았습니다.")`) 통과 후 `string` 으로 확정 |
  | `apps/api/src/lib/auth-tokens.ts` | 동일 가드 (회원가입 인증 토큰 · 비밀번호 재설정 토큰 서명) |
  | `apps/web/src/lib/jwt.ts` | 동일 가드 (`decodeSessionToken` — SSR 세션 쿠키 검증) |
  | `apps/web/.env.example` | `JWT_SECRET=""` 추가 — apps/web 도 이 변수가 필요한데 `.env.example` 에 누락돼 있었음 |

  > 처음엔 공용 `apps/api/src/lib/env.ts` 모듈로 빼려 했으나, 새 상대 import 를 `apps/api/scripts/verify-jwt-audience.ts`(raw Node, `node     
  --experimental-strip-types`)가 해석 못 하고 `.ts` 확장자는 `next build` 의 tsc 가 막아서(tsconfig `allowImportingTsExtensions` 필요) — 이 작은 변경에 비해 과해서 각 파일 인라인 가드로 확정. 가드를 hoisted `function` 선언에서도 안전하게 쓰려고 "가드 통과 값을 새 const 에 재대입 
  → 타입 `string` 확정" 패턴 사용.

  ## ⚠️ 배포 요구사항

  `apps/web/src/lib/jwt.ts` 가 모듈 최상단에서 `process.env.JWT_SECRET` 를 읽고, 이 모듈은 `server-fetch.ts → decodeSessionToken` 으로 빌드 

  ## 검증

  - `pnpm --filter api build` / `lint` ✅, `pnpm --filter web build` / `lint` ✅ (기존 warning 외 0 errors)
  - `auth.ts` 를 `JWT_SECRET` 없이 로드 → `JWT_SECRET 환경변수가 설정되지 않았습니다.` 로 throw ✅ ; `--env-file=.env` 와 함께 로드 → 정상 resolve, `signToken` 노출 ✅
  - `node --env-file=apps/api/.env --experimental-strip-types apps/api/scripts/verify-jwt-audience.ts` → 7/7 PASS ✅ (JWT audience/issuer 검증 회귀 없음)

  ## 후속 (이번 PR 범위 밖)

  - 최소 길이/강도 검증(예: ≥32바이트) — 별도 이슈. (적용 시 `ci.yml` 의 더미 `ci-secret-for-build` 도 같이 길게 바꿔야 함.)
  - `apps/web` 직접 수정은 이번 한정 예외(#202/#203 헤더 작업과 동일 패턴).