### PR TITLE
feat(#248): 이메일 변경 시 이메일 인증 도입 (BE+FE)

### DIFF
--- a/apps/api/src/app/api/auth/change-email/route.ts
+++ b/apps/api/src/app/api/auth/change-email/route.ts
@@ -1,61 +1,64 @@
 import { NextRequest, NextResponse } from "next/server";
-import bcrypt from "bcryptjs";
 import { prisma } from "@plawcess/database";
 import { requireAuth } from "@/lib/auth-guard";
+import { signToken, makeAuthCookie } from "@/lib/auth";
+import { verifyChangeEmailVerificationToken } from "@/lib/auth-tokens";
 
 export async function POST(req: NextRequest) {
   const auth = requireAuth(req);
   if (auth.error) return auth.error;
   const tokenPayload = auth.payload;
 
-  let body: { newEmail?: string; password?: string };
+  let body: { changeEmailVerificationToken?: string };
   try {
     body = await req.json();
   } catch {
     return NextResponse.json({ error: "요청 형식이 올바르지 않습니다." }, { status: 400 });
   }
 
-  const { newEmail, password } = body;
-  if (!newEmail || !password) {
-    return NextResponse.json({ error: "새 이메일과 비밀번호를 입력해주세요." }, { status: 400 });
+  const { changeEmailVerificationToken } = body;
+  if (!changeEmailVerificationToken) {
+    return NextResponse.json({ error: "이메일 인증 토큰이 필요합니다." }, { status: 400 });
   }
 
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  if (!emailRegex.test(newEmail)) {
-    return NextResponse.json({ error: "올바른 이메일 형식이 아닙니다." }, { status: 400 });
+  const payload = verifyChangeEmailVerificationToken(changeEmailVerificationToken);
+  if (!payload) {
+    return NextResponse.json({ error: "이메일 인증이 만료되었거나 유효하지 않습니다." }, { status: 401 });
+  }
+  if (payload.user_id !== tokenPayload.user_id) {
+    return NextResponse.json({ error: "토큰 사용자가 일치하지 않습니다." }, { status: 403 });
   }
 
   const user = await prisma.user.findUnique({
     where: { user_id: tokenPayload.user_id },
-    select: { password_hash: true, is_deleted: true, email: true },
+    select: { user_id: true, name: true, current_role: true, is_deleted: true },
   });
-
   if (!user || user.is_deleted) {
     return NextResponse.json({ error: "사용자를 찾을 수 없습니다." }, { status: 404 });
   }
-  if (!user.password_hash) {
-    return NextResponse.json({ error: "비밀번호가 설정되지 않은 계정입니다." }, { status: 400 });
-  }
-  if (user.email === newEmail) {
-    return NextResponse.json({ error: "현재 이메일과 동일합니다." }, { status: 400 });
-  }
 
-  const isValid = await bcrypt.compare(password, user.password_hash);
-  if (!isValid) {
-    return NextResponse.json({ error: "비밀번호가 올바르지 않습니다." }, { status: 401 });
-  }
-
-  const existing = await prisma.user.findFirst({
-    where: { email: newEmail, is_deleted: false },
+  const dup = await prisma.user.findFirst({
+    where: { email: payload.newEmail, is_deleted: false, user_id: { not: tokenPayload.user_id } },
+    select: { user_id: true },
   });
-  if (existing) {
+  if (dup) {
     return NextResponse.json({ error: "이미 사용 중인 이메일입니다." }, { status: 409 });
   }
 
   await prisma.user.update({
     where: { user_id: tokenPayload.user_id },
-    data: { email: newEmail },
+    data: { email: payload.newEmail },
   });
 
-  return NextResponse.json({ success: true });
+  const newToken = signToken({
+    user_id: user.user_id,
+    current_role: user.current_role,
+    name: user.name,
+    email: payload.newEmail,
+  });
+
+  return NextResponse.json(
+    { ok: true, email: payload.newEmail },
+    { status: 200, headers: { "Set-Cookie": makeAuthCookie(newToken) } },
+  );
 }

--- a/apps/api/src/app/api/auth/email/send-verification/route.ts
+++ b/apps/api/src/app/api/auth/email/send-verification/route.ts
@@ -1,15 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
+import bcrypt from "bcryptjs";
 import { prisma } from "@plawcess/database";
 import {
   generateSixDigitCode, hashCode, assertSendRateLimit, RateLimitError,
   CODE_EXPIRES_MINUTES, getClientIp,
 } from "@/lib/email/code";
 import { getEmailSender, EmailDeliveryError } from "@/lib/email/sender";
-import { signupCodeMail, resetPasswordCodeMail } from "@/lib/email/templates";
+import { signupCodeMail, resetPasswordCodeMail, changeEmailCodeMail } from "@/lib/email/templates";
+import { requireAuth } from "@/lib/auth-guard";
 
 type Body =
   | { purpose: "signup"; email: string }
-  | { purpose: "reset_password"; name: string; loginId: string; email: string };
+  | { purpose: "reset_password"; name: string; loginId: string; email: string }
+  | { purpose: "change_email"; email: string; password: string };
 
 export async function POST(req: NextRequest) {
   let body: Body;
@@ -52,6 +55,47 @@ export async function POST(req: NextRequest) {
         expiresAt: new Date(Date.now() + CODE_EXPIRES_MINUTES * 60 * 1000).toISOString(),
       });
     }
+  } else if (body.purpose === "change_email") {
+    const auth = requireAuth(req);
+    if (auth.error) return auth.error;
+    const tokenPayload = auth.payload;
+
+    const { password } = body;
+    if (!password || typeof password !== "string") {
+      return NextResponse.json({ error: "현재 비밀번호가 필요합니다." }, { status: 400 });
+    }
+
+    const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!EMAIL_REGEX.test(email)) {
+      return NextResponse.json({ error: "올바른 이메일 형식이 아닙니다." }, { status: 400 });
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { user_id: tokenPayload.user_id },
+      select: { email: true, password_hash: true, is_deleted: true },
+    });
+    if (!user || user.is_deleted) {
+      return NextResponse.json({ error: "사용자를 찾을 수 없습니다." }, { status: 404 });
+    }
+    if (!user.password_hash) {
+      return NextResponse.json({ error: "비밀번호가 설정되지 않은 계정입니다." }, { status: 400 });
+    }
+    if (user.email === email) {
+      return NextResponse.json({ error: "현재 이메일과 동일합니다." }, { status: 400 });
+    }
+
+    const dup = await prisma.user.findFirst({
+      where: { email, is_deleted: false },
+      select: { user_id: true },
+    });
+    if (dup) {
+      return NextResponse.json({ error: "이미 사용 중인 이메일입니다." }, { status: 409 });
+    }
+
+    const pwValid = await bcrypt.compare(password, user.password_hash);
+    if (!pwValid) {
+      return NextResponse.json({ error: "비밀번호가 올바르지 않습니다." }, { status: 401 });
+    }
   } else {
     return NextResponse.json({ error: "지원하지 않는 purpose 입니다." }, { status: 400 });
   }
@@ -68,7 +112,10 @@ export async function POST(req: NextRequest) {
 
   // 코드 생성 + Resend 발송
   const code = generateSixDigitCode();
-  const mail = body.purpose === "signup" ? signupCodeMail(code) : resetPasswordCodeMail(code);
+  const mail =
+    body.purpose === "signup" ? signupCodeMail(code)
+    : body.purpose === "reset_password" ? resetPasswordCodeMail(code)
+    : changeEmailCodeMail(code);
   try {
     await getEmailSender().send({ to: email, ...mail });
   } catch (e) {

--- a/apps/api/src/app/api/auth/email/verify-code/route.ts
+++ b/apps/api/src/app/api/auth/email/verify-code/route.ts
@@ -6,11 +6,12 @@ import {
   compareCode, findLatestActiveVerification,
   VERIFY_MAX_ATTEMPTS, RESET_TOKEN_EXPIRES_MINUTES, SIGNUP_TOKEN_EXPIRES_MINUTES,
 } from "@/lib/email/code";
-import { signSignupVerificationToken, signResetToken } from "@/lib/auth-tokens";
+import { signSignupVerificationToken, signResetToken, signChangeEmailVerificationToken } from "@/lib/auth-tokens";
+import { requireAuth } from "@/lib/auth-guard";
 
 type Body = {
   email: string;
-  purpose: "signup" | "reset_password";
+  purpose: "signup" | "reset_password" | "change_email";
   code: string;
 };
 
@@ -26,8 +27,15 @@ export async function POST(req: NextRequest) {
   if (!email || !purpose || !code) {
     return NextResponse.json({ error: "email·purpose·code 가 모두 필요합니다." }, { status: 400 });
   }
-  if (purpose !== "signup" && purpose !== "reset_password") {
+  if (purpose !== "signup" && purpose !== "reset_password" && purpose !== "change_email") {
     return NextResponse.json({ error: "지원하지 않는 purpose 입니다." }, { status: 400 });
+  }
+
+  let changeEmailUserId: string | null = null;
+  if (purpose === "change_email") {
+    const auth = requireAuth(req);
+    if (auth.error) return auth.error;
+    changeEmailUserId = auth.payload.user_id;
   }
 
   const row = await findLatestActiveVerification(email, purpose);
@@ -64,6 +72,18 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({
       ok: true,
       signupVerificationToken: token,
+      expiresAt: new Date(Date.now() + SIGNUP_TOKEN_EXPIRES_MINUTES * 60 * 1000).toISOString(),
+    });
+  }
+
+  if (purpose === "change_email") {
+    if (!changeEmailUserId) {
+      return NextResponse.json({ error: "인증이 필요합니다." }, { status: 401 });
+    }
+    const token = signChangeEmailVerificationToken(changeEmailUserId, email);
+    return NextResponse.json({
+      ok: true,
+      changeEmailVerificationToken: token,
       expiresAt: new Date(Date.now() + SIGNUP_TOKEN_EXPIRES_MINUTES * 60 * 1000).toISOString(),
     });
   }

--- a/apps/api/src/lib/auth-tokens.ts
+++ b/apps/api/src/lib/auth-tokens.ts
@@ -9,6 +9,7 @@ const ISSUER = "pLAWcess";
 
 const SIGNUP_VERIFICATION_AUDIENCE = "email-verification:signup";
 const PASSWORD_RESET_AUDIENCE = "password-reset";
+const CHANGE_EMAIL_VERIFICATION_AUDIENCE = "email-verification:change-email";
 
 export type SignupVerificationPayload = {
   email: string;
@@ -17,6 +18,11 @@ export type SignupVerificationPayload = {
 export type ResetTokenPayload = {
   token_id: string;
   raw: string;
+};
+
+export type ChangeEmailVerificationPayload = {
+  user_id: string;
+  newEmail: string;
 };
 
 export function signSignupVerificationToken(email: string): string {
@@ -52,6 +58,25 @@ export function verifyResetToken(token: string): ResetTokenPayload | null {
       issuer: ISSUER,
       audience: PASSWORD_RESET_AUDIENCE,
     }) as ResetTokenPayload;
+  } catch {
+    return null;
+  }
+}
+
+export function signChangeEmailVerificationToken(user_id: string, newEmail: string): string {
+  return jwt.sign({ user_id, newEmail } satisfies ChangeEmailVerificationPayload, JWT_SECRET, {
+    expiresIn: "10m",
+    issuer: ISSUER,
+    audience: CHANGE_EMAIL_VERIFICATION_AUDIENCE,
+  });
+}
+
+export function verifyChangeEmailVerificationToken(token: string): ChangeEmailVerificationPayload | null {
+  try {
+    return jwt.verify(token, JWT_SECRET, {
+      issuer: ISSUER,
+      audience: CHANGE_EMAIL_VERIFICATION_AUDIENCE,
+    }) as ChangeEmailVerificationPayload;
   } catch {
     return null;
   }

--- a/apps/api/src/lib/email/code.ts
+++ b/apps/api/src/lib/email/code.ts
@@ -9,7 +9,7 @@ export const SEND_COOLDOWN_SECONDS = 60;
 export const SEND_HOURLY_LIMIT = 5;
 export const VERIFY_MAX_ATTEMPTS = 5;
 
-type Purpose = "signup" | "reset_password";
+type Purpose = "signup" | "reset_password" | "change_email";
 
 export function generateSixDigitCode(): string {
   return randomInt(0, 1_000_000).toString().padStart(6, "0");

--- a/apps/api/src/lib/email/templates.ts
+++ b/apps/api/src/lib/email/templates.ts
@@ -26,3 +26,11 @@ export function resetPasswordCodeMail(code: string): MailContent {
     html: `<div style="font-family:sans-serif;font-size:15px;">인증 코드는 <strong style="font-size:20px;">${code}</strong> 입니다.<br/>5분 안에 입력해주세요.${FOOTER_HTML}</div>`,
   };
 }
+
+export function changeEmailCodeMail(code: string): MailContent {
+  return {
+    subject: "[pLAWcess] 이메일 변경 인증 코드",
+    text: `인증 코드는 ${code} 입니다. 5분 안에 입력해주세요.${FOOTER_TEXT}`,
+    html: `<div style="font-family:sans-serif;font-size:15px;">인증 코드는 <strong style="font-size:20px;">${code}</strong> 입니다.<br/>5분 안에 입력해주세요.${FOOTER_HTML}</div>`,
+  };
+}

--- a/apps/web/src/components/settings/AccountSettings.tsx
+++ b/apps/web/src/components/settings/AccountSettings.tsx
@@ -19,8 +19,11 @@ export default function AccountSettings({ initialUser }: { initialUser: AuthUser
   const [deleteLoading, setDeleteLoading] = useState(false);
 
   const [showEmailForm, setShowEmailForm] = useState(false);
+  const [emailStep, setEmailStep] = useState<'form' | 'code'>('form');
   const [newEmail, setNewEmail] = useState('');
   const [emailPassword, setEmailPassword] = useState('');
+  const [emailCode, setEmailCode] = useState('');
+  const [emailCooldown, setEmailCooldown] = useState(0);
   const [emailError, setEmailError] = useState('');
   const [emailSuccess, setEmailSuccess] = useState(false);
   const [emailLoading, setEmailLoading] = useState(false);
@@ -37,26 +40,74 @@ export default function AccountSettings({ initialUser }: { initialUser: AuthUser
     if (initialUser) saveUser(initialUser);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  async function handleChangeEmail(e: React.FormEvent) {
+  useEffect(() => {
+    if (emailCooldown <= 0) return;
+    const t = setTimeout(() => setEmailCooldown((c) => c - 1), 1000);
+    return () => clearTimeout(t);
+  }, [emailCooldown]);
+
+  function resetEmailForm() {
+    setEmailStep('form');
+    setNewEmail('');
+    setEmailPassword('');
+    setEmailCode('');
+    setEmailCooldown(0);
+    setEmailError('');
+    setEmailLoading(false);
+  }
+
+  async function handleSendEmailCode(e: React.FormEvent) {
     e.preventDefault();
     setEmailError('');
-    setEmailSuccess(false);
     setEmailLoading(true);
     try {
-      const res = await fetch(`${API_BASE}/api/auth/change-email`, {
+      const res = await fetch(`${API_BASE}/api/auth/email/send-verification`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ newEmail, password: emailPassword }),
+        body: JSON.stringify({ purpose: 'change_email', email: newEmail, password: emailPassword }),
       });
       const data = await res.json();
       if (!res.ok) { setEmailError(data.error ?? '오류가 발생했습니다.'); return; }
-      const updated = user ? { ...user, email: newEmail } : null;
+      setEmailStep('code');
+      setEmailCooldown(60);
+      setEmailCode('');
+    } catch {
+      setEmailError('서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.');
+    } finally {
+      setEmailLoading(false);
+    }
+  }
+
+  async function handleVerifyAndChangeEmail(e: React.FormEvent) {
+    e.preventDefault();
+    setEmailError('');
+    setEmailLoading(true);
+    try {
+      const verifyRes = await fetch(`${API_BASE}/api/auth/email/verify-code`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ purpose: 'change_email', email: newEmail, code: emailCode }),
+      });
+      const verifyData = await verifyRes.json();
+      if (!verifyRes.ok) { setEmailError(verifyData.error ?? '코드 검증에 실패했습니다.'); return; }
+
+      const token: string = verifyData.changeEmailVerificationToken;
+      const changeRes = await fetch(`${API_BASE}/api/auth/change-email`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ changeEmailVerificationToken: token }),
+      });
+      const changeData = await changeRes.json();
+      if (!changeRes.ok) { setEmailError(changeData.error ?? '이메일 변경에 실패했습니다.'); return; }
+
+      const updated = user ? { ...user, email: changeData.email ?? newEmail } : null;
       if (updated) { saveUser(updated); setUser(updated); }
       setEmailSuccess(true);
-      setNewEmail('');
-      setEmailPassword('');
       setShowEmailForm(false);
+      resetEmailForm();
     } catch {
       setEmailError('서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.');
     } finally {
@@ -150,7 +201,10 @@ export default function AccountSettings({ initialUser }: { initialUser: AuthUser
             </div>
             <button
               type="button"
-              onClick={() => { setShowEmailForm((v) => !v); setEmailError(''); setEmailSuccess(false); }}
+              onClick={() => {
+                if (showEmailForm) { resetEmailForm(); setShowEmailForm(false); }
+                else { setShowEmailForm(true); setEmailError(''); setEmailSuccess(false); }
+              }}
               className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-text-secondary border border-border rounded-lg hover:bg-gray-50 transition-colors shrink-0"
             >
               {showEmailForm ? (
@@ -168,20 +222,53 @@ export default function AccountSettings({ initialUser }: { initialUser: AuthUser
           </div>
 
           {showEmailForm && (
-            <form onSubmit={handleChangeEmail} className="flex flex-col gap-4 max-w-sm mt-5">
-              <div className="flex flex-col gap-1.5">
-                <label htmlFor="newEmail" className="text-sm font-medium text-text-primary">새 이메일</label>
-                <input id="newEmail" type="email" value={newEmail} onChange={(e) => setNewEmail(e.target.value)} required className={inputClass} />
-              </div>
-              <div className="flex flex-col gap-1.5">
-                <label htmlFor="emailPassword" className="text-sm font-medium text-text-primary">비밀번호 확인</label>
-                <input id="emailPassword" type="password" value={emailPassword} onChange={(e) => setEmailPassword(e.target.value)} required className={inputClass} />
-              </div>
-              {emailError && <p className="text-sm text-red-500">{emailError}</p>}
-              <button type="submit" disabled={emailLoading} className="w-fit px-4 py-2 bg-brand text-white rounded-lg hover:bg-brand-dark transition-colors text-sm font-medium disabled:opacity-50">
-                {emailLoading ? '변경 중...' : '변경'}
-              </button>
-            </form>
+            emailStep === 'form' ? (
+              <form onSubmit={handleSendEmailCode} className="flex flex-col gap-4 max-w-sm mt-5">
+                <div className="flex flex-col gap-1.5">
+                  <label htmlFor="newEmail" className="text-sm font-medium text-text-primary">새 이메일</label>
+                  <input id="newEmail" type="email" value={newEmail} onChange={(e) => setNewEmail(e.target.value)} required className={inputClass} />
+                </div>
+                <div className="flex flex-col gap-1.5">
+                  <label htmlFor="emailPassword" className="text-sm font-medium text-text-primary">현재 비밀번호</label>
+                  <input id="emailPassword" type="password" value={emailPassword} onChange={(e) => setEmailPassword(e.target.value)} required className={inputClass} />
+                </div>
+                {emailError && <p className="text-sm text-red-500">{emailError}</p>}
+                <button type="submit" disabled={emailLoading} className="w-fit px-4 py-2 bg-brand text-white rounded-lg hover:bg-brand-dark transition-colors text-sm font-medium disabled:opacity-50">
+                  {emailLoading ? '발송 중...' : '인증코드 발송'}
+                </button>
+              </form>
+            ) : (
+              <form onSubmit={handleVerifyAndChangeEmail} className="flex flex-col gap-4 max-w-sm mt-5">
+                <p className="text-sm text-text-secondary">
+                  <span className="text-text-primary font-medium">{newEmail}</span> 으로 6자리 코드를 보냈습니다. 메일을 확인해주세요.
+                </p>
+                <div className="flex flex-col gap-1.5">
+                  <label htmlFor="emailCode" className="text-sm font-medium text-text-primary">인증 코드</label>
+                  <input id="emailCode" type="text" inputMode="numeric" pattern="[0-9]{6}" maxLength={6} value={emailCode} onChange={(e) => setEmailCode(e.target.value.replace(/\D/g, ''))} required className={inputClass} />
+                </div>
+                {emailError && <p className="text-sm text-red-500">{emailError}</p>}
+                <div className="flex items-center gap-2 flex-wrap">
+                  <button type="submit" disabled={emailLoading || emailCode.length !== 6} className="px-4 py-2 bg-brand text-white rounded-lg hover:bg-brand-dark transition-colors text-sm font-medium disabled:opacity-50">
+                    {emailLoading ? '변경 중...' : '변경 완료'}
+                  </button>
+                  <button
+                    type="button"
+                    disabled={emailCooldown > 0 || emailLoading}
+                    onClick={() => handleSendEmailCode({ preventDefault() {} } as React.FormEvent)}
+                    className="px-3 py-2 text-sm text-text-secondary border border-border rounded-lg hover:bg-gray-50 transition-colors disabled:opacity-50"
+                  >
+                    {emailCooldown > 0 ? `재발송 (${emailCooldown}s)` : '재발송'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => { setEmailStep('form'); setEmailCode(''); setEmailError(''); }}
+                    className="px-3 py-2 text-sm text-text-secondary hover:underline"
+                  >
+                    ← 이전
+                  </button>
+                </div>
+              </form>
+            )
           )}
         </div>
       </div>

--- a/docs/api/api-spec.md
+++ b/docs/api/api-spec.md
@@ -9,7 +9,7 @@
 **기본 막힘(deny by default)** — `/api` 아래 모든 라우트는 인증이 필요하다. 무인증 공개 라우트는 명시적으로 허용 목록에 등록되며, 그 목록은 `apps/api/scripts/verify-route-auth.ts` 의 `PUBLIC_PATHS` 가 단일 출처다 (이 스크립트가 "비공개 라우트는 쿠키 없이 호출 시 401" 을 검증한다).
 
 - **무인증 공개**: `/api/health`, `/api/auth/login`, `/api/auth/signup`, `/api/auth/logout`, `/api/auth/find-id`, `/api/auth/reset-password`, `/api/auth/check-login-id`, `/api/auth/email/send-verification`, `/api/auth/email/verify-code`
-- **인증 필요·역할 무관** (예: `/api/auth/me`, `/api/auth/change-password`, `/api/announcements*`, `/api/cycle-schedules/active` 등): 핸들러가 `requireAuth(req)` 호출
+- **인증 필요·역할 무관** (예: `/api/auth/me`, `/api/auth/change-password`, `/api/auth/change-email`, `/api/announcements*`, `/api/cycle-schedules/active` 등): 핸들러가 `requireAuth(req)` 호출
 - `/api/mentee/*`: `mentee` 또는 `admin`
 - `/api/mentor/*`: `mentor` 또는 `admin`
 - `/api/admin/*`: `admin` — 핸들러가 `requireAdmin(req)` 호출
@@ -104,39 +104,44 @@ FE 의 `apps/web/src/lib/password.ts` 는 동일 규칙의 복제본 + 실시간
 
 ---
 
-## `/api/auth/email/send-verification` — POST (#83·#84)
+## `/api/auth/email/send-verification` — POST (#83·#84·#248)
 
-회원가입·비밀번호재설정용 6자리 코드 메일 발송.
+회원가입·비밀번호재설정·이메일변경용 6자리 코드 메일 발송.
 
 **Body (purpose 별 분기):**
 ```ts
 | { purpose: "signup"; email: string }
 | { purpose: "reset_password"; name: string; loginId: string; email: string }   // #84
+| { purpose: "change_email"; email: string; password: string }                  // #248 — email 은 "새 이메일"
 ```
 
 **처리:**
 - `signup`: User.email 중복 시 409 (가입 시점 enumeration 허용)
 - `reset_password`: 이름·아이디·이메일 셋 다 일치 시 발송. 불일치도 200 동일 응답(enumeration 방어), 메일 미발송
+- `change_email` (#248): `requireAuth` 필요. 새 이메일 형식·중복·현재 이메일 동일 여부 검사 → 현재 비밀번호 `bcrypt.compare` 검증 → rate limit → 새 이메일로 발송
 - Rate limit: 동일 (email, purpose) 60초 쿨다운, 시간당 5회 → 위반 시 429
 - Resend 발송 후 `EmailVerification` INSERT (`expires_at = now+5분`)
 
 **Response 200:** `{ sent: true, expiresAt: ISO_string }`
 
 **Errors:**
-- 400: 요청 형식 오류 / purpose 미지원
-- 409: 이미 사용 중인 이메일 (signup 만)
+- 400: 요청 형식 오류 / purpose 미지원 / 현재 이메일과 동일 (change_email) / 비밀번호 미설정 계정 (change_email)
+- 401: 미인증 (change_email) / 현재 비밀번호 불일치 (change_email)
+- 404: 사용자 부재 (change_email)
+- 409: 이미 사용 중인 이메일 (signup, change_email)
 - 429: 쿨다운/한도 초과
 - 502: 메일 발송 실패
 
 ---
 
-## `/api/auth/email/verify-code` — POST (#83·#84)
+## `/api/auth/email/verify-code` — POST (#83·#84·#248)
 
 코드 검증 + 후속 토큰 발급.
 
-**Body:** `{ email, purpose: "signup" | "reset_password", code }`
+**Body:** `{ email, purpose: "signup" | "reset_password" | "change_email", code }`
 
 **처리:**
+- `change_email` 분기는 `requireAuth` 필요 (signup/reset_password 는 익명 호출 허용)
 - (email, purpose) 가장 최근 미consumed·미만료 행 조회
 - `attempts++` → 5회 초과 시 잠금
 - `bcrypt.compare` 실패 시 400
@@ -145,9 +150,11 @@ FE 의 `apps/web/src/lib/password.ts` 는 동일 규칙의 복제본 + 실시간
 **Response 200:**
 - `signup` → `{ ok: true, signupVerificationToken: <JWT>, expiresAt }` — payload `{ email }`, audience `email-verification:signup`, 10분
 - `reset_password` → `{ ok: true, resetToken: <JWT>, expiresAt }` + `password_reset_tokens` INSERT(user_id 매핑). JWT payload `{ token_id, raw }`, audience `password-reset`, 10분
+- `change_email` (#248) → `{ ok: true, changeEmailVerificationToken: <JWT>, expiresAt }` — payload `{ user_id, newEmail }`, audience `email-verification:change-email`, 10분
 
 **Errors:**
 - 400: 코드 만료 / 시도 초과 / 코드 불일치 / purpose 미지원
+- 401: 미인증 (change_email)
 - 404: 사용자 부재 (reset_password 도중 user 삭제 등)
 
 ---
@@ -214,6 +221,40 @@ FE 의 `apps/web/src/lib/password.ts` 는 동일 규칙의 복제본 + 실시간
 **Errors:**
 - 400: 형식/비밀번호 정책 위반
 - 401: 토큰 만료/사용됨/위조
+
+---
+
+## `/api/auth/change-email` — POST (#248)
+
+세션 사용자의 이메일을 변경. 회원가입과 동일하게 새 이메일 소유 증명(코드 인증) + 1단계에서 현재 비밀번호 재확인을 요구한다.
+
+**플로우 (3 단계)**:
+1. `POST /api/auth/email/send-verification` `{ purpose:"change_email", email:newEmail, password }` — 인증·비번 검증·새 이메일 검증 후 새 이메일로 코드 발송
+2. `POST /api/auth/email/verify-code` `{ purpose:"change_email", email:newEmail, code }` — 코드 검증 후 `changeEmailVerificationToken` 발급 (10분, audience `email-verification:change-email`, payload `{ user_id, newEmail }`)
+3. `POST /api/auth/change-email` `{ changeEmailVerificationToken }` — 토큰 검증 → 세션 user_id 일치 확인 → 중복 재검 → 변경 + 세션 토큰 재발급(`Set-Cookie`)
+
+**Body:** `{ changeEmailVerificationToken }`
+
+**처리:**
+- `requireAuth` 필요
+- JWT 검증 (audience `email-verification:change-email`)
+- `payload.user_id === 세션 user_id` 일치 확인 → 불일치 시 403
+- race 재검: `User where { email: payload.newEmail, is_deleted: false, user_id ≠ self }` → 있으면 409
+- `User.email` 갱신
+- 세션 토큰 재발급 (`signToken({ user_id, current_role, name, email: payload.newEmail })`) + `Set-Cookie: plawcess_token`
+
+**Response 200:** `{ ok: true, email: newEmail }` + `Set-Cookie`
+
+**Errors:**
+- 400: 토큰 누락 / 요청 형식
+- 401: 미인증 / 토큰 만료·위조
+- 403: 토큰 사용자가 세션 사용자와 불일치
+- 404: 사용자 부재
+- 409: 토큰 발급 후 다른 유저가 같은 이메일 점유
+
+**보안 노트**:
+- 변경 토큰은 1회용은 아니지만, 직전 단계의 verify-code 가 `consumed_at` 으로 동일 코드 재검증을 차단하므로 새 토큰 발급 불가. 따라서 유효 10분 내 멱등 변경만 가능.
+- 옛 이메일로 변경 완료 통지 메일 / 변경 이력 감사 로그 / 다중 기기 강제 로그아웃은 follow-up.
 
 ---
 

--- a/packages/database/prisma/migrations/20260514004500_add_change_email_purpose/migration.sql
+++ b/packages/database/prisma/migrations/20260514004500_add_change_email_purpose/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "EmailVerificationPurpose" ADD VALUE 'change_email';

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -463,6 +463,7 @@ model CycleSchedule {
 enum EmailVerificationPurpose {
   signup
   reset_password
+  change_email
 }
 
 model EmailVerification {


### PR DESCRIPTION
  Closes #248

  ## 배경
  `/settings` 이메일 변경 폼은 현재 비밀번호만 확인하면 즉시 변경되어, 세션 탈취 시 공격자가 자신의 이메일로 변경 → 비밀번호 재설정 메일을 가로채 계정 영구 탈취가 가능했다. 회원가입과 동일한 수준의 소유 증명을 변경에도 적용한다.

  ## 보안 결정
  | 결정 | 선택 | 근거 |
  |---|---|---|
  | 본인 확인 | 비밀번호 + 새 이메일 코드 둘 다 | 세션 탈취만으로 변경 불가 |
  | 코드 발송 대상 | 새 이메일만 | 회원가입 패턴 일관, 구현 최소 |
  | 비번 검증 시점 | 1단계 (코드 발송 단계) | 세션 탈취 공격이 rate limit 카운터를 소모시키지 못하게 함 |
  | 변경 후 | 세션 토큰 재발급 + Set-Cookie | JWT payload 의 email 필드 정합성 |

  ## 변경

  **BE**
  - `EmailVerificationPurpose` enum 에 `change_email` 추가 (migration `20260514004500_add_change_email_purpose`)
  - `auth-tokens.ts`: change-email JWT 헬퍼 (audience `email-verification:change-email`, payload `{ user_id, newEmail }`, 10분)
  - `email/code.ts` Purpose union 확장, `email/templates.ts` `changeEmailCodeMail` 추가
  - `send-verification`: `change_email` 분기 — requireAuth + 새 이메일 형식·중복·동일 검사 + 현재 비번 bcrypt.compare + rate limit + 새 이메일 발송
  - `verify-code`: `change_email` 분기 — requireAuth + 코드 검증 → 변경 토큰 발급
  - `change-email`: 토큰 기반으로 재설계. `{ changeEmailVerificationToken }` 만 받아 검증 → user_id 일치 확인 → race 재검 → 변경 + 세션 토큰 재발급

  **FE**
  - `AccountSettings` 이메일 카드 2-step UI
    - Step 1: 새 이메일 + 현재 비밀번호 → [인증코드 발송]
    - Step 2: 6자리 코드 → [변경 완료] (검증 + 변경 동시 수행), [재발송] (60초 쿨다운), [← 이전]

  **Docs**
  - `docs/api/api-spec.md` send-verification / verify-code / change-email 섹션 갱신

  ## 검증
  - [x] `apps/api` typecheck (tsc --noEmit) 통과
  - [x] `apps/web` typecheck (tsc --noEmit) 통과
  - [x] `apps/api` lint 통과 (기존 warning 2개, 신규 0)
  - [x] `apps/web` lint 통과 (기존 warning 3개, 신규 0)
  - [ ] cURL 종단 (로그인 → send → verify → change, 비번 오류·이메일 동일·중복·잘못된 토큰 케이스) — dev 서버에서 수동
  - [ ] FE 수동 — `/settings` 에서 2-step UI 동작·재발송 쿨다운·이전 복귀

  ## 마이그레이션
  - `20260514004500_add_change_email_purpose` — Postgres enum value 추가 (forward-only).
  - 머지 후 운영자가 Supabase 에 `prisma migrate deploy` 실행 필요.
  - 공유 dev DB 에는 아직 미적용 (메모리 규약).

  ## 보안 노트
  - 변경 토큰은 1회용이 아니지만 직전 단계의 `verify-code` 가 `consumed_at` 으로 동일 코드 재검증을 차단하므로 새 토큰 발급 불가 → 유효 10분 내 멱등 변경만 가능.

  ## Follow-ups (out of scope)
  - 옛 이메일로 변경 완료 통지 메일
  - 이메일 변경 이력 감사 로그
  - 변경 토큰 nonce (엄격한 1회용 보장)
  - 변경 후 강제 로그아웃 / 다중 기기 세션 무효화
  - 이메일 변경 횟수 제한