### PR TITLE
fix(#267): 회원가입 시 입력한 생년월일을 DB 에 저장

### DIFF
--- a/apps/api/src/app/api/auth/signup/route.ts
+++ b/apps/api/src/app/api/auth/signup/route.ts
@@ -4,9 +4,11 @@ import { prisma } from "@plawcess/database";
 import { signToken, makeAuthCookie } from "@/lib/auth";
 import { verifySignupVerificationToken } from "@/lib/auth-tokens";
 import { validatePassword } from "@/lib/password";
+import { labelToDate } from "@/lib/labels";
 
 const LOGIN_ID_REGEX = /^[a-zA-Z0-9_]{4,30}$/;
 const STUDENT_ID_REGEX = /^[a-zA-Z0-9]{4,20}$/;
+const BIRTH_DATE_REGEX = /^\d{4}\.\d{2}\.\d{2}\.$/;
 
 export async function POST(req: NextRequest) {
   let body: {
@@ -15,6 +17,7 @@ export async function POST(req: NextRequest) {
     email?: string;
     password?: string;
     studentId?: string;
+    birthDate?: string;
     signupVerificationToken?: string;
   };
   try {
@@ -23,10 +26,10 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "요청 형식이 올바르지 않습니다." }, { status: 400 });
   }
 
-  const { name, loginId, email, password, studentId, signupVerificationToken } = body;
-  if (!name || !loginId || !email || !password || !studentId || !signupVerificationToken) {
+  const { name, loginId, email, password, studentId, birthDate, signupVerificationToken } = body;
+  if (!name || !loginId || !email || !password || !studentId || !birthDate || !signupVerificationToken) {
     return NextResponse.json(
-      { error: "이름·아이디·이메일·비밀번호·학번·이메일 인증 토큰은 필수입니다." },
+      { error: "이름·아이디·이메일·비밀번호·학번·생년월일·이메일 인증 토큰은 필수입니다." },
       { status: 400 },
     );
   }
@@ -35,6 +38,13 @@ export async function POST(req: NextRequest) {
   }
   if (!STUDENT_ID_REGEX.test(studentId)) {
     return NextResponse.json({ error: "학번은 영문/숫자 4~20자여야 합니다." }, { status: 400 });
+  }
+  if (!BIRTH_DATE_REGEX.test(birthDate)) {
+    return NextResponse.json({ error: "생년월일은 YYYY.MM.DD. 형식으로 입력해주세요." }, { status: 400 });
+  }
+  const birthDateParsed = labelToDate(birthDate);
+  if (!birthDateParsed) {
+    return NextResponse.json({ error: "유효하지 않은 생년월일입니다." }, { status: 400 });
   }
   const pwResult = validatePassword(password);
   if (!pwResult.ok) {
@@ -68,6 +78,7 @@ export async function POST(req: NextRequest) {
       email,
       password_hash,
       student_id: studentId,
+      birth_date: birthDateParsed,
       current_role: "mentee",
       military_status: "not_applicable",
     },

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -314,6 +314,7 @@ export default function SignupPage() {
           email: form.email,
           password: form.password,
           studentId: form.studentId,
+          birthDate: form.birthDate,
           signupVerificationToken,
         }),
       });


### PR DESCRIPTION
## Summary
  - 회원가입 폼은 생년월일을 입력·검증하지만 FE 가 payload 에 누락시키고 BE 도 받지 않아 `user.birth_date` 가 NULL 로 저장되던 버그 수정
  - 가입 직후 기본정보 페이지에서 생년월일이 빈 값으로 표시되던 증상 해결

  ## Changes
  **FE** — `apps/web/src/app/signup/page.tsx`
  - `/api/auth/signup` 호출 body 에 `birthDate: form.birthDate` 1줄 추가

  **BE** — `apps/api/src/app/api/auth/signup/route.ts`
  - 필수 필드에 `birthDate` 추가, 누락 시 400 + 한국어 에러
  - `YYYY.MM.DD.` 정규식 검증, 위반 시 400
  - `labelToDate()` 로 파싱, 실패 시 400 (예: `2026.02.31.`)
  - `prisma.user.create` 에 `birth_date: birthDateParsed` 저장
