### PR TITLE
fix(#225): GET /api/announcements/[id] 비-UUID id 에 404 응답

### DIFF
--- a/apps/api/src/app/api/announcements/[id]/route.ts
+++ b/apps/api/src/app/api/announcements/[id]/route.ts
@@ -2,6 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@plawcess/database";
 import { requireAuth } from "@/lib/auth-guard";
 
+// announcement_id 는 @db.Uuid — UUID 형식이 아닌 입력은 Prisma 가 P2023 을 던지므로
+// 진입 시점에 미리 거르고 일관된 404 로 응답한다 (#225).
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
@@ -11,22 +15,30 @@ export async function GET(
 
   const { id } = await params;
 
-  const [row] = await prisma.$transaction([
-    prisma.announcement.update({
-      where: { announcement_id: id },
-      data: { view_count: { increment: 1 } },
-      include: { created_by: { select: { name: true } } },
-    }),
-  ]).catch(async () => {
-    const found = await prisma.announcement.findFirst({
-      where: { announcement_id: id, is_published: true, deleted_at: null },
-      include: { created_by: { select: { name: true } } },
-    });
-    return [found];
+  if (!UUID_REGEX.test(id)) {
+    return NextResponse.json({ error: "해당 공지사항이 없습니다." }, { status: 404 });
+  }
+
+  const row = await prisma.announcement.findFirst({
+    where: { announcement_id: id, is_published: true, deleted_at: null },
+    include: { created_by: { select: { name: true } } },
   });
 
-  if (!row || !row.is_published || row.deleted_at) {
+  if (!row) {
     return NextResponse.json({ error: "해당 공지사항이 없습니다." }, { status: 404 });
+  }
+
+  // 조회수 증가는 best-effort — 실패해도 응답에는 영향을 주지 않는다.
+  let viewCount = row.view_count + 1;
+  try {
+    const updated = await prisma.announcement.update({
+      where: { announcement_id: id },
+      data: { view_count: { increment: 1 } },
+      select: { view_count: true },
+    });
+    viewCount = updated.view_count;
+  } catch {
+    // increment 실패 시 응답 본문엔 추정치(row.view_count + 1) 를 유지한다.
   }
 
   return NextResponse.json({
@@ -34,7 +46,7 @@ export async function GET(
     title: row.title,
     body: row.body,
     isPinned: row.is_pinned,
-    viewCount: row.view_count,
+    viewCount,
     createdAt: row.created_at.toISOString(),
     updatedAt: row.updated_at.toISOString(),
     author: row.created_by.name,


### PR DESCRIPTION
announcement_id 가 @db.Uuid 라 비-UUID 입력 시 Prisma 가 P2023 을 던졌고,
$transaction([update]).catch(findFirst) 의 폴백 경로도 같은 id 로 다시 쿼리해 재던짐 → 500.
- UUID 정규식으로 진입 시점에 형식 검증, 미일치 시 즉시 404
- 흐름을 findFirst → best-effort update 로 재구성, 예외 기반 제어 제거
- 부수 효과로 비공개/삭제 공지의 view_count 증가도 사라짐