### PR TITLE
feat(#268): 회원가입 재학증명서 업로드 (BE+FE)

### DIFF
--- a/apps/api/src/app/api/auth/signup/route.ts
+++ b/apps/api/src/app/api/auth/signup/route.ts
@@ -1,32 +1,36 @@
 import { NextRequest, NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
+import { randomUUID } from "node:crypto";
 import { prisma } from "@plawcess/database";
 import { signToken, makeAuthCookie } from "@/lib/auth";
 import { verifySignupVerificationToken } from "@/lib/auth-tokens";
 import { validatePassword } from "@/lib/password";
 import { labelToDate } from "@/lib/labels";
+import { validateCertFile, uploadCert } from "@/lib/enrollment-cert";
+import { removeMany } from "@/lib/storage";
 
 const LOGIN_ID_REGEX = /^[a-zA-Z0-9_]{4,30}$/;
 const STUDENT_ID_REGEX = /^[a-zA-Z0-9]{4,20}$/;
 const BIRTH_DATE_REGEX = /^\d{4}\.\d{2}\.\d{2}\.$/;
 
 export async function POST(req: NextRequest) {
-  let body: {
-    name?: string;
-    loginId?: string;
-    email?: string;
-    password?: string;
-    studentId?: string;
-    birthDate?: string;
-    signupVerificationToken?: string;
-  };
+  let form: FormData;
   try {
-    body = await req.json();
+    form = await req.formData();
   } catch {
     return NextResponse.json({ error: "요청 형식이 올바르지 않습니다." }, { status: 400 });
   }
 
-  const { name, loginId, email, password, studentId, birthDate, signupVerificationToken } = body;
+  const name = (form.get("name") ?? "") as string;
+  const loginId = (form.get("loginId") ?? "") as string;
+  const email = (form.get("email") ?? "") as string;
+  const password = (form.get("password") ?? "") as string;
+  const studentId = (form.get("studentId") ?? "") as string;
+  const birthDate = (form.get("birthDate") ?? "") as string;
+  const signupVerificationToken = (form.get("signupVerificationToken") ?? "") as string;
+  const enrollmentFileRaw = form.get("enrollmentFile");
+  const enrollmentFile = enrollmentFileRaw instanceof File ? enrollmentFileRaw : null;
+
   if (!name || !loginId || !email || !password || !studentId || !birthDate || !signupVerificationToken) {
     return NextResponse.json(
       { error: "이름·아이디·이메일·비밀번호·학번·생년월일·이메일 인증 토큰은 필수입니다." },
@@ -45,6 +49,10 @@ export async function POST(req: NextRequest) {
   const birthDateParsed = labelToDate(birthDate);
   if (!birthDateParsed) {
     return NextResponse.json({ error: "유효하지 않은 생년월일입니다." }, { status: 400 });
+  }
+  const certError = validateCertFile(enrollmentFile);
+  if (certError) {
+    return NextResponse.json({ error: certError }, { status: 400 });
   }
   const pwResult = validatePassword(password);
   if (!pwResult.ok) {
@@ -77,29 +85,57 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "이미 가입된 학번입니다." }, { status: 409 });
   }
 
+  // user_id 미리 생성 — Supabase Storage 경로에 포함시키기 위함.
+  // 업로드 → DB 순서로 처리(Approach 1): DB 실패 시 storage 정리.
+  const userId = randomUUID();
+
+  let cert;
+  try {
+    cert = await uploadCert(userId, enrollmentFile!);
+  } catch (err) {
+    console.error("[signup] 재학증명서 업로드 실패", err);
+    return NextResponse.json(
+      { error: "재학증명서 업로드에 실패했습니다." },
+      { status: 500 },
+    );
+  }
+
   const password_hash = await bcrypt.hash(password, 12);
 
-  const user = await prisma.user.create({
-    data: {
-      name,
-      login_id: loginId,
-      email,
-      password_hash,
-      student_id: studentId,
-      birth_date: birthDateParsed,
-      current_role: "mentee",
-      military_status: "not_applicable",
-    },
-    select: {
-      user_id: true,
-      name: true,
-      login_id: true,
-      email: true,
-      student_id: true,
-      current_role: true,
-      military_status: true,
-    },
-  });
+  let user;
+  try {
+    user = await prisma.user.create({
+      data: {
+        user_id: userId,
+        name,
+        login_id: loginId,
+        email,
+        password_hash,
+        student_id: studentId,
+        birth_date: birthDateParsed,
+        current_role: "mentee",
+        military_status: "not_applicable",
+        enrollment_doc_path: cert.storagePath,
+        enrollment_doc_filename: cert.filename,
+        enrollment_doc_mime: cert.mime,
+        enrollment_doc_size: cert.size,
+        enrollment_doc_uploaded_at: cert.uploadedAt,
+      },
+      select: {
+        user_id: true,
+        name: true,
+        login_id: true,
+        email: true,
+        student_id: true,
+        current_role: true,
+        military_status: true,
+      },
+    });
+  } catch (err) {
+    // 업로드 성공 후 DB 저장 실패 — 고아 객체 정리 (실패해도 사용자 흐름 막지 않음).
+    await removeMany([cert.storagePath]).catch(() => {});
+    throw err;
+  }
 
   const token = signToken({ user_id: user.user_id, current_role: user.current_role, name: user.name, email: user.email, login_id: user.login_id });
 

--- a/apps/api/src/lib/enrollment-cert.ts
+++ b/apps/api/src/lib/enrollment-cert.ts
@@ -1,0 +1,75 @@
+// 회원가입 재학증명서 처리 — Supabase Storage 업로드 + 메타 추출.
+// 자소서 첨부(attachments.ts) 와 정책·흐름이 달라 별도 모듈로 격리.
+//
+// 정책:
+// - 파일 1개, PDF/JPG/PNG, 최대 4MB
+// - 경로: enrollment-certs/{userId}/{contentHash}.{ext}  (qualitative 와 구분)
+// - 텍스트 추출 없음, Gemini 전송 없음 (저장만)
+
+import { createHash } from "node:crypto";
+
+import { uploadIfAbsent } from "./storage";
+
+export const CERT_MAX_BYTES = 4 * 1024 * 1024;
+
+export const CERT_MIME_TO_EXT: Record<string, "pdf" | "jpg" | "png"> = {
+  "application/pdf": "pdf",
+  "image/jpeg": "jpg",
+  "image/png": "png",
+};
+
+export type ProcessedCert = {
+  storagePath: string;
+  filename: string;
+  mime: string;
+  size: number;
+  uploadedAt: Date;
+};
+
+// ----------------------------------------------------------------
+// 검증 — 위반 시 한국어 사유, 통과 시 null
+// ----------------------------------------------------------------
+export function validateCertFile(file: File | null | undefined): string | null {
+  if (!file) return "재학증명서를 첨부해주세요.";
+  if (file.size === 0) return "재학증명서 파일이 비어 있습니다.";
+  if (file.size > CERT_MAX_BYTES) {
+    return `재학증명서는 ${CERT_MAX_BYTES / 1024 / 1024}MB 이하만 가능합니다.`;
+  }
+  if (!CERT_MIME_TO_EXT[file.type]) {
+    return "재학증명서는 PDF/JPG/PNG 파일만 업로드 가능합니다.";
+  }
+  return null;
+}
+
+// ----------------------------------------------------------------
+// 저장 경로 — Supabase Storage 의 pLAWcess 버킷 기준 상대 경로
+// ----------------------------------------------------------------
+export function buildCertPath(userId: string, contentHash: string, ext: string): string {
+  return `enrollment-certs/${userId}/${contentHash}.${ext}`;
+}
+
+// ----------------------------------------------------------------
+// 업로드 — bytes 읽기 → SHA-256 → uploadIfAbsent → 메타 반환
+// 호출 측은 prisma.user.create 실패 시 removeMany([storagePath]) 로 정리해야 한다.
+// ----------------------------------------------------------------
+export async function uploadCert(userId: string, file: File): Promise<ProcessedCert> {
+  const ext = CERT_MIME_TO_EXT[file.type];
+  if (!ext) {
+    // validateCertFile 을 호출 측이 먼저 거쳤다면 도달 불가, defense-in-depth
+    throw new Error("지원하지 않는 재학증명서 형식입니다.");
+  }
+
+  const buf = new Uint8Array(await file.arrayBuffer());
+  const contentHash = createHash("sha256").update(buf).digest("hex");
+  const storagePath = buildCertPath(userId, contentHash, ext);
+
+  await uploadIfAbsent(storagePath, buf, file.type);
+
+  return {
+    storagePath,
+    filename: file.name,
+    mime: file.type,
+    size: file.size,
+    uploadedAt: new Date(),
+  };
+}

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -226,8 +226,12 @@ export default function SignupPage() {
   }
 
   function handleFile(file: File | null) {
-    if (file && file.size > 10 * 1024 * 1024) {
-      setFieldErrors((prev) => ({ ...prev, file: '파일 크기는 10MB 이하여야 합니다.' }));
+    if (file && file.size > 4 * 1024 * 1024) {
+      setFieldErrors((prev) => ({ ...prev, file: '파일 크기는 4MB 이하여야 합니다.' }));
+      return;
+    }
+    if (file && !['application/pdf', 'image/jpeg', 'image/png'].includes(file.type)) {
+      setFieldErrors((prev) => ({ ...prev, file: 'PDF/JPG/PNG 파일만 업로드 가능합니다.' }));
       return;
     }
     setFieldErrors((prev) => ({ ...prev, file: undefined }));
@@ -276,6 +280,10 @@ export default function SignupPage() {
       next.phone = '010-XXXX-XXXX 형식으로 입력해주세요';
       mark('phone');
     }
+    if (!form.enrollmentFile) {
+      next.file = '재학증명서를 첨부해주세요.';
+      mark('file');
+    }
     if (!consent.privacyRequired) {
       next.consent = '개인정보 수집·이용에 동의해주세요.';
       mark('consent');
@@ -304,19 +312,20 @@ export default function SignupPage() {
 
     let res: Response;
     try {
+      const fd = new FormData();
+      fd.append('name', form.name);
+      fd.append('loginId', form.loginId);
+      fd.append('email', form.email);
+      fd.append('password', form.password);
+      fd.append('studentId', form.studentId);
+      fd.append('birthDate', form.birthDate);
+      fd.append('signupVerificationToken', signupVerificationToken);
+      if (form.enrollmentFile) fd.append('enrollmentFile', form.enrollmentFile);
       res = await fetch(`${API_BASE}/api/auth/signup`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        // Content-Type 은 명시하지 않음 — 브라우저가 boundary 포함해 자동 설정
         credentials: 'include',
-        body: JSON.stringify({
-          name: form.name,
-          loginId: form.loginId,
-          email: form.email,
-          password: form.password,
-          studentId: form.studentId,
-          birthDate: form.birthDate,
-          signupVerificationToken,
-        }),
+        body: fd,
       });
     } catch {
       setError('서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.');
@@ -569,7 +578,7 @@ export default function SignupPage() {
                   ) : (
                     <>
                       <span className="text-sm text-text-secondary">클릭하거나 파일을 드래그하여 업로드</span>
-                      <span className="text-xs text-text-placeholder mt-1">PDF, JPG, PNG (최대 10MB)</span>
+                      <span className="text-xs text-text-placeholder mt-1">PDF, JPG, PNG (최대 4MB)</span>
                     </>
                   )}
                 </div>

--- a/packages/database/prisma/migrations/20260515123000_user_add_enrollment_doc_meta/migration.sql
+++ b/packages/database/prisma/migrations/20260515123000_user_add_enrollment_doc_meta/migration.sql
@@ -1,0 +1,9 @@
+-- User 에 재학증명서 메타 컬럼 추가 (#268)
+-- 회원가입 시 Supabase Storage 의 pLAWcess 버킷에 업로드된 cert 의 메타 정보를 보관.
+-- 기존 가입자는 backfill 없이 NULL 유지. BE 핸들러가 신규 가입에서 required 검증.
+
+ALTER TABLE "users" ADD COLUMN "enrollment_doc_path"        VARCHAR(500);
+ALTER TABLE "users" ADD COLUMN "enrollment_doc_filename"    VARCHAR(255);
+ALTER TABLE "users" ADD COLUMN "enrollment_doc_mime"        VARCHAR(50);
+ALTER TABLE "users" ADD COLUMN "enrollment_doc_size"        INTEGER;
+ALTER TABLE "users" ADD COLUMN "enrollment_doc_uploaded_at" TIMESTAMPTZ(6);

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -107,6 +107,13 @@ model User {
   undergrad_entry_year      Int?
   undergrad_graduation_year Int?
 
+  // 재학 증빙 (회원가입 시 1회 수집, Supabase Storage 의 pLAWcess 버킷 기준)
+  enrollment_doc_path        String?   @db.VarChar(500)
+  enrollment_doc_filename    String?   @db.VarChar(255)
+  enrollment_doc_mime        String?   @db.VarChar(50)
+  enrollment_doc_size        Int?
+  enrollment_doc_uploaded_at DateTime? @db.Timestamptz(6)
+
   // 계정
   account_status         AccountStatus @default(active)
   current_role           CurrentRole   @default(none)


### PR DESCRIPTION
Closes #268

  ## Summary
  - 회원가입 폼이 재학증명서 첨부 UI 만 제공하고 실제로는 어디로도 전송하지 않아, 운영진이 cert 를 받지 못하던 문제 해결
  - FE 가 multipart/form-data 로 파일 포함 전송 → BE 가 Supabase Storage(`pLAWcess` 버킷)에 보관 → User 메타 5컬럼에
  path/filename/mime/size/uploaded_at 저장

  ## Changes

  **스키마** — `packages/database/prisma/schema.prisma` + 마이그레이션
  - User 에 `enrollment_doc_path/filename/mime/size/uploaded_at` 5 컬럼 추가 (nullable, 기존 가입자 backfill 없음)
  - 마이그레이션: `20260515123000_user_add_enrollment_doc_meta` — 공유 dev DB 미적용, 머지 후 배포 파이프라인에서 적용

  **BE 신규 모듈** — `apps/api/src/lib/enrollment-cert.ts`
  - `validateCertFile`: 4MB · PDF/JPG/PNG 검증
  - `buildCertPath`: `enrollment-certs/{userId}/{contentHash}.{ext}` (자소서 첨부와 폴더 분리)
  - `uploadCert`: SHA-256 contentHash + 기존 `uploadIfAbsent` 호출

  **BE signup route** — `apps/api/src/app/api/auth/signup/route.ts`
  - `req.json()` → `req.formData()` 본문 전환
  - 처리 순서: 텍스트·파일 검증 → 이메일 토큰 → 중복 재검 → `randomUUID()` 로 user_id 미리 생성 → Supabase 업로드 → `prisma.user.create`
  - `user.create` 실패 시 `storage.removeMany([path])` 로 고아 객체 정리(Approach 1)

  **FE signup page** — `apps/web/src/app/signup/page.tsx`
  - `JSON.stringify` → `FormData` 전송 (`Content-Type` 헤더 제거 — 브라우저가 boundary 자동 설정)
  - `enrollmentFile` 필수 검증 추가
  - 클라이언트 MIME 검증 (`application/pdf|image/jpeg|image/png`)
  - 크기 한도 10MB → 4MB 로 BE 와 일치, 힌트 문구도 동기화

  ## 운영 메모

  - 신규 env var 없음 (`SUPABASE_URL`, `SUPABASE_SECRET_KEY` 기존 그대로 사용)
  - 관리자 조회·다운로드 UI, 회원 cert 교체 기능은 별도 PR 로 후속 진행
  - Vercel preview 테스트 시 FE preview 의 `NEXT_PUBLIC_API_URL` 이 이 브랜치의 API preview 를 가리키는지 확인 필요 (#267 디버깅 때와 동일 이슈)