### PR TITLE
feat(security): 비밀번호 복잡도 검증 (회원가입·변경·재설정) (#243)

### DIFF
--- a/apps/api/scripts/verify-password.ts
+++ b/apps/api/scripts/verify-password.ts
@@ -1,0 +1,46 @@
+// 비밀번호 복잡도 검증 standalone — #243.
+// 실행: node --experimental-strip-types apps/api/scripts/verify-password.ts
+//
+// validatePassword 의 규칙별 분기를 12 케이스로 점검.
+
+import { validatePassword } from "../src/lib/password.ts";
+
+type Case = { input: unknown; expect: "ok" | "reject"; label: string };
+
+const cases: Case[] = [
+  { input: "", expect: "reject", label: "빈 문자열 (길이)" },
+  { input: "abc", expect: "reject", label: "3자 (길이)" },
+  { input: "abc1234", expect: "reject", label: "7자, 영+숫 2종이지만 길이 미달" },
+  { input: "a".repeat(65), expect: "reject", label: "65자 (길이 초과)" },
+  { input: "abcdefgh", expect: "reject", label: "8자, 영문만 1종" },
+  { input: "12345678", expect: "reject", label: "8자, 숫자만 1종" },
+  { input: "!@#$%^&*", expect: "reject", label: "8자, 특수만 1종" },
+  { input: "abcd1234", expect: "ok", label: "8자, 영+숫 2종" },
+  { input: "abc!@#$%", expect: "ok", label: "8자, 영+특 2종" },
+  { input: "123!@#$%", expect: "ok", label: "8자, 숫+특 2종" },
+  { input: "Abc1!Xyz", expect: "ok", label: "8자, 영(대·소)+숫+특 3종" },
+  { input: "가나다1234abcd", expect: "reject", label: "한글 포함 (charset)" },
+  { input: "abc1😀xyz1", expect: "reject", label: "이모지 포함 (charset)" },
+  { input: null, expect: "reject", label: "null (형식)" },
+];
+
+let failed = 0;
+for (const c of cases) {
+  const result = validatePassword(c.input);
+  const got: "ok" | "reject" = result.ok ? "ok" : "reject";
+  const pass = got === c.expect;
+  const detail = result.ok ? "" : `  → "${result.reason}"`;
+  console.log(
+    `${pass ? "PASS" : "FAIL"}  ${c.label}  →  expected ${c.expect}, got ${got}${detail}`,
+  );
+  if (!pass) failed++;
+}
+
+console.log("");
+if (failed === 0) {
+  console.log(`All ${cases.length} cases passed.`);
+  process.exit(0);
+} else {
+  console.error(`${failed} of ${cases.length} cases failed.`);
+  process.exit(1);
+}

--- a/apps/api/src/app/api/auth/change-password/route.ts
+++ b/apps/api/src/app/api/auth/change-password/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
 import { prisma } from "@plawcess/database";
 import { requireAuth } from "@/lib/auth-guard";
+import { validatePassword } from "@/lib/password";
 
 export async function POST(req: NextRequest) {
   const auth = requireAuth(req);
@@ -19,8 +20,9 @@ export async function POST(req: NextRequest) {
   if (!currentPassword || !newPassword) {
     return NextResponse.json({ error: "현재 비밀번호와 새 비밀번호를 입력해주세요." }, { status: 400 });
   }
-  if (newPassword.length < 8) {
-    return NextResponse.json({ error: "비밀번호는 8자 이상이어야 합니다." }, { status: 400 });
+  const pwResult = validatePassword(newPassword);
+  if (!pwResult.ok) {
+    return NextResponse.json({ error: pwResult.reason }, { status: 400 });
   }
 
   const user = await prisma.user.findUnique({

--- a/apps/api/src/app/api/auth/reset-password/route.ts
+++ b/apps/api/src/app/api/auth/reset-password/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
 import { prisma } from "@plawcess/database";
 import { verifyResetToken } from "@/lib/auth-tokens";
+import { validatePassword } from "@/lib/password";
 
 export async function POST(req: NextRequest) {
   let body: { resetToken?: string; newPassword?: string };
@@ -15,8 +16,9 @@ export async function POST(req: NextRequest) {
   if (!resetToken || !newPassword) {
     return NextResponse.json({ error: "resetToken·newPassword 가 필요합니다." }, { status: 400 });
   }
-  if (newPassword.length < 8) {
-    return NextResponse.json({ error: "비밀번호는 8자 이상이어야 합니다." }, { status: 400 });
+  const pwResult = validatePassword(newPassword);
+  if (!pwResult.ok) {
+    return NextResponse.json({ error: pwResult.reason }, { status: 400 });
   }
 
   const payload = verifyResetToken(resetToken);

--- a/apps/api/src/app/api/auth/signup/route.ts
+++ b/apps/api/src/app/api/auth/signup/route.ts
@@ -3,6 +3,7 @@ import bcrypt from "bcryptjs";
 import { prisma } from "@plawcess/database";
 import { signToken, makeAuthCookie } from "@/lib/auth";
 import { verifySignupVerificationToken } from "@/lib/auth-tokens";
+import { validatePassword } from "@/lib/password";
 
 const LOGIN_ID_REGEX = /^[a-zA-Z0-9_]{4,30}$/;
 const STUDENT_ID_REGEX = /^[a-zA-Z0-9]{4,20}$/;
@@ -35,8 +36,9 @@ export async function POST(req: NextRequest) {
   if (!STUDENT_ID_REGEX.test(studentId)) {
     return NextResponse.json({ error: "학번은 영문/숫자 4~20자여야 합니다." }, { status: 400 });
   }
-  if (password.length < 8) {
-    return NextResponse.json({ error: "비밀번호는 8자 이상이어야 합니다." }, { status: 400 });
+  const pwResult = validatePassword(password);
+  if (!pwResult.ok) {
+    return NextResponse.json({ error: pwResult.reason }, { status: 400 });
   }
 
   // 이메일 인증 토큰 검증

--- a/apps/api/src/lib/password.ts
+++ b/apps/api/src/lib/password.ts
@@ -1,0 +1,43 @@
+// 비밀번호 복잡도 검증 — 회원가입·비번 변경·비번 재설정 라우트 3곳에서 호출.
+// FE 의 apps/web/src/lib/password.ts 와 로직 동일 — 변경 시 양쪽 모두 수정.
+//
+// 규칙:
+//   - 8자 이상 64자 이하
+//   - ASCII printable 만 (\x20–\x7E)  → bcrypt 72바이트 한계 안쪽 + .length = byte 보장
+//   - 영문(대소 무관) / 숫자 / 특수문자 중 2종 이상
+
+export type PasswordValidationResult =
+  | { ok: true }
+  | { ok: false; reason: string };
+
+export const PASSWORD_MIN_LEN = 8;
+export const PASSWORD_MAX_LEN = 64;
+export const PASSWORD_REQUIRED_CLASSES = 2;
+
+const ASCII_PRINTABLE = /^[\x20-\x7E]+$/;
+
+const CHAR_CLASSES = [
+  /[a-zA-Z]/, // 영문 (대·소 무관 — 한 클래스)
+  /[0-9]/, // 숫자
+  /[^a-zA-Z0-9]/, // 특수문자 (ASCII printable 가드 뒤라 영숫자 외 ASCII printable 만 들어옴)
+];
+
+export function validatePassword(password: unknown): PasswordValidationResult {
+  if (typeof password !== "string") {
+    return { ok: false, reason: "비밀번호 형식이 올바르지 않습니다." };
+  }
+  if (password.length < PASSWORD_MIN_LEN) {
+    return { ok: false, reason: `비밀번호는 ${PASSWORD_MIN_LEN}자 이상이어야 합니다.` };
+  }
+  if (password.length > PASSWORD_MAX_LEN) {
+    return { ok: false, reason: `비밀번호는 ${PASSWORD_MAX_LEN}자 이하여야 합니다.` };
+  }
+  if (!ASCII_PRINTABLE.test(password)) {
+    return { ok: false, reason: "비밀번호는 영문/숫자/특수문자만 사용할 수 있습니다." };
+  }
+  const classCount = CHAR_CLASSES.filter((re) => re.test(password)).length;
+  if (classCount < PASSWORD_REQUIRED_CLASSES) {
+    return { ok: false, reason: "비밀번호는 영문/숫자/특수문자 중 2종 이상을 조합해야 합니다." };
+  }
+  return { ok: true };
+}

--- a/apps/web/src/app/reset-password/page.tsx
+++ b/apps/web/src/app/reset-password/page.tsx
@@ -4,7 +4,9 @@ import { useState, Suspense } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import Footer from '@/components/layout/Footer';
+import PasswordChecklist from '@/components/auth/PasswordChecklist';
 import { readJson } from '@/lib/http';
+import { validatePassword } from '@/lib/password';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? '';
 
@@ -27,12 +29,13 @@ function ResetPasswordForm() {
     e.preventDefault();
     setError('');
 
-    if (password !== confirm) {
-      setError('비밀번호가 일치하지 않습니다.');
+    const pwValid = validatePassword(password);
+    if (!pwValid.ok) {
+      setError(pwValid.reason);
       return;
     }
-    if (password.length < 8) {
-      setError('비밀번호는 8자 이상이어야 합니다.');
+    if (password !== confirm) {
+      setError('비밀번호가 일치하지 않습니다.');
       return;
     }
 
@@ -85,7 +88,7 @@ function ResetPasswordForm() {
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              placeholder="8자 이상 입력"
+              placeholder="새 비밀번호 입력"
               required
               disabled={!resetToken}
               className={`${inputClass} disabled:opacity-50`}
@@ -104,6 +107,7 @@ function ResetPasswordForm() {
               disabled={!resetToken}
               className={`${inputClass} disabled:opacity-50`}
             />
+            <PasswordChecklist password={password} confirm={confirm} className="mt-1" />
           </div>
 
           {error && <p className="text-sm text-red-500">{error}</p>}

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -5,7 +5,9 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
 import Footer from '@/components/layout/Footer';
+import PasswordChecklist from '@/components/auth/PasswordChecklist';
 import { readJson } from '@/lib/http';
+import { validatePassword } from '@/lib/password';
 
 const API_BASE = '';
 const COOLDOWN_SEC = 60;
@@ -179,6 +181,8 @@ export default function SignupPage() {
 
     if (!checkResult?.ok) { setError('아이디 중복확인을 해주세요.'); return; }
     if (emailVerifyState !== 'verified') { setError('이메일 인증을 완료해주세요.'); return; }
+    const pwValid = validatePassword(form.password);
+    if (!pwValid.ok) { setError(pwValid.reason); return; }
     if (form.password !== form.passwordConfirm) { setError('비밀번호가 일치하지 않습니다.'); return; }
     if (!/^\d{4}\.\d{2}\.\d{2}\.$/.test(form.birthDate)) {
       setError('생년월일은 YYYY.MM.DD. 형식으로 입력해주세요.');
@@ -373,7 +377,6 @@ export default function SignupPage() {
                   onChange={(e) => update('password', e.target.value)}
                   placeholder="비밀번호를 입력하세요"
                   required
-                  minLength={8}
                   className={inputClass}
                 />
               </Field>
@@ -389,6 +392,7 @@ export default function SignupPage() {
                   required
                   className={inputClass}
                 />
+                <PasswordChecklist password={form.password} confirm={form.passwordConfirm} className="mt-1" />
               </Field>
 
               {/* 생년월일 */}

--- a/apps/web/src/components/auth/PasswordChecklist.tsx
+++ b/apps/web/src/components/auth/PasswordChecklist.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { getPasswordHints } from '@/lib/password';
+
+type Props = {
+  password: string;
+  confirm?: string; // 제공 시 "비밀번호 일치" 행 추가
+  className?: string;
+};
+
+// 비밀번호 입력 아래에 표시하는 실시간 체크리스트.
+// 미충족 시 회색 ○ + 회색 텍스트, 충족 시 초록 ✓ + 초록 텍스트 — 빨간 ✗ 는 피한다
+// (사용자가 입력 중에 "틀렸다" 는 인상을 받지 않도록).
+export default function PasswordChecklist({ password, confirm, className }: Props) {
+  const hints = getPasswordHints(password);
+  const showMatch = confirm !== undefined;
+  // 비밀번호 일치: 두 필드 모두 1자 이상 + 동일.
+  const matchOk = showMatch && password.length > 0 && password === confirm;
+
+  return (
+    <ul className={`flex flex-col gap-1 text-xs ${className ?? ''}`} aria-live="polite">
+      <Item
+        ok={hints.length.ok}
+        text={`${hints.length.min}~${hints.length.max}자 (현재 ${hints.length.current}자)`}
+      />
+      <Item ok={hints.charset.ok} text="영문/숫자/특수문자만 사용" />
+      <Item
+        ok={hints.classes.ok}
+        text={`영문/숫자/특수문자 중 ${hints.classes.required}종 이상 (현재 ${hints.classes.current}종)`}
+      />
+      {showMatch && <Item ok={matchOk} text="비밀번호 일치" />}
+    </ul>
+  );
+}
+
+function Item({ ok, text }: { ok: boolean; text: string }) {
+  return (
+    <li className={`flex items-center gap-1.5 ${ok ? 'text-green-600' : 'text-text-secondary'}`}>
+      <span aria-hidden="true">{ok ? '✓' : '○'}</span>
+      <span>{text}</span>
+    </li>
+  );
+}

--- a/apps/web/src/components/settings/AccountSettings.tsx
+++ b/apps/web/src/components/settings/AccountSettings.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { saveUser, clearUser, type AuthUser } from '@/lib/api';
+import { validatePassword } from '@/lib/password';
+import PasswordChecklist from '@/components/auth/PasswordChecklist';
 import DeleteAccountModal from './DeleteAccountModal';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? '';
@@ -65,7 +67,8 @@ export default function AccountSettings({ initialUser }: { initialUser: AuthUser
     e.preventDefault();
     setPwError('');
     setPwSuccess(false);
-    if (newPassword.length < 8) { setPwError('새 비밀번호는 8자 이상이어야 합니다.'); return; }
+    const pwValid = validatePassword(newPassword);
+    if (!pwValid.ok) { setPwError(pwValid.reason); return; }
     if (newPassword !== confirmPassword) { setPwError('새 비밀번호가 일치하지 않습니다.'); return; }
     setPwLoading(true);
     try {
@@ -218,11 +221,12 @@ export default function AccountSettings({ initialUser }: { initialUser: AuthUser
               </div>
               <div className="flex flex-col gap-1.5">
                 <label htmlFor="newPassword" className="text-sm font-medium text-text-primary">새 비밀번호</label>
-                <input id="newPassword" type="password" value={newPassword} onChange={(e) => setNewPassword(e.target.value)} placeholder="8자 이상" required className={inputClass} />
+                <input id="newPassword" type="password" value={newPassword} onChange={(e) => setNewPassword(e.target.value)} placeholder="새 비밀번호 입력" required className={inputClass} />
               </div>
               <div className="flex flex-col gap-1.5">
                 <label htmlFor="confirmPassword" className="text-sm font-medium text-text-primary">새 비밀번호 확인</label>
                 <input id="confirmPassword" type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} required className={inputClass} />
+                <PasswordChecklist password={newPassword} confirm={confirmPassword} className="mt-1" />
               </div>
               {pwError && <p className="text-sm text-red-500">{pwError}</p>}
               <button type="submit" disabled={pwLoading} className="w-fit px-4 py-2 bg-brand text-white rounded-lg hover:bg-brand-dark transition-colors text-sm font-medium disabled:opacity-50">

--- a/apps/web/src/lib/password.ts
+++ b/apps/web/src/lib/password.ts
@@ -1,0 +1,61 @@
+// 비밀번호 복잡도 검증 — 회원가입·비번 변경·비번 재설정 폼에서 호출.
+// BE 의 apps/api/src/lib/password.ts 와 로직 동일 — 변경 시 양쪽 모두 수정.
+// (apps/web 과 apps/api 가 다른 워크스페이스라 import 불가 → 의도적 복제.)
+//
+// 규칙:
+//   - 8자 이상 64자 이하
+//   - ASCII printable 만 (\x20–\x7E)
+//   - 영문(대소 무관) / 숫자 / 특수문자 중 2종 이상
+
+export type PasswordValidationResult =
+  | { ok: true }
+  | { ok: false; reason: string };
+
+export const PASSWORD_MIN_LEN = 8;
+export const PASSWORD_MAX_LEN = 64;
+export const PASSWORD_REQUIRED_CLASSES = 2;
+
+const ASCII_PRINTABLE = /^[\x20-\x7E]+$/;
+
+const CHAR_CLASSES = [
+  /[a-zA-Z]/,
+  /[0-9]/,
+  /[^a-zA-Z0-9]/,
+];
+
+export function validatePassword(password: unknown): PasswordValidationResult {
+  if (typeof password !== 'string') {
+    return { ok: false, reason: '비밀번호 형식이 올바르지 않습니다.' };
+  }
+  if (password.length < PASSWORD_MIN_LEN) {
+    return { ok: false, reason: `비밀번호는 ${PASSWORD_MIN_LEN}자 이상이어야 합니다.` };
+  }
+  if (password.length > PASSWORD_MAX_LEN) {
+    return { ok: false, reason: `비밀번호는 ${PASSWORD_MAX_LEN}자 이하여야 합니다.` };
+  }
+  if (!ASCII_PRINTABLE.test(password)) {
+    return { ok: false, reason: '비밀번호는 영문/숫자/특수문자만 사용할 수 있습니다.' };
+  }
+  const classCount = CHAR_CLASSES.filter((re) => re.test(password)).length;
+  if (classCount < PASSWORD_REQUIRED_CLASSES) {
+    return { ok: false, reason: '비밀번호는 영문/숫자/특수문자 중 2종 이상을 조합해야 합니다.' };
+  }
+  return { ok: true };
+}
+
+// FE 의 실시간 체크리스트 UI 용 — 각 규칙별 충족 여부와 현재 값.
+// charset 위반 시 classes 카운트는 0 으로 게이트해 UX 일관성 유지(영문/숫자/특수만 셈).
+export type PasswordHints = {
+  length: { ok: boolean; current: number; min: number; max: number };
+  charset: { ok: boolean };
+  classes: { ok: boolean; current: number; required: number };
+};
+
+export function getPasswordHints(password: string): PasswordHints {
+  const len = password.length;
+  const length = { ok: len >= PASSWORD_MIN_LEN && len <= PASSWORD_MAX_LEN, current: len, min: PASSWORD_MIN_LEN, max: PASSWORD_MAX_LEN };
+  const charset = { ok: len > 0 && ASCII_PRINTABLE.test(password) };
+  const classCount = charset.ok ? CHAR_CLASSES.filter((re) => re.test(password)).length : 0;
+  const classes = { ok: classCount >= PASSWORD_REQUIRED_CLASSES, current: classCount, required: PASSWORD_REQUIRED_CLASSES };
+  return { length, charset, classes };
+}

--- a/docs/api/api-spec.md
+++ b/docs/api/api-spec.md
@@ -16,6 +16,26 @@
 
 새 라우트를 추가할 때: 인증이 필요하면 핸들러 첫머리에서 `requireAuth`/`requireAdmin`(또는 멘티·멘토 역할 가드)를 호출하고, 무인증 공개라면 `verify-route-auth.ts` 의 `PUBLIC_PATHS` 에 경로를 추가한다.
 
+## 비밀번호 정책 (#243)
+
+비밀번호를 *설정*하는 모든 라우트 — `/api/auth/signup`, `/api/auth/change-password`, `/api/auth/reset-password` — 는 동일한 복잡도 규칙을 강제한다. 단일 진실 출처: `apps/api/src/lib/password.ts` 의 `validatePassword`.
+
+**규칙:**
+- 8자 이상 64자 이하 (bcrypt 의 72바이트 한계 안쪽)
+- ASCII printable 만 (`\x20`–`\x7E`) — 한글·이모지 거부
+- 영문(대소 무관) / 숫자 / 특수문자 중 **2종 이상** 조합
+
+**위반 시 응답:** `400 { error: "<구체 메시지>" }`
+- `"비밀번호는 8자 이상이어야 합니다."`
+- `"비밀번호는 64자 이하여야 합니다."`
+- `"비밀번호는 영문/숫자/특수문자만 사용할 수 있습니다."`
+- `"비밀번호는 영문/숫자/특수문자 중 2종 이상을 조합해야 합니다."`
+- `"비밀번호 형식이 올바르지 않습니다."` (string 이 아닐 때)
+
+FE 의 `apps/web/src/lib/password.ts` 는 동일 규칙의 복제본 + 실시간 체크리스트용 `getPasswordHints` — BE 변경 시 양쪽 동기화 필수. 검증 스크립트: `node --experimental-strip-types apps/api/scripts/verify-password.ts` (14 케이스).
+
+기존 회원의 약한 비번은 강제 변경하지 않는다 (새 비번 설정 시점부터만 적용).
+
 ## 라벨 변환 컨벤션
 
 응답에서 enum 필드는 한국어 라벨로 변환되어 전달된다 (FE 표시용 직접 사용 가능).
@@ -140,7 +160,8 @@
 
 - `signupVerificationToken` JWT 검증: audience `email-verification:signup`, `payload.email === body.email` 일치, 만료 미경과
 - `studentId` 검증: 영문/숫자 4~20자
-- 기존 검증(loginId 형식, password 길이, email/loginId 중복)은 그대로
+- `password` 검증: 위 "비밀번호 정책" 섹션 (#243)
+- 기존 검증(loginId 형식, email/loginId 중복)은 그대로
 
 **Response 201:** `{ user: { user_id, name, login_id, email, student_id, current_role, military_status } }` + 세션 쿠키.
 
@@ -185,13 +206,13 @@
 - JWT 검증 → `token_id` 추출
 - `password_reset_tokens` 조회: 미consumed, 미만료
 - `bcrypt.compare(raw, token_hash)`
-- `newPassword.length ≥ 8`
+- `newPassword` 검증: 위 "비밀번호 정책" 섹션 (#243)
 - 트랜잭션: `User.password_hash` 갱신 + 이 token consumed + 같은 user 의 다른 미사용 reset token 일괄 무효화
 
 **Response 200:** `{ success: true }`
 
 **Errors:**
-- 400: 형식/비밀번호 길이
+- 400: 형식/비밀번호 정책 위반
 - 401: 토큰 만료/사용됨/위조
 
 ---


### PR DESCRIPTION
 ## 무엇을

  비밀번호를 *설정*하는 모든 경로 — `/api/auth/signup`, `/api/auth/change-password`, `/api/auth/reset-password` — 에 **복잡도 검증**을 추가합니다. BE 가 권위, FE 는 실시간 힌트 + 제출 가드. Closes #243.

  ## 규칙

  | 항목 | 값 |
  |---|---|
  | 길이 | 8자 이상 64자 이하 (bcrypt 72바이트 한계 안쪽) |
  | 허용 문자 | ASCII printable 만 (`\x20`–`\x7E`) — 한글·이모지 거부 |
  | 조합 | 영문(대소 무관) / 숫자 / 특수문자 중 **2종 이상** |

  단일 진실 출처: `apps/api/src/lib/password.ts` 의 `validatePassword`. FE 복제본은 `apps/web/src/lib/password.ts` (변경 시 양쪽 동기화 — 주석 명시).

  ## 왜

  기존엔 `password.length < 8` 한 줄만 → `"password"`, `"12345678"` 같은 약한 비번이 그대로 저장됐음. credential stuffing / 사전 공격 표면 확대. remediation M4.

  ## 변경 내용

  | 영역 | 파일 |
  |---|---|
  | BE 공용 모듈 | `apps/api/src/lib/password.ts` (신규) |
  | BE 라우트 | `signup`·`change-password`·`reset-password` 의 `route.ts` — `length<8` 한 줄을 `validatePassword` 호출로 교체 |
  | BE 검증 스크립트 | `apps/api/scripts/verify-password.ts` (신규, 14 케이스) |
  | FE 공용 모듈 | `apps/web/src/lib/password.ts` (신규, BE 동일 + `getPasswordHints`) |
  | FE 컴포넌트 | `apps/web/src/components/auth/PasswordChecklist.tsx` (신규, 실시간 ✓/○ 체크리스트) |
  | FE 폼 | `app/signup/page.tsx`, `app/reset-password/page.tsx`, `components/settings/AccountSettings.tsx` — 체크리스트 + 제출 시점 가드 |   
  | 문서 | `docs/api/api-spec.md` — "비밀번호 정책" 섹션 추가, signup·reset-password 섹션 갱신 |

  > 평소 BE 담당은 `apps/web/` 직접 수정 안 하지만, 이번은 보안 일관성을 위해 BE+FE 동시 적용 (사용자 결정, #202/#203/#183 와 동일 한정 예외).

  ## 검증

  - `pnpm --filter api build` / `lint` ✅, `pnpm --filter web build` / `lint` ✅ (기존 warning 외 0 errors)
  - `node --experimental-strip-types apps/api/scripts/verify-password.ts` → **14/14 PASS** (빈 문자열, 짧음, 김, 1/2/3종, 한글·이모지, null)  
  - 기존 회원의 약한 비번은 *강제 변경 안 함* — 새 비번 설정 시점부터만 적용 (UX/마이그레이션 부담 회피)

  ## 후속 (이 PR 밖)

  - 흔한 비번 사전 차단 (`zxcvbn` / rockyou 등) — 별도 이슈
  - 사용자명·이메일과 동일 비번 차단 — 별도
  - 과거 N개 비번 재사용 차단 (hash history) — 별도