### PR TITLE
fix(#245): 클라이언트 fetch same-origin 통일 (CORS preflight 실패 회피)

### DIFF
--- a/apps/web/src/app/announcements/AnnouncementCard.tsx
+++ b/apps/web/src/app/announcements/AnnouncementCard.tsx
@@ -9,7 +9,7 @@ function formatDate(iso: string): string {
   return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, '0')}.${String(d.getDate()).padStart(2, '0')}`;
 }
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? '';
+const API_BASE = '';
 
 export default function AnnouncementCard({ a }: { a: AnnouncementRow }) {
   const [expanded, setExpanded] = useState(false);

--- a/apps/web/src/app/find-id/page.tsx
+++ b/apps/web/src/app/find-id/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import Footer from '@/components/layout/Footer';
 import { readJson } from '@/lib/http';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? '';
+const API_BASE = '';
 
 export default function FindIdPage() {
   const [email, setEmail] = useState('');

--- a/apps/web/src/app/forgot-password/page.tsx
+++ b/apps/web/src/app/forgot-password/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import Footer from '@/components/layout/Footer';
 import { readJson } from '@/lib/http';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? '';
+const API_BASE = '';
 const COOLDOWN_SEC = 60;
 
 type Step = 'form' | 'code';

--- a/apps/web/src/app/reset-password/page.tsx
+++ b/apps/web/src/app/reset-password/page.tsx
@@ -8,7 +8,7 @@ import PasswordChecklist from '@/components/auth/PasswordChecklist';
 import { readJson } from '@/lib/http';
 import { validatePassword } from '@/lib/password';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? '';
+const API_BASE = '';
 
 function ResetPasswordForm() {
   const router = useRouter();

--- a/apps/web/src/components/settings/AccountSettings.tsx
+++ b/apps/web/src/components/settings/AccountSettings.tsx
@@ -8,7 +8,7 @@ import PasswordChecklist from '@/components/auth/PasswordChecklist';
 import DeleteAccountModal from './DeleteAccountModal';
 import MenteeShareSettingsCard from './MenteeShareSettingsCard';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? '';
+const API_BASE = '';
 
 const ROLE_LABEL: Record<string, string> = { mentee: '멘티', mentor: '멘토', admin: '관리자' };
 


### PR DESCRIPTION
  Closes #245

  ## 증상
  - 유저 설정 화면에서 **이메일 변경 / 비밀번호 변경** 시도 시:
    - Network 탭에 `OPTIONS /api/auth/change-{email,password}` → `204 No Content`
    - 실제 POST 는 발사되지 않음
    - UI: "서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요."

  ## 원인
  브라우저가 `Content-Type: application/json` + cross-origin (`:3000` → `:3001`) 요청 전에 보내는 **CORS preflight (OPTIONS)** 실패가 원인.

  - `apps/web/.env` 에 `NEXT_PUBLIC_API_URL="http://localhost:3001"` 설정됨.
  - 일부 FE 파일이 `const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? '';` 패턴으로
    fetch URL 을 절대경로(`http://localhost:3001/api/...`)로 만들고 있어 브라우저 입장에선 cross-origin.
  - `apps/api` 에는 OPTIONS 핸들러도, `Access-Control-Allow-Origin` 헤더도 없음 (#184 에서 proxy.ts 삭제 후 미들웨어 없음).
  - Next.js Route Handler 가 OPTIONS 에 대해 `Allow` 헤더만 달린 **204** 를 자동 응답 → 브라우저가 CORS 위반으로 차단 → `fetch()` reject →
  `catch` 분기에서 "서버에 연결할 수 없습니다" 노출.

  대조: `apps/web/src/lib/api.ts`, `apps/web/src/app/signup/page.tsx` 는 `const API_BASE = ""` 하드코딩으로 **relative URL** 만 발급.
  `apps/web/next.config.mjs` 의 `/api/:path*` 리라이트가 서버사이드에서 `:3001` 로 프록시하므로 브라우저 관점에선 항상 same-origin → preflight 안 일어남 → 정상 동작.

  ## 변경
  영향받은 5 개 파일의 `API_BASE` 를 `""` 로 통일:

  - `apps/web/src/components/settings/AccountSettings.tsx` (이메일/비밀번호 변경)
  - `apps/web/src/app/reset-password/page.tsx` (비밀번호 재설정 — 사용자 미보고지만 같은 버그)
  - `apps/web/src/app/forgot-password/page.tsx`
  - `apps/web/src/app/find-id/page.tsx`
  - `apps/web/src/app/announcements/AnnouncementCard.tsx`

  `apps/api` 코드는 변경 없음 — 라우트 자체는 200 + `{ success: true }` 정상 응답 중.

  ## 검증
  - [x] `pnpm lint` (apps/web) — 통과 (기존 warning 3건만, 본 변경 무관)
  - [x] `pnpm exec tsc --noEmit` (apps/web) — 통과
  - [x] 수동 — 유저 설정에서:
    - 이메일 변경 폼 제출 → 성공 메시지
    - 비밀번호 변경 폼 제출 → 성공 메시지
    - 비밀번호 재설정 폼 → 정상 동작
    - DevTools Network 에서 `/api/auth/change-*` 가 same-origin (`localhost:3000`) 요청으로 보이는지 확인

  ## Follow-ups (out of scope)
  - `NEXT_PUBLIC_API_URL` 환경변수 자체의 용도 재검토 — 현재 `next.config.mjs` 의 rewrite destination 으로만 의미 있고, 클라이언트 fetch 에 쓸 일은 없음. 향후 잘못 사용되지 않도록 주석/문서 보강 고려.
  - 진짜 외부 도메인에서 API 를 호출할 필요가 생기면 그때 `apps/api` 에 CORS 핸들링 추가.