### PR TITLE
fix(#295): 보완요청 후 재제출 + 거절 사유 노출

### DIFF
--- a/apps/api/src/app/api/mentee/applications/status/route.ts
+++ b/apps/api/src/app/api/mentee/applications/status/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@plawcess/database";
+import { getTokenFromCookie } from "@/lib/auth";
+import { applicationStatusToLabel } from "@/lib/labels";
+
+function getUserId(req: NextRequest): string | null {
+  return getTokenFromCookie(req)?.user_id ?? null;
+}
+
+function getProcessYear(req: NextRequest): number {
+  const raw = req.nextUrl.searchParams.get("year");
+  if (!raw) return new Date().getFullYear();
+  const match = raw.match(/\d{4}/);
+  return match ? parseInt(match[0]) : new Date().getFullYear();
+}
+
+// ----------------------------------------------------------------
+// GET /api/mentee/applications/status?year=2026
+// 멘티 프로세스 신청 페이지가 사용. 본인 application 의 현재 상태와
+// (보완요청·거절 시) 최신 admin 메모를 반환한다.
+//   applicationStatus: null = 미신청
+//   latestMemo:        revision/rejected 일 때만 채움 (그 외엔 null)
+// ----------------------------------------------------------------
+export async function GET(req: NextRequest) {
+  const userId = getUserId(req);
+  if (!userId) {
+    return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
+  }
+
+  const processYear = getProcessYear(req);
+
+  const application = await prisma.application.findUnique({
+    where: {
+      user_id_process_year_role: {
+        user_id: userId,
+        process_year: processYear,
+        role: "mentee",
+      },
+    },
+    select: {
+      application_status: true,
+      submitted_at: true,
+      admin_memos: {
+        take: 1,
+        orderBy: { created_at: "desc" },
+        select: { memo_content: true },
+      },
+    },
+  });
+
+  if (!application) {
+    return NextResponse.json({
+      applicationStatus: null,
+      submittedAt: null,
+      latestMemo: null,
+    });
+  }
+
+  const label = applicationStatusToLabel(application.application_status) || null;
+  const exposeMemo = label === "revision" || label === "rejected";
+  const latestMemo = exposeMemo ? (application.admin_memos[0]?.memo_content ?? null) : null;
+
+  return NextResponse.json({
+    applicationStatus: label,
+    submittedAt: application.submitted_at?.toISOString() ?? null,
+    latestMemo,
+  });
+}

--- a/apps/api/src/app/api/mentee/applications/submit/route.ts
+++ b/apps/api/src/app/api/mentee/applications/submit/route.ts
@@ -55,11 +55,24 @@ export async function POST(req: NextRequest) {
     share_requests: shareInput.requests ?? true,
   };
 
-  // 사용자 + 멘티 record 조회
-  const record = await prisma.menteeRecord.findUnique({
-    where: { user_id_process_year: { user_id: userId, process_year: processYear } },
-    select: { record_id: true, record_status: true },
-  });
+  // 사용자 + 멘티 record + 기존 application 조회
+  // record_status 가 아니라 Application 존재/상태를 진실의 원천으로 분기한다.
+  const [record, existing] = await Promise.all([
+    prisma.menteeRecord.findUnique({
+      where: { user_id_process_year: { user_id: userId, process_year: processYear } },
+      select: { record_id: true, record_status: true },
+    }),
+    prisma.application.findUnique({
+      where: {
+        user_id_process_year_role: {
+          user_id: userId,
+          process_year: processYear,
+          role: "mentee",
+        },
+      },
+      select: { application_id: true, application_status: true },
+    }),
+  ]);
 
   if (!record) {
     return NextResponse.json(
@@ -68,11 +81,21 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  if (record.record_status === "submitted") {
-    return NextResponse.json({ error: "이미 제출된 신청서입니다." }, { status: 409 });
+  // 기존 신청이 있는데 보완요청 외의 상태(승인/거절/대기) → 사용자가 임의로 재제출 불가
+  if (existing && existing.application_status !== "revision_requested") {
+    const message =
+      existing.application_status === "approved"
+        ? "이미 승인된 신청서입니다."
+        : existing.application_status === "rejected"
+          ? "거절된 신청서입니다. 관리자에게 문의해주세요."
+          : "이미 제출된 신청서입니다.";
+    return NextResponse.json({ error: message }, { status: 409 });
   }
 
-  // 트랜잭션: record_status 전환 + 공개 설정 저장 + Application 생성
+  // 트랜잭션: record_status 전환 + 공개 설정 저장 + Application upsert
+  // - 첫 제출            : Application 새로 생성
+  // - 보완요청 후 재제출 : Application status 를 submitted 로 되돌리고 submitted_at 만 갱신
+  //                       (revision_requested_at 등 기존 timestamp 는 audit 으로 보존)
   const submittedAt = new Date();
   try {
     const application = await prisma.$transaction(async (tx) => {
@@ -80,6 +103,17 @@ export async function POST(req: NextRequest) {
         where: { record_id: record.record_id },
         data: { record_status: "submitted", ...shareData },
       });
+
+      if (existing) {
+        return tx.application.update({
+          where: { application_id: existing.application_id },
+          data: {
+            application_status: "submitted",
+            submitted_at: submittedAt,
+          },
+          select: { application_id: true, submitted_at: true },
+        });
+      }
 
       return tx.application.create({
         data: {

--- a/apps/api/src/app/api/mentor/applications/status/route.ts
+++ b/apps/api/src/app/api/mentor/applications/status/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@plawcess/database";
 import { getTokenFromCookie } from "@/lib/auth";
+import { applicationStatusToLabel } from "@/lib/labels";
 
 function getUserId(req: NextRequest): string | null {
   return getTokenFromCookie(req)?.user_id ?? null;
@@ -27,7 +28,7 @@ export async function GET(req: NextRequest) {
 
   const processYear = getProcessYear(req);
 
-  const [user, record] = await Promise.all([
+  const [user, record, application] = await Promise.all([
     prisma.user.findUnique({
       where: { user_id: userId },
       select: {
@@ -48,6 +49,23 @@ export async function GET(req: NextRequest) {
         lawschool_name: true,
         lawschool_grade: true,
         application: { select: { submitted_at: true } },
+      },
+    }),
+    prisma.application.findUnique({
+      where: {
+        user_id_process_year_role: {
+          user_id: userId,
+          process_year: processYear,
+          role: "mentor",
+        },
+      },
+      select: {
+        application_status: true,
+        admin_memos: {
+          take: 1,
+          orderBy: { created_at: "desc" },
+          select: { memo_content: true },
+        },
       },
     }),
   ]);
@@ -71,10 +89,18 @@ export async function GET(req: NextRequest) {
     missingFields.push("학적상태", "소속 로스쿨", "로스쿨 기수");
   }
 
+  const label = application
+    ? (applicationStatusToLabel(application.application_status) || null)
+    : null;
+  const exposeMemo = label === "revision" || label === "rejected";
+  const latestMemo = exposeMemo ? (application?.admin_memos[0]?.memo_content ?? null) : null;
+
   return NextResponse.json({
     submitted: record?.record_status === "submitted",
     submittedAt: record?.application?.submitted_at?.toISOString() ?? null,
     missingFields,
     hasRecord: !!record,
+    applicationStatus: label,
+    latestMemo,
   });
 }

--- a/apps/api/src/app/api/mentor/applications/submit/route.ts
+++ b/apps/api/src/app/api/mentor/applications/submit/route.ts
@@ -31,7 +31,7 @@ export async function POST(req: NextRequest) {
 
   const processYear = getProcessYear(req);
 
-  const [user, record] = await Promise.all([
+  const [user, record, existing] = await Promise.all([
     prisma.user.findUnique({
       where: { user_id: userId },
       select: {
@@ -54,6 +54,16 @@ export async function POST(req: NextRequest) {
         lawschool_grade: true,
       },
     }),
+    prisma.application.findUnique({
+      where: {
+        user_id_process_year_role: {
+          user_id: userId,
+          process_year: processYear,
+          role: "mentor",
+        },
+      },
+      select: { application_id: true, application_status: true },
+    }),
   ]);
 
   if (!user) {
@@ -65,8 +75,16 @@ export async function POST(req: NextRequest) {
       { status: 404 },
     );
   }
-  if (record.record_status === "submitted") {
-    return NextResponse.json({ error: "이미 제출된 신청서입니다." }, { status: 409 });
+
+  // 기존 신청이 있는데 보완요청 외의 상태(승인/거절/대기) → 사용자가 임의로 재제출 불가
+  if (existing && existing.application_status !== "revision_requested") {
+    const message =
+      existing.application_status === "approved"
+        ? "이미 승인된 신청서입니다."
+        : existing.application_status === "rejected"
+          ? "거절된 신청서입니다. 관리자에게 문의해주세요."
+          : "이미 제출된 신청서입니다.";
+    return NextResponse.json({ error: message }, { status: 409 });
   }
 
   // 멘토 dashboard/basic-info 의 모든 필드가 채워져 있어야 제출 가능.
@@ -90,6 +108,8 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  // 첫 제출이면 create, 보완요청 후 재제출이면 update.
+  // submitted_at 만 갱신하고 revision_requested_at/rejected_at 등은 audit 으로 보존.
   const submittedAt = new Date();
   try {
     const application = await prisma.$transaction(async (tx) => {
@@ -97,6 +117,17 @@ export async function POST(req: NextRequest) {
         where: { record_id: record.record_id },
         data: { record_status: "submitted" },
       });
+
+      if (existing) {
+        return tx.application.update({
+          where: { application_id: existing.application_id },
+          data: {
+            application_status: "submitted",
+            submitted_at: submittedAt,
+          },
+          select: { application_id: true, submitted_at: true },
+        });
+      }
 
       return tx.application.create({
         data: {

--- a/apps/web/src/app/mentee/applications/ApplicationsClient.tsx
+++ b/apps/web/src/app/mentee/applications/ApplicationsClient.tsx
@@ -2,7 +2,16 @@
 
 import { useState } from 'react';
 import ConcernCard from '@/components/concerns/ConcernCard';
-import { submitMenteeApplicationWithShare, patchConcern, type CycleSchedule, type BasicInfoAdmission, type ConcernData, type ShareSettings } from '@/lib/api';
+import {
+  submitMenteeApplicationWithShare,
+  patchConcern,
+  getMenteeApplicationStatus,
+  type CycleSchedule,
+  type BasicInfoAdmission,
+  type ConcernData,
+  type ShareSettings,
+  type MenteeApplicationStatus,
+} from '@/lib/api';
 import ShareSettingsModal from './ShareSettingsModal';
 import { useToast } from '@/components/ui/Toast';
 import { useBeforeUnloadGuard } from '@/hooks/useBeforeUnloadGuard';
@@ -33,15 +42,17 @@ type Props = {
   initialSchedule: CycleSchedule | null;
   initialAdmission: BasicInfoAdmission | null;
   initialConcerns: ConcernData | null;
+  initialStatus: MenteeApplicationStatus | null;
 };
 
-export default function ApplicationsClient({ initialSchedule, initialAdmission, initialConcerns }: Props) {
+export default function ApplicationsClient({ initialSchedule, initialAdmission, initialConcerns, initialStatus }: Props) {
   const [agreed, setAgreed] = useState(false);
   const [showConsentError, setShowConsentError] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [extraRequest, setExtraRequest] = useState(initialConcerns?.extraRequest ?? '');
   const [editingCards, setEditingCards] = useState<Set<string>>(new Set());
   const [shareModalOpen, setShareModalOpen] = useState(false);
+  const [status, setStatus] = useState<MenteeApplicationStatus | null>(initialStatus);
   const DEFAULT_SHARE: ShareSettings = {
     basicInfo: true,
     quantitative: true,
@@ -76,6 +87,11 @@ export default function ApplicationsClient({ initialSchedule, initialAdmission, 
 
   const isClosed = isDeadlinePassed(activeSchedule?.mentee_apply_end ?? null);
   const isNotRegistered = !activeSchedule || !activeSchedule.mentee_apply_end;
+  const applicationStatus = status?.applicationStatus ?? null;
+  // 사용자가 (재)제출 가능한 상태: 미신청(null) 또는 보완요청(revision).
+  // 그 외(대기/승인/거절) 는 제출 폼/버튼을 숨기고 상태 카드만 노출한다.
+  const canShowSubmitForm = applicationStatus === null || applicationStatus === 'revision';
+  const isResubmit = applicationStatus === 'revision';
 
   // 1단계: 사전 검증 후 공개 설정 모달 오픈. 실제 제출은 모달의 onConfirm 에서.
   function handleSubmit() {
@@ -98,8 +114,15 @@ export default function ApplicationsClient({ initialSchedule, initialAdmission, 
     try {
       await patchConcern(year, { extraRequest });
       await submitMenteeApplicationWithShare(year, share);
-      toast.success('신청서가 제출되었습니다.');
+      toast.success(isResubmit ? '신청서가 재제출되었습니다.' : '신청서가 제출되었습니다.');
       setShareModalOpen(false);
+      // 제출 직후 상태 동기화 (대기 카드 노출 + 버튼 숨김)
+      try {
+        const next = await getMenteeApplicationStatus(year);
+        setStatus(next);
+      } catch {
+        // 상태 갱신 실패해도 제출 자체는 성공이므로 무시
+      }
     } catch (e) {
       toast.error(e instanceof Error ? e.message : '신청서 제출에 실패했습니다.');
     } finally {
@@ -114,6 +137,15 @@ export default function ApplicationsClient({ initialSchedule, initialAdmission, 
         <h1 className="text-2xl font-bold text-text-primary">프로세스 신청</h1>
         <p className="text-sm text-text-secondary mt-1">멘토링 프로세스를 신청하고 진행 상황을 확인하세요</p>
       </div>
+
+      {/* 신청 상태 안내 카드 — 미신청 외 상태에서만 노출 */}
+      {applicationStatus && (
+        <ApplicationStatusCard
+          status={applicationStatus}
+          memo={status?.latestMemo ?? null}
+          submittedAt={status?.submittedAt ?? null}
+        />
+      )}
 
       {/* 사업 일정 카드 */}
       {activeSchedule && (
@@ -202,7 +234,8 @@ export default function ApplicationsClient({ initialSchedule, initialAdmission, 
         onEditingChange={makeEditingHandler('specialNotes')}
       />
 
-      {/* 개인정보 동의 카드 */}
+      {/* 개인정보 동의 카드 — (재)제출 가능한 상태일 때만 노출 */}
+      {canShowSubmitForm && (
       <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
         <h2 className="text-base font-semibold text-text-primary mb-5">개인정보 수집 및 이용 동의</h2>
         <div className="text-sm text-text-body leading-relaxed space-y-4 mb-6">
@@ -246,6 +279,7 @@ export default function ApplicationsClient({ initialSchedule, initialAdmission, 
           </p>
         )}
       </div>
+      )}
 
       {/* 신청서 카드 */}
       <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
@@ -303,41 +337,45 @@ export default function ApplicationsClient({ initialSchedule, initialAdmission, 
           </div>
         </div>
 
-        <div className="mt-8 text-center text-sm text-text-secondary leading-relaxed">
-          {isNotRegistered ? (
-            <p>현재 진행 중인 pLAWcess 사업의 신청 기간이 아직 등록되지 않았습니다.</p>
-          ) : !isClosed ? (
-            <>
-              <p>모든 내용을 꼼꼼히 확인한 후 신청해주시기 바랍니다.</p>
-              <p className="mt-1">매칭은 <span className="text-brand font-medium">{formatDateKo(activeSchedule!.mentee_apply_end)}</span>까지 등록된 정량 및 정성 데이터를 기준으로 진행되므로, 마감 전까지 정보 등록을 완료해주시기 바랍니다.</p>
-              <p className="mt-1">신청 후에도 언제든 내용을 수정할 수 있습니다.</p>
-            </>
-          ) : null}
-        </div>
+        {canShowSubmitForm && (
+          <>
+            <div className="mt-8 text-center text-sm text-text-secondary leading-relaxed">
+              {isNotRegistered ? (
+                <p>현재 진행 중인 pLAWcess 사업의 신청 기간이 아직 등록되지 않았습니다.</p>
+              ) : !isClosed ? (
+                <>
+                  <p>모든 내용을 꼼꼼히 확인한 후 신청해주시기 바랍니다.</p>
+                  <p className="mt-1">매칭은 <span className="text-brand font-medium">{formatDateKo(activeSchedule!.mentee_apply_end)}</span>까지 등록된 정량 및 정성 데이터를 기준으로 진행되므로, 마감 전까지 정보 등록을 완료해주시기 바랍니다.</p>
+                  <p className="mt-1">신청 후에도 언제든 내용을 수정할 수 있습니다.</p>
+                </>
+              ) : null}
+            </div>
 
-        {isClosed ? (
-          <div className="flex justify-center mt-6">
-            <p className="text-sm text-red-500 font-medium">신청 기간이 마감되어 신청이 불가합니다.</p>
-          </div>
-        ) : (
-          <div className="flex justify-center mt-6">
-            <button
-              onClick={handleSubmit}
-              disabled={isNotRegistered || isSubmitting}
-              className={`flex items-center gap-2 px-6 py-2.5 text-sm rounded-md transition-colors ${
-                isNotRegistered || isSubmitting
-                  ? 'bg-border text-text-placeholder cursor-not-allowed'
-                  : agreed
-                    ? 'bg-brand text-white hover:bg-brand-dark'
-                    : 'bg-border text-text-placeholder cursor-not-allowed'
-              }`}
-            >
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" /><polyline points="17 21 17 13 7 13 7 21" /><polyline points="7 3 7 8 15 8" />
-              </svg>
-              {isSubmitting ? '제출 중...' : '신청서 제출'}
-            </button>
-          </div>
+            {isClosed ? (
+              <div className="flex justify-center mt-6">
+                <p className="text-sm text-red-500 font-medium">신청 기간이 마감되어 신청이 불가합니다.</p>
+              </div>
+            ) : (
+              <div className="flex justify-center mt-6">
+                <button
+                  onClick={handleSubmit}
+                  disabled={isNotRegistered || isSubmitting}
+                  className={`flex items-center gap-2 px-6 py-2.5 text-sm rounded-md transition-colors ${
+                    isNotRegistered || isSubmitting
+                      ? 'bg-border text-text-placeholder cursor-not-allowed'
+                      : agreed
+                        ? 'bg-brand text-white hover:bg-brand-dark'
+                        : 'bg-border text-text-placeholder cursor-not-allowed'
+                  }`}
+                >
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" /><polyline points="17 21 17 13 7 13 7 21" /><polyline points="7 3 7 8 15 8" />
+                  </svg>
+                  {isSubmitting ? '제출 중...' : isResubmit ? '신청서 재제출' : '신청서 제출'}
+                </button>
+              </div>
+            )}
+          </>
         )}
       </div>
 
@@ -348,6 +386,74 @@ export default function ApplicationsClient({ initialSchedule, initialAdmission, 
           onClose={() => !isSubmitting && setShareModalOpen(false)}
           onConfirm={handleConfirmSubmit}
         />
+      )}
+    </div>
+  );
+}
+
+// 신청 상태 안내 카드. 어드민이 사용자 신청에 대해 내린 결정/요청을 사용자에게 보여준다.
+// memo 는 BE 가 revision/rejected 일 때만 채워서 내려주므로, 그대로 노출한다.
+function ApplicationStatusCard({
+  status,
+  memo,
+  submittedAt,
+}: {
+  status: NonNullable<MenteeApplicationStatus['applicationStatus']>;
+  memo: string | null;
+  submittedAt: string | null;
+}) {
+  const meta: Record<typeof status, { label: string; description: string; badge: string; tint: string; memoLabel: string | null }> = {
+    pending: {
+      label: '검토 대기 중',
+      description: '관리자가 신청서를 검토 중입니다. 결과가 안내되기 전까지 기다려주세요.',
+      badge: 'bg-gray-200 text-gray-600',
+      tint: 'bg-gray-50 border-border',
+      memoLabel: null,
+    },
+    approved: {
+      label: '승인 완료',
+      description: '신청이 승인되었습니다. 매칭 결과 발표일을 기다려주세요.',
+      badge: 'bg-green-500 text-white',
+      tint: 'bg-green-50 border-green-200',
+      memoLabel: null,
+    },
+    revision: {
+      label: '보완 요청',
+      description: '관리자가 신청서 보완을 요청했습니다. 아래 사유를 확인하고 내용을 수정한 뒤 재제출해주세요.',
+      badge: 'border border-orange-400 text-orange-500 bg-white',
+      tint: 'bg-orange-50 border-orange-200',
+      memoLabel: '보완 요청 사유',
+    },
+    rejected: {
+      label: '거절됨',
+      description: '신청이 거절되었습니다. 자세한 내용은 아래 사유를 확인해주세요.',
+      badge: 'bg-red-500 text-white',
+      tint: 'bg-red-50 border-red-200',
+      memoLabel: '거절 사유',
+    },
+  };
+  const m = meta[status];
+  const submittedLabel = submittedAt ? formatDateKo(submittedAt) : null;
+  return (
+    <div className={`rounded-xl border shadow-sm px-4 sm:px-8 py-6 ${m.tint}`}>
+      <div className="flex items-center gap-3 mb-2">
+        <span className={`inline-flex items-center justify-center min-w-[64px] px-3 py-1 rounded-full text-xs font-semibold ${m.badge}`}>
+          {m.label}
+        </span>
+        {submittedLabel && (
+          <span className="text-xs text-text-secondary">제출일: {submittedLabel}</span>
+        )}
+      </div>
+      <p className="text-sm text-text-body leading-relaxed">{m.description}</p>
+      {m.memoLabel && (
+        <div className="mt-4 bg-white border border-border rounded-md px-4 py-3">
+          <p className="text-xs font-medium text-text-secondary mb-1">{m.memoLabel}</p>
+          {memo ? (
+            <p className="text-sm text-text-primary whitespace-pre-wrap">{memo}</p>
+          ) : (
+            <p className="text-sm text-text-placeholder">관리자가 입력한 사유가 없습니다.</p>
+          )}
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/app/mentee/applications/page.tsx
+++ b/apps/web/src/app/mentee/applications/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers';
 import ApplicationsClient from './ApplicationsClient';
-import type { CycleSchedule, BasicInfoAdmission, ConcernData } from '@/lib/api';
+import type { CycleSchedule, BasicInfoAdmission, ConcernData, MenteeApplicationStatus } from '@/lib/api';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
 const COOKIE_NAME = 'plawcess_token';
@@ -26,14 +26,17 @@ export default async function ApplicationsPage() {
 
   let initialAdmission: BasicInfoAdmission | null = null;
   let initialConcerns: ConcernData | null = null;
+  let initialStatus: MenteeApplicationStatus | null = null;
   if (activeSchedule) {
     const year = encodeURIComponent(`${activeSchedule.process_year}학년도`);
-    const [basicInfo, concerns] = await Promise.all([
+    const [basicInfo, concerns, status] = await Promise.all([
       fetchWithCookie<{ admission: BasicInfoAdmission }>(`/api/mentee/basic-info?year=${year}`, token),
       fetchWithCookie<ConcernData>(`/api/mentee/concerns?year=${year}`, token),
+      fetchWithCookie<MenteeApplicationStatus>(`/api/mentee/applications/status?year=${year}`, token),
     ]);
     initialAdmission = basicInfo?.admission ?? null;
     initialConcerns = concerns;
+    initialStatus = status;
   }
 
   return (
@@ -41,6 +44,7 @@ export default async function ApplicationsPage() {
       initialSchedule={activeSchedule}
       initialAdmission={initialAdmission}
       initialConcerns={initialConcerns}
+      initialStatus={initialStatus}
     />
   );
 }

--- a/apps/web/src/app/mentor/applications/MentorApplicationsClient.tsx
+++ b/apps/web/src/app/mentor/applications/MentorApplicationsClient.tsx
@@ -3,7 +3,12 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { submitMentorApplication, type CycleSchedule, type MentorApplicationStatus } from '@/lib/api';
+import {
+  submitMentorApplication,
+  getMentorApplicationStatus,
+  type CycleSchedule,
+  type MentorApplicationStatus,
+} from '@/lib/api';
 import { useToast } from '@/components/ui/Toast';
 import { isTodayInRange } from '@/lib/schedule';
 
@@ -52,9 +57,9 @@ export default function MentorApplicationsClient({ initialSchedule, initialStatu
   const [agreed, setAgreed] = useState(false);
   const [showConsentError, setShowConsentError] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [status, setStatus] = useState<MentorApplicationStatus | null>(initialStatus);
 
   const activeSchedule = initialSchedule;
-  const status = initialStatus;
   const year = String(activeSchedule?.process_year ?? new Date().getFullYear());
 
   const isNotRegistered = !activeSchedule || (!activeSchedule.mentor_recruit_start && !activeSchedule.mentor_recruit_end && !activeSchedule.matching_start);
@@ -63,11 +68,15 @@ export default function MentorApplicationsClient({ initialSchedule, initialStatu
     activeSchedule?.mentor_recruit_end ?? null,
     activeSchedule?.matching_start ?? null,
   );
-  const submitted = !!status?.submitted;
   const missing = status?.missingFields ?? [];
   const allFilled = missing.length === 0;
+  const applicationStatus = status?.applicationStatus ?? null;
+  // 사용자가 (재)제출 가능한 상태: 미신청(null) 또는 보완요청(revision).
+  // 그 외(대기/승인/거절) 는 제출 폼/버튼을 숨기고 상태 카드만 노출한다.
+  const canShowSubmitForm = applicationStatus === null || applicationStatus === 'revision';
+  const isResubmit = applicationStatus === 'revision';
 
-  const canSubmit = !isNotRegistered && recruitState.inRange && !submitted && allFilled && agreed && !isSubmitting;
+  const canSubmit = canShowSubmitForm && !isNotRegistered && recruitState.inRange && allFilled && agreed && !isSubmitting;
 
   async function handleSubmit() {
     if (!agreed) {
@@ -78,7 +87,14 @@ export default function MentorApplicationsClient({ initialSchedule, initialStatu
     setIsSubmitting(true);
     try {
       await submitMentorApplication(year);
-      toast.success('신청서가 제출되었습니다.');
+      toast.success(isResubmit ? '신청서가 재제출되었습니다.' : '신청서가 제출되었습니다.');
+      // 제출 직후 상태 동기화 + SSR refresh (제출일 등 갱신)
+      try {
+        const next = await getMentorApplicationStatus(year);
+        setStatus(next);
+      } catch {
+        // 상태 갱신 실패해도 제출 자체는 성공이므로 무시
+      }
       router.refresh();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : '신청서 제출에 실패했습니다.');
@@ -94,6 +110,15 @@ export default function MentorApplicationsClient({ initialSchedule, initialStatu
         <h1 className="text-2xl font-bold text-text-primary">프로세스 신청</h1>
         <p className="text-sm text-text-secondary mt-1">멘토링 프로세스를 신청하고 진행 상황을 확인하세요</p>
       </div>
+
+      {/* 신청 상태 안내 카드 — 미신청 외 상태에서만 노출 */}
+      {applicationStatus && (
+        <ApplicationStatusCard
+          status={applicationStatus}
+          memo={status?.latestMemo ?? null}
+          submittedAt={status?.submittedAt ?? null}
+        />
+      )}
 
       {/* 사업 일정 카드 */}
       {activeSchedule && (
@@ -155,7 +180,8 @@ export default function MentorApplicationsClient({ initialSchedule, initialStatu
         </div>
       </div>
 
-      {/* 개인정보 동의 카드 */}
+      {/* 개인정보 동의 카드 — (재)제출 가능한 상태일 때만 노출 */}
+      {canShowSubmitForm && (
       <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
         <h2 className="text-base font-semibold text-text-primary mb-5">개인정보 수집 및 이용 동의</h2>
         <div className="text-sm text-text-body leading-relaxed space-y-4 mb-6">
@@ -199,23 +225,17 @@ export default function MentorApplicationsClient({ initialSchedule, initialStatu
           </p>
         )}
       </div>
+      )}
 
-      {/* 신청서 카드 */}
+      {/* 신청서 카드 — (재)제출 가능한 상태일 때만 노출 */}
+      {canShowSubmitForm && (
       <div className="bg-white rounded-xl border border-border shadow-sm px-4 sm:px-8 py-6">
         <div className="mb-6">
           <h2 className="text-base font-semibold text-text-primary">pLAWcess 멘토 신청서</h2>
         </div>
 
         <div className="text-center text-sm text-text-secondary leading-relaxed">
-          {submitted ? (
-            <>
-              <p className="text-brand font-medium">신청서가 제출되었습니다.</p>
-              {status?.submittedAt && (
-                <p className="mt-1">제출일: {formatDateKo(status.submittedAt)}</p>
-              )}
-              <p className="mt-1">관리자 승인 후 매칭 풀에 포함됩니다.</p>
-            </>
-          ) : isNotRegistered ? (
+          {isNotRegistered ? (
             <p>현재 진행 중인 pLAWcess 사업의 멘토 모집 기간이 아직 등록되지 않았습니다.</p>
           ) : recruitState.beforeStart ? (
             <p>
@@ -243,7 +263,7 @@ export default function MentorApplicationsClient({ initialSchedule, initialStatu
           )}
         </div>
 
-        {!submitted && recruitState.inRange && !isNotRegistered && (
+        {recruitState.inRange && !isNotRegistered && (
           <>
             <div className="flex flex-col items-center mt-6 gap-3">
               <button
@@ -258,7 +278,7 @@ export default function MentorApplicationsClient({ initialSchedule, initialStatu
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" /><polyline points="17 21 17 13 7 13 7 21" /><polyline points="7 3 7 8 15 8" />
                 </svg>
-                {isSubmitting ? '제출 중...' : '신청서 제출'}
+                {isSubmitting ? '제출 중...' : isResubmit ? '신청서 재제출' : '신청서 제출'}
               </button>
               {!allFilled && (
                 <p className="text-xs text-text-secondary text-center">
@@ -272,6 +292,75 @@ export default function MentorApplicationsClient({ initialSchedule, initialStatu
           </>
         )}
       </div>
+      )}
+    </div>
+  );
+}
+
+// 신청 상태 안내 카드. 어드민이 사용자 신청에 대해 내린 결정/요청을 사용자에게 보여준다.
+// memo 는 BE 가 revision/rejected 일 때만 채워서 내려주므로, 그대로 노출한다.
+function ApplicationStatusCard({
+  status,
+  memo,
+  submittedAt,
+}: {
+  status: NonNullable<MentorApplicationStatus['applicationStatus']>;
+  memo: string | null;
+  submittedAt: string | null;
+}) {
+  const meta: Record<typeof status, { label: string; description: string; badge: string; tint: string; memoLabel: string | null }> = {
+    pending: {
+      label: '검토 대기 중',
+      description: '관리자가 신청서를 검토 중입니다. 결과가 안내되기 전까지 기다려주세요.',
+      badge: 'bg-gray-200 text-gray-600',
+      tint: 'bg-gray-50 border-border',
+      memoLabel: null,
+    },
+    approved: {
+      label: '승인 완료',
+      description: '신청이 승인되었습니다. 매칭 결과 발표일을 기다려주세요.',
+      badge: 'bg-green-500 text-white',
+      tint: 'bg-green-50 border-green-200',
+      memoLabel: null,
+    },
+    revision: {
+      label: '보완 요청',
+      description: '관리자가 신청서 보완을 요청했습니다. 아래 사유를 확인하고 내용을 수정한 뒤 재제출해주세요.',
+      badge: 'border border-orange-400 text-orange-500 bg-white',
+      tint: 'bg-orange-50 border-orange-200',
+      memoLabel: '보완 요청 사유',
+    },
+    rejected: {
+      label: '거절됨',
+      description: '신청이 거절되었습니다. 자세한 내용은 아래 사유를 확인해주세요.',
+      badge: 'bg-red-500 text-white',
+      tint: 'bg-red-50 border-red-200',
+      memoLabel: '거절 사유',
+    },
+  };
+  const m = meta[status];
+  const submittedLabel = submittedAt ? formatDateKo(submittedAt) : null;
+  return (
+    <div className={`rounded-xl border shadow-sm px-4 sm:px-8 py-6 ${m.tint}`}>
+      <div className="flex items-center gap-3 mb-2">
+        <span className={`inline-flex items-center justify-center min-w-[64px] px-3 py-1 rounded-full text-xs font-semibold ${m.badge}`}>
+          {m.label}
+        </span>
+        {submittedLabel && (
+          <span className="text-xs text-text-secondary">제출일: {submittedLabel}</span>
+        )}
+      </div>
+      <p className="text-sm text-text-body leading-relaxed">{m.description}</p>
+      {m.memoLabel && (
+        <div className="mt-4 bg-white border border-border rounded-md px-4 py-3">
+          <p className="text-xs font-medium text-text-secondary mb-1">{m.memoLabel}</p>
+          {memo ? (
+            <p className="text-sm text-text-primary whitespace-pre-wrap">{memo}</p>
+          ) : (
+            <p className="text-sm text-text-placeholder">관리자가 입력한 사유가 없습니다.</p>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1564,11 +1564,31 @@ export type MentorApplicationStatus = {
   submittedAt: string | null;
   missingFields: string[];
   hasRecord: boolean;
+  /** null = Application 없음(미신청). 그 외엔 BE 라벨 그대로. */
+  applicationStatus: ApplicationStatusLabel | null;
+  /** revision/rejected 상태에서만 채워짐 */
+  latestMemo: string | null;
 };
 
 export async function getMentorApplicationStatus(year: string): Promise<MentorApplicationStatus> {
   const res = await fetch(
     `${API_BASE}/api/mentor/applications/status?year=${encodeURIComponent(year)}`,
+    { headers: headers(), credentials: "include" },
+  );
+  return jsonOrError(res, "신청 상태 조회 실패");
+}
+
+export type MenteeApplicationStatus = {
+  /** null = Application 없음(미신청). 그 외엔 BE 라벨 그대로. */
+  applicationStatus: ApplicationStatusLabel | null;
+  submittedAt: string | null;
+  /** revision/rejected 상태에서만 채워짐 */
+  latestMemo: string | null;
+};
+
+export async function getMenteeApplicationStatus(year: string): Promise<MenteeApplicationStatus> {
+  const res = await fetch(
+    `${API_BASE}/api/mentee/applications/status?year=${encodeURIComponent(year)}`,
     { headers: headers(), credentials: "include" },
   );
   return jsonOrError(res, "신청 상태 조회 실패");


### PR DESCRIPTION
## 배경

  `/applications` 에서 사용자가 신청한 뒤 어드민이 `/admin/applications` 에서 **보완요청** 을 누르면, 사용자가 다시 신청을 시도해도 매번 `409
  "이미 제출된 신청서입니다."` 로 막혔다 (#295). 또한 어드민이 **거절** 했을 때 사용자가 사유(어드민 메모)를 확인할 경로가 없었다.

  ## 원인

  - `apps/api/src/app/api/mentee/applications/submit/route.ts`, `apps/api/src/app/api/mentor/applications/submit/route.ts` 가 항상
  `application.create(...)` 만 호출. 보완요청 상태에서는 `record_status` 가 `draft` 로 풀려 record 게이트는 통과하지만, `Application` 행은
  그대로 남아있어 `@@unique([user_id, process_year, role])` 위반(P2002) → 라우트가 catch 해서 409.
  - 사용자 측에 application 상태/메모를 노출하는 엔드포인트와 UI 가 없었음 (멘티는 status 엔드포인트 자체가 없었고, 멘토 status 엔드포인트는
  `submitted` boolean 만 반환).

  ## 변경 사항

  ### BE

  - **`apps/api/src/app/api/mentee/applications/submit/route.ts` / `apps/api/src/app/api/mentor/applications/submit/route.ts`**
    - `application` 존재/상태를 진실의 원천으로 분기.
    - `revision_requested` 면 `update`(`application_status=submitted`, `submitted_at=now`). `revision_requested_at` / `rejected_at` 등은 audit
   으로 보존.
    - 첫 제출이면 기존대로 `create`.
    - 그 외(`approved`/`rejected`/`submitted`) 는 상태별 메시지로 409 (`"이미 승인된 신청서입니다."` 등).
  - **`apps/api/src/app/api/mentee/applications/status/route.ts`** (신규)
    GET /api/mentee/applications/status?year=YYYY
    → { applicationStatus: "pending"|"approved"|"rejected"|"revision"|null,
        submittedAt: string|null,
        latestMemo: string|null }
  `latestMemo` 는 `revision`/`rejected` 상태에서만 채움.
  - **`apps/api/src/app/api/mentor/applications/status/route.ts`**
  - 응답에 `applicationStatus`, `latestMemo` 추가. 기존 `submitted`/`submittedAt`/`missingFields`/`hasRecord` 는 호환을 위해 유지.

  ### FE

  - **`apps/web/src/lib/api.ts`** — `getMenteeApplicationStatus` + `MenteeApplicationStatus` 타입 추가, `MentorApplicationStatus` 에
  `applicationStatus`/`latestMemo` 추가.
  - **`apps/web/src/app/mentee/applications/page.tsx`** — SSR 에서 status 함께 fetch 해서 client 에 전달.
  - **`apps/web/src/app/mentee/applications/ApplicationsClient.tsx` / `apps/web/src/app/mentor/applications/MentorApplicationsClient.tsx`**
  - 상단에 `ApplicationStatusCard` 추가 — 승인/대기/보완요청/거절 별 색상·문구, **보완요청·거절 시 어드민 메모(사유) 노출**.
  - `revision`/null 외 상태에서는 동의 카드·제출 폼 숨김 (대기/승인/거절 사용자가 의도치 않게 재제출 시도하는 경로 제거).
  - `revision` 일 때 버튼 라벨 `신청서 재제출`.
  - 제출 직후 status 재조회로 카드/버튼 즉시 동기화.

  ## DB 마이그레이션

  없음. 스키마(`packages/database/prisma/schema.prisma`) 와 마이그레이션 폴더 변경 0건. 기존 컬럼만 사용.

  ## Test plan

  - [ ] 첫 제출: 멘티/멘토 모두 정상 제출 → "검토 대기 중" 카드 노출, 버튼 사라짐.
  - [ ] 어드민이 **보완요청** + 메모 입력 → 사용자 페이지에서 "보완 요청" 카드 + 사유 표시, "신청서 재제출" 버튼 노출.
  - [ ] 보완요청 상태에서 사용자 재제출 → 200, `Application.application_status=submitted` 로 갱신, `submitted_at` 갱신,
  `revision_requested_at` 보존 확인. 카드가 "검토 대기 중" 으로 즉시 전환.
  - [ ] 어드민이 **거절** → 사용자 페이지에 "거절됨" 카드 + 거절 사유 노출, 버튼 사라짐.
  - [ ] 어드민이 거절 → **대기** 로 되돌림 → 사용자 페이지에 "검토 대기 중" 카드 노출, 재제출 시도 시 친절한 409 메시지 ("이미 제출된
  신청서입니다.").
  - [ ] 어드민이 **승인** → "승인 완료" 카드 노출.