### PR TITLE
fix(#285): 회원가입 시 전화번호가 DB에 저장되지 않던 문제 수정

### DIFF
--- a/apps/api/src/app/api/auth/signup/route.ts
+++ b/apps/api/src/app/api/auth/signup/route.ts
@@ -12,6 +12,7 @@ import { removeMany } from "@/lib/storage";
 const LOGIN_ID_REGEX = /^[a-zA-Z0-9_]{4,30}$/;
 const STUDENT_ID_REGEX = /^[a-zA-Z0-9]{4,20}$/;
 const BIRTH_DATE_REGEX = /^\d{4}\.\d{2}\.\d{2}\.$/;
+const PHONE_REGEX = /^010-\d{4}-\d{4}$/;
 
 export async function POST(req: NextRequest) {
   let form: FormData;
@@ -27,6 +28,7 @@ export async function POST(req: NextRequest) {
   const password = (form.get("password") ?? "") as string;
   const studentId = (form.get("studentId") ?? "") as string;
   const birthDate = (form.get("birthDate") ?? "") as string;
+  const phone = (form.get("phone") ?? "") as string;
   const signupVerificationToken = (form.get("signupVerificationToken") ?? "") as string;
   const enrollmentFileRaw = form.get("enrollmentFile");
   const enrollmentFile = enrollmentFileRaw instanceof File ? enrollmentFileRaw : null;
@@ -45,6 +47,9 @@ export async function POST(req: NextRequest) {
   }
   if (!BIRTH_DATE_REGEX.test(birthDate)) {
     return NextResponse.json({ error: "생년월일은 YYYY.MM.DD. 형식으로 입력해주세요." }, { status: 400 });
+  }
+  if (phone && !PHONE_REGEX.test(phone)) {
+    return NextResponse.json({ error: "전화번호는 010-XXXX-XXXX 형식으로 입력해주세요." }, { status: 400 });
   }
   const birthDateParsed = labelToDate(birthDate);
   if (!birthDateParsed) {
@@ -113,6 +118,7 @@ export async function POST(req: NextRequest) {
         password_hash,
         student_id: studentId,
         birth_date: birthDateParsed,
+        phone: phone || null,
         current_role: "mentee",
         military_status: "not_applicable",
         enrollment_doc_path: cert.storagePath,

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -370,6 +370,7 @@ export default function SignupPage() {
       fd.append('password', form.password);
       fd.append('studentId', form.studentId);
       fd.append('birthDate', form.birthDate);
+      if (form.phone) fd.append('phone', form.phone);
       fd.append('signupVerificationToken', signupVerificationToken);
       if (form.enrollmentFile) fd.append('enrollmentFile', form.enrollmentFile);
       res = await fetch(`${API_BASE}/api/auth/signup`, {


### PR DESCRIPTION
## Summary
  - 회원가입 폼에서 전화번호를 입력해도 `User.phone` 이 NULL 로 저장되던 버그 수정
  - FE: `signup/page.tsx` FormData 에 `phone` 필드가 누락되어 서버로 전송되지 않음 → 한 줄 추가
  - BE: `signup/route.ts` 에 phone 파싱·형식검증(`^010-\d{4}-\d{4}$`)·저장 로직 추가
  - Prisma 스키마의 `User.phone String? @db.VarChar(20)` 는 기존 그대로 → **마이그레이션 불필요**

  ## Test plan
  - [ ] 정상: `010-1234-5678` 입력 후 가입 → DB `User.phone` 에 값 저장 확인 (`SELECT phone FROM "User" WHERE login_id = '...'`)
  - [ ] 미입력: 전화번호 빈 칸으로 가입 → 가입 성공 + `User.phone IS NULL`
  - [ ] 잘못된 형식 (BE 방어선): curl 로 `phone=01012345678` 직접 호출 → 400 "전화번호는 010-XXXX-XXXX 형식으로 입력해주세요."
  - [ ] 회귀: 이름/아이디/이메일/비밀번호/학번/생년월일/이메일 인증/재학증명서 흐름 변동 없음

  Closes #285